### PR TITLE
Fix URL typo for Appveyor badge

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -3,8 +3,7 @@ Sysl
 
 .. image:: https://img.shields.io/travis/anz-bank/sysl/master.svg?label=Linux%20build%20%40%20Travis%20CI
    :target: http://travis-ci.org/anz-bank/sysl
-
-.. image:: https://img.shields.io/appveyor/ci/anz-bank/sysl.svg?label=Windows%20build%20%40%20Appveyor%20CI
+.. image:: https://img.shields.io/appveyor/ci/anz-bank/sysl_pb2.svg?label=Windows%20build%20%40%20Appveyor%20CI
    :target: https://ci.appveyor.com/project/anz-bank/sysl
 
 Sysl (pronounced "sizzle") is a system specification language. Using Sysl, you

--- a/README.rst
+++ b/README.rst
@@ -3,7 +3,7 @@ Sysl
 
 .. image:: https://img.shields.io/travis/anz-bank/sysl/master.svg?label=Linux%20build%20%40%20Travis%20CI
    :target: http://travis-ci.org/anz-bank/sysl
-.. image:: https://img.shields.io/appveyor/ci/anz-bank/sysl_pb2.svg?label=Windows%20build%20%40%20Appveyor%20CI
+.. image:: https://img.shields.io/appveyor/ci/anz-bank/sysl.svg?label=Windows%20build%20%40%20Appveyor%20CI
    :target: https://ci.appveyor.com/project/anz-bank/sysl
 
 Sysl (pronounced "sizzle") is a system specification language. Using Sysl, you

--- a/README.rst
+++ b/README.rst
@@ -4,6 +4,9 @@ Sysl
 .. image:: https://img.shields.io/travis/anz-bank/sysl/master.svg?label=Linux%20build%20%40%20Travis%20CI
    :target: http://travis-ci.org/anz-bank/sysl
 
+.. image:: https://img.shields.io/appveyor/ci/anz-bank/sysl.svg?label=Windows%20build%20%40%20Appveyor%20CI
+   :target: https://ci.appveyor.com/project/anz-bank/sysl
+
 Sysl (pronounced "sizzle") is a system specification language. Using Sysl, you
 can specify systems, endpoints, endpoint behaviour, data models and data
 transformations. The Sysl compiler automatically generates sequence diagrams,
@@ -22,7 +25,7 @@ If you are interested in trying out Sysl, you will need to install `Python 2.7 <
 
 Now you can execute Sysl as command line tool with ::
 
-  > core  --root demo/petshop textpb -o out/petshop.txt /petshop
+  > sysl    --root demo/petshop textpb -o out/petshop.txt /petshop
   > reljam  --root demo/petshop model /petshop PetShopModel
 
 If you are behind a corporate proxy you might want to consider setting up a global ``pip.conf``

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,7 +3,6 @@ test = pytest
 lint = flake8
 
 [flake8]
-# No need to traverse:
 ignore =
     E265 # block comment should start with '# '
     E402 # module level import not at top of file


### PR DESCRIPTION
Fixes # grey Windows CI badges

https://img.shields.io/appveyor/ci/anz-bank/sysl.svg?label=Windows%20build%20%40%20Appveyor%20CI

@anz-bank/sysl-developers
