### PR TITLE
:pencil2: Fix typo in Appveyor badge URL

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -3,7 +3,7 @@ Sysl
 
 .. image:: https://img.shields.io/travis/anz-bank/sysl/master.svg?label=Linux%20build%20%40%20Travis%20CI
    :target: http://travis-ci.org/anz-bank/sysl
-.. image:: https://img.shields.io/appveyor/ci/anz-bank/sysl_pb2.svg?label=Windows%20build%20%40%20Appveyor%20CI
+.. image:: https://img.shields.io/appveyor/ci/anz-bank/sysl.svg?label=Windows%20build%20%40%20Appveyor%20CI
    :target: https://ci.appveyor.com/project/anz-bank/sysl
 
 Sysl (pronounced "sizzle") is a system specification language. Using Sysl, you

--- a/README.rst
+++ b/README.rst
@@ -6,7 +6,7 @@ Sysl
 .. image:: https://img.shields.io/appveyor/ci/anz-bank/sysl.svg?label=Windows%20build%20%40%20Appveyor%20CI
    :target: https://ci.appveyor.com/project/anz-bank/sysl
 
-Sysl (pronounced "sizzle") is a system specification language. Using Sysl, you
+Sysl (pronounce "sizzle") is a system specification language. Using Sysl, you
 can specify systems, endpoints, endpoint behaviour, data models and data
 transformations. The Sysl compiler automatically generates sequence diagrams,
 integrations, and other views. It also offers a range of code generation

--- a/README.rst
+++ b/README.rst
@@ -6,7 +6,7 @@ Sysl
 .. image:: https://img.shields.io/appveyor/ci/anz-bank/sysl.svg?label=Windows%20build%20%40%20Appveyor%20CI
    :target: https://ci.appveyor.com/project/anz-bank/sysl
 
-Sysl (pronounce "sizzle") is a system specification language. Using Sysl, you
+Sysl (pronounced "sizzle") is a system specification language. Using Sysl, you
 can specify systems, endpoints, endpoint behaviour, data models and data
 transformations. The Sysl compiler automatically generates sequence diagrams,
 integrations, and other views. It also offers a range of code generation


### PR DESCRIPTION
Fixes typo in URL for Appveyor badge.
https://img.shields.io/appveyor/ci/anz-bank/sysl.svg?label=Windows%20build%20%40%20Appveyor%20CI

@anz-bank/sysl-developers
