### PR TITLE
Fix install and dev dependencies for behind corporate proxy

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -20,7 +20,7 @@ If you are interested in trying out Sysl, you will need to install `Python 2.7 <
 
   > git clone https://github.com/anz-bank/sysl.git
   > cd sysl
-  > python setup.py install
+  > pip install .
 
 Now you can execute Sysl as command line tool with ::
 
@@ -34,21 +34,16 @@ Development
 -----------
 Install dependencies and the ``sysl`` package with symlinks ::
 
-  > pip install -e .
+  > pip install -e ".[dev]"
 
-Test the source code and your changes with ::
+Test and lint the source code and your changes with ::
 
-  > python setup.py test
-  > python setup.py lint
+  > pytest
+  > flake
 
 and create a distribution with ::
 
   > python setup.py bdist_wheel --universal
-
-You can also run tests and lint more interactively with ::
-
-  > pytest # --help
-  > flake8 # --help
 
 Consider using `virtualenv <https://virtualenv.pypa.io/en/stable/>`_ and `virtualenvwrapper <https://virtualenvwrapper.readthedocs.io/en/latest/>`_ to isolate your environment.
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,8 +5,7 @@ environment:
 install:
   - "SET PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%"
   - "pip install --upgrade setuptools"
-  - "python setup.py install"
-  - "pip install pytest flake8"
+  - "pip install . pytest flake8"
 
 build: off
 

--- a/setup.py
+++ b/setup.py
@@ -59,6 +59,10 @@ setup(
         'Programming Language :: Python',
         'Programming Language :: Python :: 2.7',
     ],
-    setup_requires=['pytest-runner', 'pytest'],
-    tests_require=['pytest'],
+    extras_require={
+        'dev': [
+            'pytest',
+            'flake8',
+        ]
+    }
 )


### PR DESCRIPTION
Fixes #28 .

Changes proposed in this pull request:
- Updated setup.py using extras-require
- Update README to install with `pip install .` and `pip install -e ".[dev]"`
- Update appveyor CI setup
- Remove documentation of `python setup.py test` and `python setup.py lint` in favour of `pytest` and `flake8`

@anz-bank/sysl-developers
