### PR TITLE
Introduce --version : 0.1.0

### DIFF
--- a/src/sysl/__version__.py
+++ b/src/sysl/__version__.py
@@ -1,3 +1,3 @@
-VERSION = (0, 0, 1)
+VERSION = (0, 1, 0)
 
 __version__ = '.'.join(map(str, VERSION))

--- a/src/sysl/core/__main__.py
+++ b/src/sysl/core/__main__.py
@@ -17,6 +17,7 @@ from sysl.core import syslints
 from sysl.core import syslloader
 from sysl.core import syslseqs
 from sysl.util.argparse import add_modules_option, add_output_option
+from sysl.__version__ import __version__
 
 
 def _pb_sub_parser(subparser):
@@ -98,6 +99,9 @@ def main():
                       help='suppress validations')
     argp.add_argument('--root', '-r', default='.',
                       help='sysl root directory for input files (default: .)')
+    argp.add_argument('--version', '-v',
+                      help='show version number (semver.org standard)',
+                      action='version', version='%(prog)s ' + __version__)
 
     subparser = argp.add_subparsers(help='\n'.join(['sub-commands',
                                                     'more help with: sysl <sub-command> --help', 'eg: sysl pb --help']))


### PR DESCRIPTION
Getting ready for 0.1.0 release

Changes proposed in this pull request:
- Update version to `0.1.0` according to [semver standard](https://semver.org)
- Add `--version` command line option

@anz-bank/sysl-developers
