### PR TITLE
Move e2e output to <repo>/tmp

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,4 @@ dist
 build
 .eggs
 
-/test/e2e/actual_output
+/tmp

--- a/test/e2e/test_e2e.py
+++ b/test/e2e/test_e2e.py
@@ -25,7 +25,8 @@ def test_e2e(fname):
     dname = path.dirname(__file__)
     root = path.join(dname, 'input')
     model = '/' + fname
-    out_fname = path.join(dname, 'actual_output', fname + '.txt')
+    out_fname = path.join(dname, '..', '..', 'tmp',
+        'test', 'e2e', 'actual_output', fname + '.txt')
     remove_file(out_fname)
 
     cmd = ['sysl', '--root', root, 'textpb', '-o', out_fname, model]

--- a/test/e2e/test_e2e.py
+++ b/test/e2e/test_e2e.py
@@ -2,7 +2,6 @@ from sysl.core import syslloader
 from sysl.util.file import filesAreIdentical
 
 import pytest
-import os
 
 from os import path, remove
 from subprocess import call
@@ -26,7 +25,7 @@ def remove_file(fname):
 ])
 def test_e2e(fname):
     e2e_dir = path.normpath(path.dirname(__file__))
-    e2e_rel_dir = os.path.relpath(e2e_dir, start=REPO_ROOT)
+    e2e_rel_dir = path.relpath(e2e_dir, start=REPO_ROOT)
 
     root = path.join(e2e_dir, 'input')
     model = '/' + fname

--- a/test/e2e/test_e2e.py
+++ b/test/e2e/test_e2e.py
@@ -2,9 +2,12 @@ from sysl.core import syslloader
 from sysl.util.file import filesAreIdentical
 
 import pytest
+import os
 
 from os import path, remove
 from subprocess import call
+
+REPO_ROOT = path.normpath(path.join(path.dirname(__file__), '..', '..'))
 
 
 def remove_file(fname):
@@ -22,16 +25,18 @@ def remove_file(fname):
     '005_annotations',
 ])
 def test_e2e(fname):
-    dname = path.dirname(__file__)
-    root = path.join(dname, 'input')
+    e2e_dir = path.normpath(path.dirname(__file__))
+    e2e_rel_dir = os.path.relpath(e2e_dir, start=REPO_ROOT)
+
+    root = path.join(e2e_dir, 'input')
     model = '/' + fname
-    out_fname = path.join(dname, '..', '..', 'tmp',
-                          'test', 'e2e', 'actual_output', fname + '.txt')
+    out_dir = path.join(REPO_ROOT, 'tmp', e2e_rel_dir)
+    out_fname = path.join(out_dir, 'actual_output', fname + '.txt')
     remove_file(out_fname)
 
     cmd = ['sysl', '--root', root, 'textpb', '-o', out_fname, model]
     print 'calling', ' '.join(cmd)
     call(cmd)
 
-    expected_fname = path.join(dname, 'expected_output', fname + '.txt')
+    expected_fname = path.join(e2e_dir, 'expected_output', fname + '.txt')
     assert filesAreIdentical(expected_fname, out_fname)

--- a/test/e2e/test_e2e.py
+++ b/test/e2e/test_e2e.py
@@ -26,7 +26,7 @@ def test_e2e(fname):
     root = path.join(dname, 'input')
     model = '/' + fname
     out_fname = path.join(dname, '..', '..', 'tmp',
-        'test', 'e2e', 'actual_output', fname + '.txt')
+                          'test', 'e2e', 'actual_output', fname + '.txt')
     remove_file(out_fname)
 
     cmd = ['sysl', '--root', root, 'textpb', '-o', out_fname, model]


### PR DESCRIPTION
Changes proposed in this pull request:
- Move generated e2e output on `<repo>/tmp location` 
In accordance with [previous comment](https://github.com/anz-bank/sysl/pull/25#discussion_r160290819), temporary, generated code used in tests should not sit alongside "real" source code.
- Adjust `.gitignore` accordingly

@anz-bank/sysl-developers
