### PR TITLE
Fix seq diagram parameter parsing

### DIFF
--- a/src/sysl/core/__main__.py
+++ b/src/sysl/core/__main__.py
@@ -102,6 +102,9 @@ def main():
     argp.add_argument('--version', '-v',
                       help='show version number (semver.org standard)',
                       action='version', version='%(prog)s ' + __version__)
+    argp.add_argument('--trace', '-t',
+                      help=argparse.SUPPRESS,
+                      action='store_true', default=False)
 
     subparser = argp.add_subparsers(help='\n'.join(['sub-commands',
                                                     'more help with: sysl <sub-command> --help', 'eg: sysl pb --help']))
@@ -121,8 +124,13 @@ def main():
         except OSError as exc:
             if exc.errno != errno.EEXIST or os.path.isdir(args.output):
                 raise
-
-    args.func(args)
+    try:
+        args.func(args)
+    except Exception as e:
+        if args.trace:
+            raise
+        else:
+            print e
 
 
 if __name__ == '__main__':

--- a/src/sysl/core/__main__.py
+++ b/src/sysl/core/__main__.py
@@ -134,6 +134,7 @@ def main():
             print e
             sys.exit(1)
 
+
 if __name__ == '__main__':
     #  debug.init()
     main()

--- a/src/sysl/core/__main__.py
+++ b/src/sysl/core/__main__.py
@@ -126,12 +126,13 @@ def main():
                 raise
     try:
         args.func(args)
+        sys.exit(0)
     except Exception as e:
         if args.trace:
             raise
         else:
             print e
-
+            sys.exit(1)
 
 if __name__ == '__main__':
     #  debug.init()

--- a/src/sysl/core/syslseqs.py
+++ b/src/sysl/core/syslseqs.py
@@ -465,14 +465,19 @@ def add_subparser(subp):
                     diagutil.output_plantuml(args, out)
 
         else:
+            if not args.endpoint:
+                raise Exception(
+                    'sysl sd requires either one specific endpoint, ' +
+                    'e.g. --endpoint "ATM <- GetBalance", or an output ' +
+                    'pattern with %(epname), e.g. -o "out/%(epname).svg".')
             out = sequence_diag(module, SequenceDiagParams(
                 # -s builds list of lists (idkw).
-                endpoints=[i[0] for i in args.endpoint],
+                endpoints=args.endpoint,
                 epfmt=diagutil.parse_fmt(args.endpoint_format),
                 appfmt=diagutil.parse_fmt(args.app_format),
                 activations=args.activations,
                 title=args.title,
-                blackboxes=args.blackboxes))
+                blackboxes=args.blackbox))
             diagutil.output_plantuml(args, out)
 
     argp.set_defaults(func=cmd)


### PR DESCRIPTION
Fixes #36 

Changes proposed in this pull request:
- Fix parameter parsing for `sysl sd` to require specific endpoint or output pattern
- Improve UX: only show stack trace if `--trace` is specified

@anz-bank/sysl-developers
