### PR TITLE
Initialise release script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,30 +1,46 @@
 language: python
 python:
-  - "2.7"
+- '2.7'
 matrix:
   include:
-    - os: linux
-      dist: trusty
-      after_success:
-        - pip install codecov -e .
-        - coverage run --source=src/sysl -m py.test
-        - codecov
-    - os: osx
-      osx_image: xcode8.3
-      language: generic
-      before_install:
-        - brew update
-        - brew list python >/dev/null 2>&1 || brew install python
-        - brew list gradle >/dev/null 2>&1 || brew install gradle
-        - export PATH=/usr/local/opt/python/libexec/bin:$PATH
+  - os: linux
+    dist: trusty
+    after_success:
+    - pip install codecov -e .
+    - coverage run --source=src/sysl -m py.test
+    - codecov
+  - os: osx
+    osx_image: xcode8.3
+    language: generic
+    before_install:
+    - brew update
+    - brew list python >/dev/null 2>&1 || brew install python
+    - brew list gradle >/dev/null 2>&1 || brew install gradle
+    - export PATH=/usr/local/opt/python/libexec/bin:$PATH
 
 env:
-  - SYSL_PLANTUML=http://www.plantuml.com/plantuml
-
+- SYSL_PLANTUML=http://www.plantuml.com/plantuml
 install:
-  - pip install . pytest flake8
-
+- pip install . pytest flake8
 script:
-  - flake8
-  - pytest
-  - gradle test -b test/java/build.gradle
+- flake8
+- pytest
+- gradle test -b test/java/build.gradle
+
+before_deploy:
+  python setup.py bdist_wheel
+deploy:
+  provider: releases
+  draft: true
+  tag_name: $TRAVIS_TAG
+  name: Sysl $TRAVIS_TAG
+  api_key:
+    secure: TkWCKFPiDVTbOup9rQi+VceTbXHWoHphMzB6ZJ3bBGPZsHf2rZeVdknQ/9jcUHiYdnhvFspKpp2Dn2e58At8IJTYRx3F93uBCFu9om/U2UtphccO1X6rZw0rcCVTHIuosvyp7iec3qxxTwmnIliQvHnnVJgRzt6IKw/jjDyMZzvBrch52xQV5eDOacW2PwfMJ3Q03UI+fM6C8F/F7RW1T7k+jBcXTzp4mr1mPm3zYvvKBjFPLQk4+8lT9Nbh+FGAXwc6SVl1ue9jQIH3zK4ED4y9uQcdFaz253QqXpnKCl9kJhyYnlsKCAnqqGm/X9DrZUqxYWuSMz9DWA7T+ulI0LO1w4S/DNkZ4ksaGYuwHqVTBSErEC1cJZgSRSsedjaENZgav/FUFL4+3WQf3wP+vM8UzGVJsUJEWlx9DFW61btRwBEJuflVaL6HqhDBebv1sa/8vskcyaiMszxr7V58/Kh3AGC3KBX6sqU0Oc5KXWwgsYiQbNIctFZR0EbcH4aO2yoQO5RPJW8KkaJgMYec6/si/2jT1KxHsA2PAE7GQOOyhTIrTc0AEAA1/6rb8ksIlREOObv4YZFdNYLP3Kv3PGECbHgDh9Ee15MtnezHQqY9qwbh2+0T6i0heHa/1XgNOiG/Y3OpriB1vil/yerH1FJVr6i73xXAyRpgnl4EC7I=
+  file_glob: true
+  file: dist/*
+  skip_cleanup: true
+  prerelease: true
+  on:
+    repo: anz-bank/sysl
+    tags: true
+    condition: $TRAVIS_OS_NAME = linux

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -27,12 +27,15 @@ artifacts:
   - path: dist\sysl.exe
 
 deploy:
-  - provider: GitHub
-    artifact: /.*\.exe/
+    provider: GitHub
+    release: Sysl $(APPVEYOR_REPO_TAG_NAME)
+    tag: $(APPVEYOR_REPO_TAG_NAME)
+    artifact: dist\sysl.exe
     draft: true
     prerelease: true
+    repository: anz-bank/sysl
+    auth_token:
+      secure: 7mE6RzdwrjEUXhoYE6dMaOmEY+gA+XU12+g6YzboUsY1GKNx8ZH52vNKsDiKAj8v
     on:
-      branch: master
       appveyor_repo_tag: true
-
 

--- a/src/scripts/release.sh
+++ b/src/scripts/release.sh
@@ -37,7 +37,7 @@ echo "------- Create release branch $RELEASE_BRANCH ---------"
 git co -b "$RELEASE_BRANCH" || fatal "Cannot create release branch $RELEASE_BRANCH"
 
 echo "------- Update version ---------"
-echo "__version__ = '$VERSION'" > 'src/sysl/__version__.py' || { echo "Could not override src/sysl/__version__.py"; exit 1; }
+echo "__version__ = '$VERSION'" > 'src/sysl/__version__.py' || fatal "Could not override src/sysl/__version__.py"
 
 echo "------- Commit ---------"
 git commit -am "Bump version to $VERSION" || fatal "Cannot commit version update"
@@ -50,7 +50,7 @@ REPO="sysl"
 CREDENTIALS=$(echo "host=github.com" | git credential fill)
 USERNAME=$(echo "$CREDENTIALS" | sed -n "s/.*username=\\([^ ]*\\).*/\\1/p")
 PASSWORD=$(echo "$CREDENTIALS" | sed -n "s/.*password=\\([^ ]*\\).*/\\1/p")
-if [ -z "$USERNAME" ] || [ -z "$PASSWORD" ]; then
+if [ -z "$USERNAME" -o -z "$PASSWORD" ]; then
     fatal "Could not get GitHub credentials, please create pull request manually."
 fi
 

--- a/src/scripts/release.sh
+++ b/src/scripts/release.sh
@@ -4,71 +4,71 @@ USAGE="Usage: release.sh <prepare|deploy> MAJOR.MINOR.PATCH"
 COMMAND=$1
 VERSION=$2
 
-function exit_error {
+function fatal {
     echo "$@" >&2
     exit 1
 }
 if [ "$#" -ne 2 ]; then
-    exit_error $USAGE
+    fatal "$USAGE"
 fi
 if ! [[ $VERSION =~ ^[[:digit:]+\\.[:digit:]+\\.[:digit:]]+$ ]]; then
-	exit_error $USAGE
+	fatal "$USAGE"
 fi
 if [[ $COMMAND != "prepare" && $COMMAND != "deploy" ]]; then
-	exit_error $USAGE
+	fatal "$USAGE"
 fi
 if [[ $(git status --porcelain 2> /dev/null | tail -n1) != "" ]]; then
-	exit_error "Repo is not clean please commit or delete dirty files."
+	fatal "Repo is not clean please commit or delete dirty files."
 fi
 
-ORIGIN_URL=`git remote get-url origin`
-ORIGIN=`echo "$ORIGIN_URL" | sed -n "s/.*\/\/github.com\/\(..*\)\/..*.git/\1/p"`
+ORIGIN_URL=$(git remote get-url origin)
+ORIGIN=$(echo "$ORIGIN_URL" | sed -n "s/.*\\/\\/github.com\\/\\(..*\\)\\/..*.git/\\1/p")
 UPSTREAM="anz-bank"
-UPSTREAM_URL=`echo "$ORIGIN_URL" | sed -n "s/\(.*\/\/github.com\/\)\(..*\)\(\/..*.git\)/\1$UPSTREAM\3/p"`
+UPSTREAM_URL=$(echo "$ORIGIN_URL" | sed -n "s/\\(.*\\/\\/github.com\\/\\)\\(..*\\)\\(\\/..*.git\\)/\\1$UPSTREAM\\3/p")
 RELEASE_BRANCH="release-v$VERSION"
 
 echo "------- Checkout master ---------"
-git checkout master || exit_error "Cannot checkout master"
+git checkout master || fatal "Cannot checkout master"
 
 echo "------- Pull upstream ---------"
-git pull $UPSTREAM_URL master || exit_error "Cannot pull  upstream master"
+git pull "$UPSTREAM_URL" master || fatal "Cannot pull  upstream master"
 
 echo "------- Create release branch $RELEASE_BRANCH ---------"
-git co -b $RELEASE_BRANCH || exit_error "Cannot create release branch $RELEASE_BRANCH"
+git co -b "$RELEASE_BRANCH" || fatal "Cannot create release branch $RELEASE_BRANCH"
 
 echo "------- Update version ---------"
 echo "__version__ = '$VERSION'" > 'src/sysl/__version__.py' || { echo "Could not override src/sysl/__version__.py"; exit 1; }
 
 echo "------- Commit ---------"
-git commit -am "Bump version to $VERSION" || exit_error "Cannot commit version update"
+git commit -am "Bump version to $VERSION" || fatal "Cannot commit version update"
 
 echo "------- Push ---------"
-git push -u origin || exit_error "Cannot push release branch to origin"
+git push -u origin || fatal "Cannot push release branch to origin"
 
 echo "------- Create PR ---------"
 REPO="sysl"
-CREDENTIALS=`echo "host=github.com" | git credential fill`
-USERNAME=`echo $CREDENTIALS | sed -n "s/.*username=\([^ ]*\).*/\1/p"`
-PASSWORD=`echo $CREDENTIALS | sed -n "s/.*password=\([^ ]*\).*/\1/p"`
+CREDENTIALS=$(echo "host=github.com" | git credential fill)
+USERNAME=$(echo "$CREDENTIALS" | sed -n "s/.*username=\\([^ ]*\\).*/\\1/p")
+PASSWORD=$(echo "$CREDENTIALS" | sed -n "s/.*password=\\([^ ]*\\).*/\\1/p")
 if [ -z "$USERNAME" ] || [ -z "$PASSWORD" ]; then
-    exit_error "Could not get GitHub credentials, please create pull request manually."
+    fatal "Could not get GitHub credentials, please create pull request manually."
 fi
 
-JSON=`jq -nc "{title:\"Bump version to $VERSION\",head:\"$ORIGIN:$RELEASE_BRANCH\",base:\"master\"}"`
-RESPONSE=`wget --quiet --output-document=- --content-on-error \
+JSON="{title:\"Bump version to $VERSION\",head:\"$ORIGIN:$RELEASE_BRANCH\",base:\"master\"}"
+RESPONSE=$(wget --quiet --output-document=- --content-on-error \
                --user="$USERNAME" --password="$PASSWORD" --auth-no-challenge \
                --header="Content-Type: application/json" \
                --header="Accept: application/vnd.github.v3+json" \
-               --post-data="$JSON" "https://api.github.com/repos/$UPSTREAM/$REPO/pulls"`
+               --post-data="$JSON" "https://api.github.com/repos/$UPSTREAM/$REPO/pulls")
 
 WGET_STATUS=$?
 if [ $WGET_STATUS -eq 0 ]; then
-	GITHUB_PR_URL=`echo "$RESPONSE" | jq -r '.html_url'`
+	  GITHUB_PR_URL=$(echo "$RESPONSE" | jq -r '.html_url')
     echo "Pull request opened:"
     echo "$GITHUB_PR_URL"
     open "$GITHUB_PR_URL"
 elif [ $WGET_STATUS -eq 6 ]; then
-	exit_error "Wrong username or password/token."
+	  fatal "Wrong username or password/token"
 else
-    exit_error "Unknown error."
+    fatal "Unknown error"
 fi

--- a/src/scripts/release.sh
+++ b/src/scripts/release.sh
@@ -50,11 +50,11 @@ REPO="sysl"
 CREDENTIALS=$(echo "host=github.com" | git credential fill)
 USERNAME=$(echo "$CREDENTIALS" | sed -n "s/.*username=\\([^ ]*\\).*/\\1/p")
 PASSWORD=$(echo "$CREDENTIALS" | sed -n "s/.*password=\\([^ ]*\\).*/\\1/p")
-if [ -z "$USERNAME" -o -z "$PASSWORD" ]; then
+if [ -z "$USERNAME" ] || [ -z "$PASSWORD" ]; then
     fatal "Could not get GitHub credentials, please create pull request manually."
 fi
 
-JSON="{title:\"Bump version to $VERSION\",head:\"$ORIGIN:$RELEASE_BRANCH\",base:\"master\"}"
+JSON="{\"title\":\"Bump version to $VERSION\",\"head\":\"$ORIGIN:$RELEASE_BRANCH\",\"base\":\"master\"}"
 RESPONSE=$(wget --quiet --output-document=- --content-on-error \
                --user="$USERNAME" --password="$PASSWORD" --auth-no-challenge \
                --header="Content-Type: application/json" \

--- a/src/scripts/release.sh
+++ b/src/scripts/release.sh
@@ -12,13 +12,13 @@ if [ "$#" -ne 2 ]; then
     fatal "$USAGE"
 fi
 if ! [[ $VERSION =~ ^[[:digit:]+\\.[:digit:]+\\.[:digit:]]+$ ]]; then
-  fatal "$USAGE"
+    fatal "$USAGE"
 fi
 if [[ $COMMAND != "prepare" && $COMMAND != "deploy" ]]; then
-  fatal "$USAGE"
+    fatal "$USAGE"
 fi
 if [[ $(git status --porcelain 2> /dev/null | tail -n1) != "" ]]; then
-  fatal "Repo is not clean please commit or delete dirty files."
+    fatal "Repo is not clean please commit or delete dirty files."
 fi
 
 ORIGIN_URL=$(git remote get-url origin)
@@ -36,10 +36,8 @@ git pull "$UPSTREAM_URL" master || fatal "Cannot pull  upstream master"
 echo "------- Create release branch $RELEASE_BRANCH ---------"
 git co -b "$RELEASE_BRANCH" || fatal "Cannot create release branch $RELEASE_BRANCH"
 
-echo "------- Update version ---------"
+echo "------- Update version and commit ---------"
 echo "__version__ = '$VERSION'" > 'src/sysl/__version__.py' || fatal "Could not override src/sysl/__version__.py"
-
-echo "------- Commit ---------"
 git commit -am "Bump version to $VERSION" || fatal "Cannot commit version update"
 
 echo "------- Push ---------"
@@ -59,7 +57,8 @@ RESPONSE=$(wget --quiet --output-document=- --content-on-error \
                --user="$USERNAME" --password="$PASSWORD" --auth-no-challenge \
                --header="Content-Type: application/json" \
                --header="Accept: application/vnd.github.v3+json" \
-               --post-data="$JSON" "https://api.github.com/repos/$UPSTREAM/$REPO/pulls")
+               --post-data="$JSON" \
+               "https://api.github.com/repos/$UPSTREAM/$REPO/pulls")
 
 WGET_STATUS=$?
 if [ $WGET_STATUS -eq 0 ]; then

--- a/src/scripts/release.sh
+++ b/src/scripts/release.sh
@@ -12,13 +12,13 @@ if [ "$#" -ne 2 ]; then
     fatal "$USAGE"
 fi
 if ! [[ $VERSION =~ ^[[:digit:]+\\.[:digit:]+\\.[:digit:]]+$ ]]; then
-	fatal "$USAGE"
+  fatal "$USAGE"
 fi
 if [[ $COMMAND != "prepare" && $COMMAND != "deploy" ]]; then
-	fatal "$USAGE"
+  fatal "$USAGE"
 fi
 if [[ $(git status --porcelain 2> /dev/null | tail -n1) != "" ]]; then
-	fatal "Repo is not clean please commit or delete dirty files."
+  fatal "Repo is not clean please commit or delete dirty files."
 fi
 
 ORIGIN_URL=$(git remote get-url origin)
@@ -50,7 +50,7 @@ REPO="sysl"
 CREDENTIALS=$(echo "host=github.com" | git credential fill)
 USERNAME=$(echo "$CREDENTIALS" | sed -n "s/.*username=\\([^ ]*\\).*/\\1/p")
 PASSWORD=$(echo "$CREDENTIALS" | sed -n "s/.*password=\\([^ ]*\\).*/\\1/p")
-if [ -z "$USERNAME" ] || [ -z "$PASSWORD" ]; then
+if [ "$USERNAME" = "" ] || [ "$PASSWORD" = "" ]; then
     fatal "Could not get GitHub credentials, please create pull request manually."
 fi
 
@@ -63,12 +63,12 @@ RESPONSE=$(wget --quiet --output-document=- --content-on-error \
 
 WGET_STATUS=$?
 if [ $WGET_STATUS -eq 0 ]; then
-	  GITHUB_PR_URL=$(echo "$RESPONSE" | jq -r '.html_url')
+    GITHUB_PR_URL=$(echo "$RESPONSE" | jq -r '.html_url')
     echo "Pull request opened:"
     echo "$GITHUB_PR_URL"
     open "$GITHUB_PR_URL"
 elif [ $WGET_STATUS -eq 6 ]; then
-	  fatal "Wrong username or password/token"
+    fatal "Wrong username or password/token"
 else
     fatal "Unknown error"
 fi

--- a/src/scripts/release.sh
+++ b/src/scripts/release.sh
@@ -1,0 +1,74 @@
+#!/bin/bash
+
+USAGE="Usage: release.sh <prepare|deploy> MAJOR.MINOR.PATCH"
+COMMAND=$1
+VERSION=$2
+
+function exit_error {
+    echo "$@" >&2
+    exit 1
+}
+if [ "$#" -ne 2 ]; then
+    exit_error $USAGE
+fi
+if ! [[ $VERSION =~ ^[[:digit:]+\\.[:digit:]+\\.[:digit:]]+$ ]]; then
+	exit_error $USAGE
+fi
+if [[ $COMMAND != "prepare" && $COMMAND != "deploy" ]]; then
+	exit_error $USAGE
+fi
+if [[ $(git status --porcelain 2> /dev/null | tail -n1) != "" ]]; then
+	exit_error "Repo is not clean please commit or delete dirty files."
+fi
+
+ORIGIN_URL=`git remote get-url origin`
+ORIGIN=`echo "$ORIGIN_URL" | sed -n "s/.*\/\/github.com\/\(..*\)\/..*.git/\1/p"`
+UPSTREAM="anz-bank"
+UPSTREAM_URL=`echo "$ORIGIN_URL" | sed -n "s/\(.*\/\/github.com\/\)\(..*\)\(\/..*.git\)/\1$UPSTREAM\3/p"`
+RELEASE_BRANCH="release-v$VERSION"
+
+echo "------- Checkout master ---------"
+git checkout master || exit_error "Cannot checkout master"
+
+echo "------- Pull upstream ---------"
+git pull $UPSTREAM_URL master || exit_error "Cannot pull  upstream master"
+
+echo "------- Create release branch $RELEASE_BRANCH ---------"
+git co -b $RELEASE_BRANCH || exit_error "Cannot create release branch $RELEASE_BRANCH"
+
+echo "------- Update version ---------"
+echo "__version__ = '$VERSION'" > 'src/sysl/__version__.py' || { echo "Could not override src/sysl/__version__.py"; exit 1; }
+
+echo "------- Commit ---------"
+git commit -am "Bump version to $VERSION" || exit_error "Cannot commit version update"
+
+echo "------- Push ---------"
+git push -u origin || exit_error "Cannot push release branch to origin"
+
+echo "------- Create PR ---------"
+REPO="sysl"
+CREDENTIALS=`echo "host=github.com" | git credential fill`
+USERNAME=`echo $CREDENTIALS | sed -n "s/.*username=\([^ ]*\).*/\1/p"`
+PASSWORD=`echo $CREDENTIALS | sed -n "s/.*password=\([^ ]*\).*/\1/p"`
+if [ -z "$USERNAME" ] || [ -z "$PASSWORD" ]; then
+    exit_error "Could not get GitHub credentials, please create pull request manually."
+fi
+
+JSON=`jq -nc "{title:\"Bump version to $VERSION\",head:\"$ORIGIN:$RELEASE_BRANCH\",base:\"master\"}"`
+RESPONSE=`wget --quiet --output-document=- --content-on-error \
+               --user="$USERNAME" --password="$PASSWORD" --auth-no-challenge \
+               --header="Content-Type: application/json" \
+               --header="Accept: application/vnd.github.v3+json" \
+               --post-data="$JSON" "https://api.github.com/repos/$UPSTREAM/$REPO/pulls"`
+
+WGET_STATUS=$?
+if [ $WGET_STATUS -eq 0 ]; then
+	GITHUB_PR_URL=`echo "$RESPONSE" | jq -r '.html_url'`
+    echo "Pull request opened:"
+    echo "$GITHUB_PR_URL"
+    open "$GITHUB_PR_URL"
+elif [ $WGET_STATUS -eq 6 ]; then
+	exit_error "Wrong username or password/token."
+else
+    exit_error "Unknown error."
+fi

--- a/src/scripts/release.sh
+++ b/src/scripts/release.sh
@@ -22,10 +22,8 @@ if [[ $(git status --porcelain 2> /dev/null | tail -n1) != "" ]]; then
 fi
 
 ORIGIN_URL=$(git remote get-url origin)
-ORIGIN=$(echo "$ORIGIN_URL" | sed -n "s/.*\\/\\/github.com\\/\\(..*\\)\\/..*.git/\\1/p")
 UPSTREAM="anz-bank"
 UPSTREAM_URL=$(echo "$ORIGIN_URL" | sed -n "s/\\(.*\\/\\/github.com\\/\\)\\(..*\\)\\(\\/..*.git\\)/\\1$UPSTREAM\\3/p")
-RELEASE_BRANCH="release-v$VERSION"
 
 echo "------- Checkout master ---------"
 git checkout master || fatal "Cannot checkout master"
@@ -33,41 +31,53 @@ git checkout master || fatal "Cannot checkout master"
 echo "------- Pull upstream ---------"
 git pull "$UPSTREAM_URL" master || fatal "Cannot pull  upstream master"
 
-echo "------- Create release branch $RELEASE_BRANCH ---------"
-git co -b "$RELEASE_BRANCH" || fatal "Cannot create release branch $RELEASE_BRANCH"
+if [[ $COMANND = "prepare" ]]; then
+    RELEASE_BRANCH="release-v$VERSION"
+    ORIGIN=$(echo "$ORIGIN_URL" | sed -n "s/.*\\/\\/github.com\\/\\(..*\\)\\/..*.git/\\1/p")
+    REPO=$(echo "$ORIGIN_URL" | sed -n "s/.*\\/\\/github.com\\/..*\\/\\(..*\\).git/\\1/p")
+    echo "------- Create release branch $RELEASE_BRANCH ---------"
+    git co -b "$RELEASE_BRANCH" || fatal "Cannot create release branch $RELEASE_BRANCH"
 
-echo "------- Update version and commit ---------"
-echo "__version__ = '$VERSION'" > 'src/sysl/__version__.py' || fatal "Could not override src/sysl/__version__.py"
-git commit -am "Bump version to $VERSION" || fatal "Cannot commit version update"
+    echo "------- Update version and commit ---------"
+    echo "__version__ = '$VERSION'" > 'src/sysl/__version__.py' || fatal "Could not override src/sysl/__version__.py"
+    git commit -am "Bump version to $VERSION" || fatal "Cannot commit version update"
 
-echo "------- Push ---------"
-git push -u origin || fatal "Cannot push release branch to origin"
+    echo "------- Push ---------"
+    git push -u origin || fatal "Cannot push release branch to origin"
 
-echo "------- Create PR ---------"
-REPO="sysl"
-CREDENTIALS=$(echo "host=github.com" | git credential fill)
-USERNAME=$(echo "$CREDENTIALS" | sed -n "s/.*username=\\([^ ]*\\).*/\\1/p")
-PASSWORD=$(echo "$CREDENTIALS" | sed -n "s/.*password=\\([^ ]*\\).*/\\1/p")
-if [ "$USERNAME" = "" ] || [ "$PASSWORD" = "" ]; then
-    fatal "Could not get GitHub credentials, please create pull request manually."
-fi
+    echo "------- Create PR ---------"
+    CREDENTIALS=$(echo "host=github.com" | git credential fill)
+    USERNAME=$(echo "$CREDENTIALS" | sed -n "s/.*username=\\([^ ]*\\).*/\\1/p")
+    PASSWORD=$(echo "$CREDENTIALS" | sed -n "s/.*password=\\([^ ]*\\).*/\\1/p")
+    if [ "$USERNAME" = "" ] || [ "$PASSWORD" = "" ]; then
+        fatal "Could not get GitHub credentials, please create pull request manually."
+    fi
 
-JSON="{\"title\":\"Bump version to $VERSION\",\"head\":\"$ORIGIN:$RELEASE_BRANCH\",\"base\":\"master\"}"
-RESPONSE=$(wget --quiet --output-document=- --content-on-error \
-               --user="$USERNAME" --password="$PASSWORD" --auth-no-challenge \
-               --header="Content-Type: application/json" \
-               --header="Accept: application/vnd.github.v3+json" \
-               --post-data="$JSON" \
-               "https://api.github.com/repos/$UPSTREAM/$REPO/pulls")
+    JSON="{\"title\":\"Bump version to $VERSION\",\"head\":\"$ORIGIN:$RELEASE_BRANCH\",\"base\":\"master\"}"
+    RESPONSE=$(wget --quiet --output-document=- --content-on-error \
+                   --user="$USERNAME" --password="$PASSWORD" --auth-no-challenge \
+                   --header="Content-Type: application/json" \
+                   --header="Accept: application/vnd.github.v3+json" \
+                   --post-data="$JSON" \
+                   "https://api.github.com/repos/$UPSTREAM/$REPO/pulls")
 
-WGET_STATUS=$?
-if [ $WGET_STATUS -eq 0 ]; then
-    GITHUB_PR_URL=$(echo "$RESPONSE" | jq -r '.html_url')
-    echo "Pull request opened:"
-    echo "$GITHUB_PR_URL"
-    open "$GITHUB_PR_URL"
-elif [ $WGET_STATUS -eq 6 ]; then
-    fatal "Wrong username or password/token"
-else
-    fatal "Unknown error"
+    WGET_STATUS=$?
+    if [ $WGET_STATUS -eq 0 ]; then
+        GITHUB_PR_URL=$(echo "$RESPONSE" | jq -r '.html_url')
+        echo "Pull request opened:"
+        echo "$GITHUB_PR_URL"
+        open "$GITHUB_PR_URL"
+    elif [ $WGET_STATUS -eq 6 ]; then
+        fatal "Wrong username or password/token"
+    else
+        fatal "Unknown error"
+    fi
+elif [[ $COMANND = "prepare" ]]; then
+    PY_VERSION=$(sed -n "s/__version__ = '\\([^ ]*\\)'/\\1/p" src/sysl/__version__.py)
+    [[  "$VERSION" =  "$PY_VERSION" ]] || fatal "Version ($VERSION) different from __version__.py ($PY_VERSION)"
+    echo "------- Tag release ---------"
+    git tag "v$VERSION" || fatal "Cannot create tag v$VERSION"
+    echo "------- Push tag ---------"
+    git push --tags "$UPSTREAM_URL"
+    echo "------- Deployment triggered on Travis and Appveyor ---------"
 fi

--- a/src/sysl/__version__.py
+++ b/src/sysl/__version__.py
@@ -1,3 +1,1 @@
-VERSION = (0, 1, 1)
-
-__version__ = '.'.join(map(str, VERSION))
+__version__ = '0.1.2'


### PR DESCRIPTION
Fixes #45.

Changes proposed in this pull request:
- Create release script (`src/scripts/release.sh <prepare|deploy> X.Y.Z`)
- Release preparation via release.sh: `release.sh prepare X.Y.Z`
  * Create release branch
  * Update, commit and push version file
  * Create PR from `origin/release-<VERSION>` to `upstream/master`
- Release deployment via release.sh: `release.sh deploy X.Y.Z`
  * Tag current version
  * Push tags to `updastream/master`
- Travis and Appveyor config update to deploy to `Github releases` on tags

@anz-bank/sysl-developers
