### PR TITLE
Rework e2e tests to be included in coverage

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,7 +6,7 @@ environment:
 install:
   - SET PATH=%PYTHON%;%PYTHON%\\Scripts;%JAVA_HOME%\bin;%PATH%
   - pip install --upgrade setuptools
-  - pip install http://sourceforge.net/projects/py2exe/files/latest/download?source=files
+  - pip install py2exe_py2
   - pip install . pytest flake8
   - choco install gradle
 

--- a/src/sysl/core/__main__.py
+++ b/src/sysl/core/__main__.py
@@ -88,7 +88,7 @@ def _deps_sub_parser(subparser):
     add_modules_option(argp)
 
 
-def main():
+def main(input_args=sys.argv[1:]):
     """Main function."""
     argp = argparse.ArgumentParser(
         description='System Modelling Language Toolkit',
@@ -115,7 +115,7 @@ def main():
     syslints.add_subparser(subparser)
     syslseqs.add_subparser(subparser)
 
-    args = argp.parse_args()
+    args = argp.parse_args(input_args)
 
     # Ensure the output directory exists.
     if 'output' in args and os.path.dirname(args.output):
@@ -126,7 +126,6 @@ def main():
                 raise
     try:
         args.func(args)
-        sys.exit(0)
     except Exception as e:
         if args.trace:
             raise
@@ -136,5 +135,5 @@ def main():
 
 
 if __name__ == '__main__':
-    #  debug.init()
     main()
+    sys.exit(0)

--- a/test/e2e/test_e2e.py
+++ b/test/e2e/test_e2e.py
@@ -1,4 +1,4 @@
-from sysl.core import syslloader
+from sysl.core.__main__ import main
 from sysl.util.file import filesAreIdentical
 
 import pytest
@@ -16,14 +16,19 @@ def remove_file(fname):
         pass
 
 
-@pytest.mark.parametrize("fname", [
-    '001_annotations',
-    '002_annotations',
-    '003_annotations',
-    '004_annotations',
-    '005_annotations',
+@pytest.mark.parametrize("fname, subprocess", [
+    ('001_annotations', True),
+    ('002_annotations', True),
+    ('003_annotations', True),
+    ('004_annotations', True),
+    ('005_annotations', True),
+    ('001_annotations', False),
+    ('002_annotations', False),
+    ('003_annotations', False),
+    ('004_annotations', False),
+    ('005_annotations', False)
 ])
-def test_e2e(fname):
+def test_e2e(fname, subprocess):
     e2e_dir = path.normpath(path.dirname(__file__))
     e2e_rel_dir = path.relpath(e2e_dir, start=REPO_ROOT)
 
@@ -33,9 +38,15 @@ def test_e2e(fname):
     out_fname = path.join(out_dir, 'actual_output', fname + '.txt')
     remove_file(out_fname)
 
-    cmd = ['sysl', '--root', root, 'textpb', '-o', out_fname, model]
-    print 'calling', ' '.join(cmd)
-    call(cmd)
+    args = ['--root', root, 'textpb', '-o', out_fname, model]
+
+    if subprocess:
+        cmd = ['sysl'] + args
+        print 'subprocess call: ', ' '.join(cmd)
+        call(cmd)
+    else:
+        print 'python function call: main([{}])'.format(', '.join(args))
+        main(args)
 
     expected_fname = path.join(e2e_dir, 'expected_output', fname + '.txt')
     assert filesAreIdentical(expected_fname, out_fname)


### PR DESCRIPTION
Fixes #71  .

Changes proposed in this pull request:
- rework `sysl.main` to take argument as optional (default `sys.argv[1:]`) parameter for testing
- extend e2e tests to optionally directly call `sysl.main` rather than start a subprocess

@anz-bank/sysl-developers