### PR TITLE
Use curl instead of wget

### DIFF
--- a/src/scripts/release.sh
+++ b/src/scripts/release.sh
@@ -55,22 +55,23 @@ if [[ $COMMAND = "prepare" ]]; then
     fi
 
     JSON="{\"title\":\"Bump version to $VERSION\",\"head\":\"$ORIGIN:$RELEASE_BRANCH\",\"base\":\"master\"}"
-    RESPONSE=$(wget --quiet --output-document=- --content-on-error \
-                   --user="$USERNAME" --password="$PASSWORD" --auth-no-challenge \
-                   --header="Content-Type: application/json" \
-                   --header="Accept: application/vnd.github.v3+json" \
-                   --post-data="$JSON" \
-                   "https://api.github.com/repos/$UPSTREAM/$REPO/pulls")
+    RESPONSE=$(curl -X POST -s -S \
+            -u "$USERNAME:$PASSWORD" \
+            --header "Content-Type: application/json" \
+            --header "Accept: application/vnd.github.v3+json" \
+            -d "$JSON" "https://api.github.com/repos/$UPSTREAM/$REPO/pulls")
 
-    WGET_STATUS=$?
-    if [ $WGET_STATUS -eq 0 ]; then
+    CURL_STATUS=$?
+    if [ $CURL_STATUS -eq 0 ]; then
         GITHUB_PR_URL=$(echo "$RESPONSE" | jq -r '.html_url')
         echo "Pull request opened:"
         echo "$GITHUB_PR_URL"
         open "$GITHUB_PR_URL"
-    elif [ $WGET_STATUS -eq 6 ]; then
+    elif [ $CURL_STATUS -eq 6 ]; then
         fatal "Wrong username or password/token"
     else
+        echo "$CURL_STATUS"
+        echo "$RESPONSE"
         fatal "Unknown error"
     fi
 elif [[ $COMMAND = "deploy" ]]; then


### PR DESCRIPTION
Changes proposed in this pull request:
- Use curl instead of wget. Helps when creating release from inside corp/proxy networks.

@anz-bank/sysl-developers
