### PR TITLE
Fix missing exe CI testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,6 +34,7 @@ install:
 script:
 - flake8
 - pytest
+- pytest test/e2e --syslexe=sysl --reljamexe=reljam
 - gradle test -b test/java/build.gradle
 before_deploy:
 - python setup.py sdist bdist_wheel

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,6 +6,7 @@ environment:
 install:
   - SET PATH=%PYTHON%;%PYTHON%\\Scripts;%JAVA_HOME%\bin;%PATH%
   - pip install --upgrade setuptools
+  # py2exe for Python 2.7 missing on PyPI (https://stackoverflow.com/q/23734172)
   - pip install http://sourceforge.net/projects/py2exe/files/latest/download?source=files
   - pip install . pytest flake8
   - choco install gradle

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,7 +6,7 @@ environment:
 install:
   - SET PATH=%PYTHON%;%PYTHON%\\Scripts;%JAVA_HOME%\bin;%PATH%
   - pip install --upgrade setuptools
-  - pip install py2exe_py2
+  - pip install http://sourceforge.net/projects/py2exe/files/latest/download?source=files
   - pip install . pytest flake8
   - choco install gradle
 
@@ -14,6 +14,7 @@ build: off
 
 test_script:
   - pytest
+  - pytest test/e2e --syslexe=sysl --reljamexe=reljam
   - flake8
   - gradle --no-daemon -b test\java\build.gradle test
 
@@ -22,6 +23,7 @@ after_test:
   - msiexec /i C:\VCForPython27.msi /quiet /q
   - XCOPY src\libs\google-site-packages-override\__init__.py  C:\Python27\Lib\site-packages\google /Y
   - python setup.py py2exe
+  - pytest test/e2e --syslexe=dist/sysl.exe --reljamexe=dist/reljam.exe
 
 artifacts:
   - path: 'dist'

--- a/test/e2e/conftest.py
+++ b/test/e2e/conftest.py
@@ -1,0 +1,10 @@
+def pytest_addoption(parser):
+    parser.addoption('--syslexe', action='store', default='')
+    parser.addoption('--reljamexe', action='store', default='')
+
+
+def pytest_generate_tests(metafunc):
+    if 'syslexe' in metafunc.fixturenames:
+        metafunc.parametrize('syslexe', [metafunc.config.option.syslexe])
+    if 'reljamexe' in metafunc.fixturenames:
+        metafunc.parametrize('reljamexe', [metafunc.config.option.reljamexe])


### PR DESCRIPTION

Fixes #105.

Changes proposed in this pull request:
- Refactor e2e tests to work with exe passed in as command line argument to pytest
- Add pytest arguments to Travis and Appveyor to test sysl|reljam python scripts and exes
- Change py2exe package origin back to sourceforge in hopes of fixing random HTTPS package error

@anz-bank/sysl-developers