### PR TITLE
Fix Appveyor sysl.exe

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,7 +7,7 @@ install:
   - SET PATH=%PYTHON%;%PYTHON%\\Scripts;%JAVA_HOME%\bin;%PATH%
   - pip install --upgrade setuptools
   - pip install py2exe_py2
-  - pip install protobuf==3.5.1 # protobuf 3.5.2 causes problems in sysl.exe
+  - pip install protobuf==3.5.1 # protobuf 3.5.2 and py2exe don't work together
   - pip install . pytest flake8
   - pip freeze
   - choco install gradle

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,7 +7,9 @@ install:
   - SET PATH=%PYTHON%;%PYTHON%\\Scripts;%JAVA_HOME%\bin;%PATH%
   - pip install --upgrade setuptools
   - pip install py2exe_py2
+  - pip install protobuf==3.5.1 # protobuf 3.5.2 causes problems in sysl.exe
   - pip install . pytest flake8
+  - pip freeze
   - choco install gradle
 
 build: off


### PR DESCRIPTION
Fixes [broken CI build on Appveyor](https://ci.appveyor.com/project/anz-bank/sysl/build/1.0.309).

Changes proposed in this pull request:
- Pin Python protobuf library to 3.5.1
- Dump library versions in Appvyor logs

@anz-bank/sysl-developers