### PR TITLE
Enhance sysl module naming

### DIFF
--- a/demo/simple/example2.sysl
+++ b/demo/simple/example2.sysl
@@ -1,5 +1,5 @@
 # sysl ints -o "example2.svg" /example2 --project "Internet Banking" -v
-# sysl ints -o "example2-epa.svg" /example2 --project "My Project :: Integration" --epa -v
+# sysl ints -o "example2-epa.svg" /example2 --project "Integration" --epa -v
 InternetBanking:
     GetCustomer:
         Customer <- GetCustomer

--- a/docs/website/content/docs/commandline.md
+++ b/docs/website/content/docs/commandline.md
@@ -40,8 +40,7 @@ optional arguments:
   --root ROOT, -r ROOT  sysl root directory for input files (default: .)
   --version, -v         show version number (semver.org standard)
   --trace, -t
-  ```
-
+```
 
 reljam
 ------

--- a/docs/website/content/docs/outputs.md
+++ b/docs/website/content/docs/outputs.md
@@ -24,9 +24,9 @@ Reljam outputs
 --------------
 | Command | Description |
 |---------|-------------|
-| model   | Java model implementation (in memory) | 
+| model   | Java model implementation (in memory) |
 | facade  | Java facade implementation (restricted access to creating and populating models) |
-| view    | Java implementation of sysl model transformatios|
-| xsd     | XSD represtation of sysl model | 
+| view    | Java implementation of Sysl model transformations|
+| xsd     | XSD representation of Sysl model |
 | swagger | Swagger representation of REST APIs and models |
 | spring-rest-service | Java Spring REST API implementation |

--- a/src/sysl/core/syslloader.py
+++ b/src/sysl/core/syslloader.py
@@ -1,7 +1,6 @@
 """sysl module loader"""
 
 import codecs
-import collections
 import os
 import re
 import sys
@@ -324,14 +323,12 @@ def load(names, validate, root):
     def do_import(name, indent="-"):
         """Import a sysl module and its dependencies."""
         imports.add(name)
-        # print indent, name
         (basedir, _) = os.path.split(name)
         new_imports = {
             root + i if i[:1] == '/' else os.path.join(basedir, i)
             for i in syslparse.Parser().parse(
                 codecs.open(name + '.sysl', 'r', 'utf8'), name + '.sysl', module)
         } - imports
-        #print >>sys.stderr, '+++++++++++', new_imports
         while new_imports:
             do_import(new_imports.pop(), indent + "-")
             new_imports -= imports
@@ -339,7 +336,9 @@ def load(names, validate, root):
     for name in names:
         if name not in imports:
             if name[:1] != '/':
-                raise RuntimeError('module ref must start with "/"')
+                name = '/' + name
+            if name.endswith('.sysl'):
+                name = name[:-5]
             do_import(root + name)
 
     try:

--- a/test/e2e/test_e2e.py
+++ b/test/e2e/test_e2e.py
@@ -34,7 +34,7 @@ def test_e2e(name, syslexe):
     actual = path.join(ACTUAL_DIR, name + '.txt')
     remove_file(actual)
 
-    args = ['--root', IN_DIR, 'textpb', '-o', actual, '/' + name]
+    args = ['--root', IN_DIR, 'textpb', '-o', actual, name + '.sysl']
 
     if syslexe:
         print 'Sysl exe call'


### PR DESCRIPTION
Fixes #135.

Changes proposed in this pull request:
- Fix various typos in documentation.
- Allow for module specification as `sample.sysl` in addition to `/sample`
- End-to-end test this new feature

@anz-bank/sysl-developers
