### PR TITLE
Fix trailing whitespace handling for rest apis

### DIFF
--- a/src/sysl/core/syslparse.py
+++ b/src/sysl/core/syslparse.py
@@ -1040,7 +1040,7 @@ class Parser(object):
 
             if match(r'^@(.*)'):
                 attrp += match.groups[0]
-            elif match(ur'^(/\S*)(?:·\[(.*)\])?$'):
+            elif match(ur'^(/\S*)(?:·\[(.*)\])?·$'):
                 (subpath, extra_extra_attrs) = match.groups
                 self._parse_rest_api(
                     app, path, subpath, attrp + extra_attrs + extra_extra_attrs,


### PR DESCRIPTION
Allow trailing whitespace after REST attributes, e.g.:

```python
RestApp:
    /foo [x=1]  :
        GET: ...
```
