### PR TITLE
Add support to render relational data view

### DIFF
--- a/test/e2e/input/020_diagram.sysl
+++ b/test/e2e/input/020_diagram.sysl
@@ -9,7 +9,7 @@ BankModel [package="io.sysl.bank.model"]:
         customer_name <: string?
         customer_address <: string?
         customer_dob <: date?
-        branch_id <: Branches.branch_id
+        branch_id <: Branch.branch_id
 
     !table Account:
         account_number <: int [~pk]
@@ -22,12 +22,12 @@ BankModel [package="io.sysl.bank.model"]:
         transaction_type <: string?
         transaction_date_time <: date?
         transaction_amount <: int?
-        from_account_number <: Accounts.account_number
-        to_account_number <: Accounts.account_number
+        from_account_number <: Account.account_number
+        to_account_number <: Account.account_number
 
     !table CustomerAccount:
-        customer_id <: Customers.customer_id
-        account_number <: Accounts.account_number
+        customer_id <: Customer.customer_id
+        account_number <: Account.account_number
 
 
 BankFacade [package="io.sysl.bank.facade"]:
@@ -108,8 +108,8 @@ AccountTransactionApi [package="io.sysl.account.api"]:
         transaction_type <: string?
         transaction_date_time <: date?
         transaction_amount <: int?
-        from_account_number <: Accounts.account_number
-        to_account_number <: Accounts.account_number
+        from_account_number <: Account.account_number
+        to_account_number <: Account.account_number
 
 ATM:
     GetBalance:
@@ -133,11 +133,15 @@ Bank :: Integrations [title="%(epname)", appfmt="%(@gaf22?//%(@gaf22)//\n|%(need
         AccountTransactionApi
         ATM
 
-Bank :: Data Views:
+Bank :: Tuple Views:
 
     AccountTransactionApi [page="Bank ISD"]:
         AccountTransactionApi
 
+Bank :: Relational Views:
+
+    BankModel:
+      BankModel
 
 
 Bank :: Sequences [seqtitle="%(epname): %(eplongname)%(@title_suffix? (%(title_suffix)%))", appfmt="%(DONOTWANT?%(@gaf22?//%(@gaf22)//\n))**%(appname)**", epfmt="%(@gaf22?//«%(@gaf22)»//**%(patterns? %(patterns~/\btba|tbd\b/?<color red>%(patterns)</color>|<color green>%(patterns)</color>)| <color red>pattern?</color>)**\n)%(epname)%(args?\n(%(args)%))"]:

--- a/test/e2e/input/020_diagram.sysl
+++ b/test/e2e/input/020_diagram.sysl
@@ -125,9 +125,9 @@ ATM:
         AccountTransactionApi <- POST /accounts/{account_number}/transfer
         Transfer funds
 
-Bank :: Integrations [title="%(epname)", appfmt="%(@gaf22?//%(@gaf22)//\n|%(needs_fc?<color red>(missing FC%)</color>\n))**%(appname)**", highlight_color="aqua", indirect_arrow_color="silver"]:
+Bank :: Integrations:
 
-    APIs [page="Bank CSP Overview", exclude=["COD"]]:
+    APIs:
         BankDatabase
         CustomerApi
         AccountTransactionApi
@@ -135,7 +135,7 @@ Bank :: Integrations [title="%(epname)", appfmt="%(@gaf22?//%(@gaf22)//\n|%(need
 
 Bank :: Tuple Views:
 
-    AccountTransactionApi [page="Bank ISD"]:
+    AccountTransactionApi:
         AccountTransactionApi
 
 Bank :: Relational Views:
@@ -144,9 +144,9 @@ Bank :: Relational Views:
       BankModel
 
 
-Bank :: Sequences [seqtitle="%(epname): %(eplongname)%(@title_suffix? (%(title_suffix)%))", appfmt="%(DONOTWANT?%(@gaf22?//%(@gaf22)//\n))**%(appname)**", epfmt="%(@gaf22?//«%(@gaf22)»//**%(patterns? %(patterns~/\btba|tbd\b/?<color red>%(patterns)</color>|<color green>%(patterns)</color>)| <color red>pattern?</color>)**\n)%(epname)%(args?\n(%(args)%))"]:
+Bank :: Sequences [seqtitle="%(epname): %(eplongname)"]:
 
-    SEQ-ATM "Submit Application (Bankers Desktop)" [page="Bank SEQ-001 Submit Application", blackboxes=[['Pega :: PO <- POST /orders/{id}/order-state-requests', 'SEQ-001c']]]:
+    SEQ-ATM "Submit Application" [page="Bank SEQ-001 Submit Application"]:
         ATM <- GetBalance
         ATM <- Withdraw
         ATM <- Deposit

--- a/test/e2e/test_e2e.py
+++ b/test/e2e/test_e2e.py
@@ -73,7 +73,7 @@ def test_reljam(mode, module, app, java_pkg, expected, reljamexe):
 
 
 @pytest.mark.unit
-def test_sysl_diagramm(syslexe):
+def test_sysl_seq_diagramm(syslexe):
     name = '020_diagram'
     actual_pattern = path.join(ACTUAL_DIR, name + '-%(epname).svg')
     fname = name + '-SEQ-ATM.svg'
@@ -99,4 +99,76 @@ def test_sysl_diagramm(syslexe):
     assert 'GetBalance</text>' in svg
     assert 'GET /accounts/{account_number}</text>' in svg
     assert "/accounts/{account_number}/deposit</text>" in svg
-    assert '@startuml' in svg
+
+
+@pytest.mark.unit
+def test_sysl_tuple_data_diagramm(syslexe):
+    name = '020_diagram'
+    actual_pattern = path.join(ACTUAL_DIR, name + '-%(epname).svg')
+    fname = name + '-AccountTransactionApi.svg'
+    actual = path.join(ACTUAL_DIR, fname)
+    remove_file(actual)
+    args = ['--root', IN_DIR, 'data', '-o', actual_pattern, '/' + name, '-j', 'Bank :: Tuple Views']
+
+    if syslexe:
+        print 'Sysl exe call'
+        call([syslexe] + args)
+    else:
+        print 'Sysl python function call'
+        main(args)
+
+    with open(actual, 'r') as f:
+        svg = f.read()
+
+    assert svg.startswith('<?xml version="1.0" encoding="UTF-8" standalone="no"?>')
+    assert 'Account</text>' in svg
+    assert 'account_number : int</text>' in svg
+    assert 'account_type : string</text>' in svg
+    assert 'account_status : string</text>' in svg
+    assert 'account_balance : int</text>' in svg
+    assert 'Transaction</text>' in svg
+    assert 'transaction_id : int</text>' in svg
+    assert 'from_account_number :</text>' in svg
+    assert 'to_account_number :</text>' in svg
+
+
+@pytest.mark.unit
+def test_sysl_relational_data_diagramm(syslexe):
+    name = '020_diagram'
+    actual_pattern = path.join(ACTUAL_DIR, name + '-%(epname).svg')
+    fname = name + '-BankModel.svg'
+    actual = path.join(ACTUAL_DIR, fname)
+    remove_file(actual)
+    args = ['--root', IN_DIR, 'data', '-o', actual_pattern, '/' + name, '-j', 'Bank :: Relational Views']
+
+    if syslexe:
+        print 'Sysl exe call'
+        call([syslexe] + args)
+    else:
+        print 'Sysl python function call'
+        main(args)
+
+    with open(actual, 'r') as f:
+        svg = f.read()
+
+    assert svg.startswith('<?xml version="1.0" encoding="UTF-8" standalone="no"?>')
+    assert '--class _0--' in svg
+    assert '--class _1--' in svg
+    assert '--class _2--' in svg
+    assert '--class _3--' in svg
+    assert '--class _4--' in svg
+    assert 'link _0 to _1' in svg
+    assert 'link _3 to _2' in svg
+    assert 'link _4 to _0' in svg
+    assert 'link _4 to _2' in svg
+    assert 'id="_0"' in svg
+    assert 'id="_1"' in svg
+    assert 'id="_2"' in svg
+    assert 'id="_3"' in svg
+    assert 'id="_4"' in svg
+    assert 'id="_0-_1"' in svg
+    assert 'id="_3-_2"' in svg
+    assert 'id="_4-_0"' in svg
+    assert 'id="_4-_2"' in svg
+    assert 'from_account_number :</text>' in svg
+    assert 'to_account_number :</text>' in svg

--- a/test/e2e/test_e2e.py
+++ b/test/e2e/test_e2e.py
@@ -92,7 +92,7 @@ def test_sysl_seq_diagramm(syslexe):
         svg = f.read()
 
     assert svg.startswith('<?xml version="1.0" encoding="UTF-8" standalone="no"?>')
-    assert 'SEQ-ATM: Submit Application (Bankers Desktop)</text>' in svg
+    assert 'SEQ-ATM: Submit Application</text>' in svg
     assert 'ATM</text>' in svg
     assert 'AccountTransactionApi</text>' in svg
     assert 'BankDatabase</text>' in svg

--- a/test/e2e/test_e2e.py
+++ b/test/e2e/test_e2e.py
@@ -152,23 +152,12 @@ def test_sysl_relational_data_diagramm(syslexe):
         svg = f.read()
 
     assert svg.startswith('<?xml version="1.0" encoding="UTF-8" standalone="no"?>')
-    assert '--class _0--' in svg
-    assert '--class _1--' in svg
-    assert '--class _2--' in svg
-    assert '--class _3--' in svg
-    assert '--class _4--' in svg
-    assert 'link _0 to _1' in svg
-    assert 'link _3 to _2' in svg
-    assert 'link _4 to _0' in svg
-    assert 'link _4 to _2' in svg
-    assert 'id="_0"' in svg
-    assert 'id="_1"' in svg
-    assert 'id="_2"' in svg
-    assert 'id="_3"' in svg
-    assert 'id="_4"' in svg
-    assert 'id="_0-_1"' in svg
-    assert 'id="_3-_2"' in svg
-    assert 'id="_4-_0"' in svg
-    assert 'id="_4-_2"' in svg
+    assert 'Account</text>' in svg
+    assert 'account_number : int</text>' in svg
+    assert 'account_type : string</text>' in svg
+    assert 'account_status : string</text>' in svg
+    assert 'account_balance : int</text>' in svg
+    assert 'Transaction</text>' in svg
+    assert 'transaction_id : int</text>' in svg
     assert 'from_account_number :</text>' in svg
     assert 'to_account_number :</text>' in svg


### PR DESCRIPTION
Fixes #153 .

Changes proposed in this pull request:
Provides support for rendering relational data models
- Support for many-to-one using '}--' syntax
- Support for one-to-one using '||--||' syntax

@anz-bank/sysl-developers
