### PR TITLE
:art: Pass abstract filesystem to sysl.Parse() + more testable main()

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,4 @@
+ignore:
+  - sysl2/sysl/sysl_js/SyslLexer.js
+  - sysl2/sysl/sysl_js/SyslParser.js
+  - sysl2/sysl/sysl_js/SyslParserListener.js

--- a/sysl2/sysl/Parser_test.go
+++ b/sysl2/sysl/Parser_test.go
@@ -12,10 +12,49 @@ import (
 	"github.com/golang/protobuf/proto"
 )
 
-func loadAndCompare(m2 *sysl.Module, filename string, root string) bool {
+func pyParse(filename, root string) (*sysl.Module, error) {
+	output := filename + ".pb"
 
-	// remove that does not match legacy.
-	for _, app := range m2.Apps {
+	args := []string{"pb", "-o", output, filename}
+	if len(root) > 0 {
+		rootArg := []string{"--root", root}
+		// TODO: This looks dubious
+		args[2] = root + "/" + args[2]
+		output = args[2]
+		args = append(rootArg, args...)
+	}
+
+	pySysl, found := os.LookupEnv("SYSL_PYTHON_BIN")
+	if !found {
+		pySysl = "sysl"
+	}
+	cmd := exec.Command(pySysl, args...)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		return nil, err
+	}
+	buf := bytes.NewBuffer(nil)
+
+	f, _ := os.Open(output)
+	io.Copy(buf, f)
+	f.Close()
+
+	module := &sysl.Module{}
+	if err := proto.Unmarshal(buf.Bytes(), module); err != nil {
+		return nil, err
+	}
+	return module, nil
+}
+
+func parseComparable(filename, root string) (*sysl.Module, error) {
+	module, err := Parse(filename, root)
+	if err != nil {
+		return nil, err
+	}
+
+	// remove stuff that does not match legacy.
+	for _, app := range module.Apps {
 		app.SourceContext = nil
 		// app.SourceContext.Start.Col = 0
 		for _, ep := range app.Endpoints {
@@ -26,57 +65,57 @@ func loadAndCompare(m2 *sysl.Module, filename string, root string) bool {
 		}
 	}
 
-	output := filename + ".pb"
+	return module, nil
+}
 
-	args := []string{"pb", "-o", output, filename}
-	if len(root) > 0 {
-		root_array := []string{"--root", root}
-		args[2] = root_array[1] + "/" + args[2]
-		output = args[2]
-		args = append(root_array, args...)
+func parseAndCompare(filename, root string) (bool, error) {
+	goModule, err := parseComparable(filename, root)
+	if err != nil {
+		return false, err
 	}
 
-	pySysl, found := os.LookupEnv("SYSL_PYTHON_BIN")
-	if !found {
-		pySysl = "sysl"
+	pyModule, err := pyParse(filename, root)
+	if err != nil {
+		return false, err
 	}
-	cmd := exec.Command(pySysl, args...)
+	if proto.Equal(pyModule, goModule) {
+		return true, nil
+	}
+
+	golden := "golden.txt"
+	generated := "generated.txt"
+	if err = TextPB(pyModule, golden); err != nil {
+		return false, err
+	}
+	if err = TextPB(goModule, generated); err != nil {
+		return false, err
+	}
+	cmd := exec.Command("diff", "-y", golden, generated)
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
-	err := cmd.Run()
+	cmd.Run()
+
+	return false, nil
+}
+
+func parseAndPrint(t *testing.T, filename, root string) error {
+	goModule, err := parseComparable(filename, root)
 	if err != nil {
-		fmt.Println(err)
-		return false
+		return err
 	}
-	buf := bytes.NewBuffer(nil)
-
-	f, _ := os.Open(output)
-	io.Copy(buf, f)
-	f.Close()
-
-	mod := sysl.Module{}
-	err = proto.Unmarshal(buf.Bytes(), &mod)
-	if err != nil {
-		fmt.Println(err)
-		return false
-	}
-	result := proto.Equal(&mod, m2)
-	// uncomment to compare
-	if !result {
-		TextPB(m2, "generated.txt")
-		TextPB(&mod, "golden.txt")
-		cmd = exec.Command("diff", "-y", "golden.txt", "generated.txt")
-		cmd.Stdout = os.Stdout
-		cmd.Stderr = os.Stderr
-		cmd.Run()
-	}
-
-	return result
+	fmt.Fprintf(os.Stderr, "Outputting %#v:\n", filename)
+	FTextPB(os.Stderr, goModule)
+	fmt.Fprintf(os.Stderr, "------------------------\n")
+	return nil
 }
 
 func testParse(t *testing.T, filename, root string) {
-	if !loadAndCompare(Parse(filename, root), filename, root) {
-		t.Error("failed")
+	equal, err := parseAndCompare(filename, root)
+	if err != nil {
+		t.Errorf("Parsing error: %v", err)
+	}
+	if !equal {
+		t.Error("Mismatch")
 	}
 }
 
@@ -180,13 +219,8 @@ func TestSimpleProject(t *testing.T) {
 }
 
 func TestUrlParamOrder(t *testing.T) {
-	filename := "tests/rest_url_params.sysl"
-	// output does not match with legacy
-	// the order does not match
-	// check the diff.
-	if loadAndCompare(Parse(filename, ""), filename, "") == true {
-		t.Error("failed")
-	}
+	// Output won't match legacy; visually inspect the diff.
+	parseAndCompare("tests/rest_url_params.sysl", "")
 }
 
 func TestRestApi_WrongOrder(t *testing.T) {

--- a/sysl2/sysl/Parser_test.go
+++ b/sysl2/sysl/Parser_test.go
@@ -264,7 +264,7 @@ func TestFuncs(t *testing.T) {
 }
 
 func TestPetshop(t *testing.T) {
-	testParse(t, "../../demo/petshop/petshop.sysl", "")
+	testParse(t, "petshop.sysl", "../../demo/petshop")
 }
 
 func TestCrash(t *testing.T) {

--- a/sysl2/sysl/grammar/lexer_impl.go
+++ b/sysl2/sysl/grammar/lexer_impl.go
@@ -1,9 +1,11 @@
 package parser
 
 import (
+	"os"
 	s "strings"
 
 	"github.com/antlr/antlr4/runtime/Go/antlr"
+	"github.com/sirupsen/logrus"
 )
 
 func calcSpaces(text string) int {
@@ -102,6 +104,9 @@ func GetNextToken(l *SyslLexer) antlr.Token {
 	}
 
 	next := l.BaseLexer.NextToken()
+	if os.Getenv("SYSL_LEXER_LOG") != "" {
+		logrus.Info(next)
+	}
 	// return NEWLINE
 	if gotNewLine {
 		switch next.GetTokenType() {

--- a/sysl2/sysl/sysl.go
+++ b/sysl2/sysl/sysl.go
@@ -19,11 +19,6 @@ import (
 	"github.com/golang/protobuf/proto"
 )
 
-var (
-	root   = flag.String("root", ".", "sysl root directory for input files (default: .)")
-	output = flag.String("o", "", "output file name")
-)
-
 const (
 	// ParserSuccess is returned by parser when it was able to parse input correctly
 	ParserSuccess = 0
@@ -46,20 +41,25 @@ func (e exit) Error() string {
 	return e.message
 }
 
-func init() {
-	flag.Parse()
+// JSONPB ...
+func JSONPB(m *sysl.Module, filename string) error {
+	if m == nil {
+		return fmt.Errorf("module is nil: %#v", filename)
+	}
+	f, err := os.Create(filename)
+	if err != nil {
+		return err
+	}
+	return FJSONPB(f, m)
 }
 
-// JsonPB ...
-func JsonPB(m *sysl.Module, filename string) bool {
-	ma := jsonpb.Marshaler{Indent: " ", EmitDefaults: false}
-	f, err := os.Create(filename)
-	err = ma.Marshal(f, m)
-	if err != nil {
-		fmt.Fprintln(os.Stderr, err)
-		return false
+// FJSONPB ...
+func FJSONPB(w io.Writer, m *sysl.Module) error {
+	if m == nil {
+		return fmt.Errorf("module is nil")
 	}
-	return true
+	ma := jsonpb.Marshaler{Indent: " ", EmitDefaults: false}
+	return ma.Marshal(w, m)
 }
 
 // TextPB ...
@@ -627,25 +627,71 @@ func FSParse(filename string, fs http.FileSystem) (*sysl.Module, error) {
 	return listener.module, nil
 }
 
-func main() {
-	fmt.Printf("Args: %v\n", flag.Args())
-	fmt.Printf("Root: %s\n", *root)
-	fmt.Printf("Module: %s\n", flag.Arg(0))
+// main3 is the real main function. It takes its output streams and command-line
+// arguments as parameters to support testability.
+func main3(stdout, stderr io.Writer, args []string) error {
+	flags := flag.NewFlagSet(args[0], flag.PanicOnError)
+
+	root := flags.String("root", ".", "sysl root directory for input files (default: .)")
+	output := flags.String("o", "", "output file name")
+	mode := flags.String("mode", "textpb", "output mode")
+
+	flags.Parse(args[1:])
+
+	switch *mode {
+	case "", "textpb", "json":
+	default:
+		return fmt.Errorf("Invalid -mode %#v", *mode)
+	}
+
+	filename := flags.Arg(0)
+
+	fmt.Fprintf(stderr, "Args: %v\n", flags.Args())
+	fmt.Fprintf(stderr, "Root: %s\n", *root)
+	fmt.Fprintf(stderr, "Module: %s\n", filename)
+	fmt.Fprintf(stderr, "Mode: %s\n", *mode)
 	format := strings.ToLower(*output)
-	toJson := strings.HasSuffix(format, ".json")
-	mod, err := Parse(flag.Arg(0), *root)
+	toJSON := *mode == "json" || *mode == "" && strings.HasSuffix(format, ".json")
+	fmt.Fprintf(stderr, "%s\n", filename)
+	mod, err := Parse(filename, *root)
 	if err != nil {
-		fmt.Fprintln(os.Stderr, err.Error())
-		if err, ok := err.(exit); ok {
-			os.Exit(err.code)
-		}
-		os.Exit(1)
+		return err
 	}
 	if mod != nil {
-		if toJson {
-			JsonPB(mod, *output)
-		} else {
-			TextPB(mod, *output)
+		if toJSON {
+			if *output == "-" {
+				return FJSONPB(stdout, mod)
+			}
+			return JSONPB(mod, *output)
 		}
+		if *output == "-" {
+			return FTextPB(stdout, mod)
+		}
+		return TextPB(mod, *output)
+	}
+	return nil
+}
+
+// main2 calls main3 and handles any errors it returns. It takes its output
+// streams and command-line arguments and even main3 as parameters to support
+// testability.
+func main2(
+	stdout, stderr io.Writer, args []string,
+	main3 func(stdout, stderr io.Writer, args []string) error,
+) int {
+	if err := main3(stdout, stderr, args); err != nil {
+		fmt.Fprintln(stderr, err.Error())
+		if err, ok := err.(exit); ok {
+			return err.code
+		}
+		return 1
+	}
+	return 0
+}
+
+// main is as small as possible to minimise its no-coverage footprint.
+func main() {
+	if rc := main2(os.Stdout, os.Stderr, os.Args, main3); rc != 0 {
+		os.Exit(rc)
 	}
 }

--- a/sysl2/sysl/sysl_listener_impl.go
+++ b/sysl2/sysl/sysl_listener_impl.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"math"
+	"net/http"
 	"strconv"
 	"strings"
 
@@ -18,7 +19,7 @@ var _ = fmt.Println
 type TreeShapeListener struct {
 	*parser.BaseSyslParserListener
 	base                  string
-	root                  string
+	fs                    http.FileSystem
 	filename              string
 	imports               []string
 	module                *sysl.Module
@@ -42,7 +43,7 @@ type TreeShapeListener struct {
 }
 
 // NewTreeShapeListener ...
-func NewTreeShapeListener(root string) *TreeShapeListener {
+func NewTreeShapeListener(fs http.FileSystem) *TreeShapeListener {
 	opmap := map[string]sysl.Expr_BinExpr_Op{
 		"==":        sysl.Expr_BinExpr_EQ,
 		"!=":        sysl.Expr_BinExpr_NE,
@@ -57,7 +58,7 @@ func NewTreeShapeListener(root string) *TreeShapeListener {
 	}
 
 	return &TreeShapeListener{
-		root: root,
+		fs: fs,
 		module: &sysl.Module{
 			Apps: map[string]*sysl.Application{},
 		},
@@ -3501,9 +3502,7 @@ func (s *TreeShapeListener) ExitPath(ctx *parser.PathContext) {}
 func (s *TreeShapeListener) EnterImport_stmt(ctx *parser.Import_stmtContext) {
 	p := strings.Split(strings.TrimSpace(ctx.IMPORT().GetText()), " ")
 	path := p[len(p)-1]
-	if path[0] == '/' {
-		path = s.root + path
-	} else {
+	if path[0] != '/' {
 		path = s.base + "/" + path
 	}
 	path += ".sysl"

--- a/sysl2/sysl/sysl_test.go
+++ b/sysl2/sysl/sysl_test.go
@@ -1,0 +1,29 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestOSFileSystem(t *testing.T) {
+	fs := &osFileSystem{root: "."}
+
+	f, err := fs.Open("sysl.go")
+	assert.NoError(t, err)
+	stat, err := f.Stat()
+	assert.NoError(t, err)
+	assert.False(t, stat.IsDir())
+	assert.True(t, stat.Size() > 0)
+
+	_, err = fs.Open("doesn't.exist")
+	assert.Error(t, err)
+}
+
+func TestFSFileStream(t *testing.T) {
+	fs := &osFileSystem{root: "."}
+
+	s, err := newFSFileStream("sysl.go", fs)
+	assert.NoError(t, err)
+	assert.Equal(t, "package main", s.GetText(0, 11))
+}

--- a/sysl2/sysl/sysl_test.go
+++ b/sysl2/sysl/sysl_test.go
@@ -1,10 +1,62 @@
 package main
 
 import (
+	"bytes"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
 	"testing"
 
+	"github.com/anz-bank/sysl/src/proto"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
+
+type testTempFile struct {
+	f *os.File
+}
+
+func newTestTempFile(t *testing.T, dir, pattern string) *testTempFile {
+	f, err := ioutil.TempFile("", "github.com-sysl-sysl2-sysl-sysl_test.go-TestJSONPB-*.json")
+	if assert.NoError(t, err, "newTestTempFile(%#v, %#v)", dir, pattern) {
+		return &testTempFile{f}
+	}
+	return nil
+}
+
+func testTempFilename(t *testing.T, dir, pattern string) string {
+	if tf := newTestTempFile(t, dir, pattern); tf != nil {
+		defer tf.CloseAndRemove()
+		return tf.Name()
+	}
+	return ""
+}
+
+func (tf *testTempFile) File() *os.File {
+	return tf.f
+}
+
+func (tf *testTempFile) Name() string {
+	return tf.f.Name()
+}
+
+func (tf *testTempFile) CloseAndRemove() {
+	tf.f.Close()
+	os.Remove(tf.Name())
+}
+
+func TestExit(t *testing.T) {
+	format := "Exiting: %s"
+	param := "Oopsies!"
+	message := fmt.Sprintf(format, param)
+	code := 42
+	e := exitf(code, format, param)
+	assert.Error(t, e)
+	assert.Equal(t, message, e.message)
+	assert.Equal(t, message, e.Error())
+	assert.Equal(t, 42, e.code)
+}
 
 func TestOSFileSystem(t *testing.T) {
 	fs := &osFileSystem{root: "."}
@@ -26,4 +78,211 @@ func TestFSFileStream(t *testing.T) {
 	s, err := newFSFileStream("sysl.go", fs)
 	assert.NoError(t, err)
 	assert.Equal(t, "package main", s.GetText(0, 11))
+}
+
+var testModule = &sysl.Module{
+	Apps: map[string]*sysl.Application{
+		"Test": &sysl.Application{
+			Name: &sysl.AppName{
+				Part: []string{"Test"},
+			},
+			Endpoints: map[string]*sysl.Endpoint{
+				"GetInfo": &sysl.Endpoint{
+					Name: "GetInfo",
+					Stmt: []*sysl.Statement{
+						{
+							Stmt: &sysl.Statement_Action{
+								Action: &sysl.Action{
+									Action: "Do something",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	},
+}
+
+var testModuleJSONPB = `{
+ "apps": {
+  "Test": {
+   "name": {
+    "part": [
+     "Test"
+    ]
+   },
+   "endpoints": {
+    "GetInfo": {
+     "name": "GetInfo",
+     "stmt": [
+      {
+       "action": {
+        "action": "Do something"
+       }
+      }
+     ]
+    }
+   }
+  }
+ }
+}`
+
+var testModuleTextPB = `apps: <
+  key: "Test"
+  value: <
+    name: <
+      part: "Test"
+    >
+    endpoints: <
+      key: "GetInfo"
+      value: <
+        name: "GetInfo"
+        stmt: <
+          action: <
+            action: "Do something"
+          >
+        >
+      >
+    >
+  >
+>
+`
+
+func TestJSONPB(t *testing.T) {
+	if filename := testTempFilename(t, "", "github.com-sysl-sysl2-sysl-sysl_test.go-TestJSONPB-*.json"); filename != "" {
+		JSONPB(testModule, filename)
+		output, err := ioutil.ReadFile(filename)
+		require.NoError(t, err)
+		assert.Equal(t, testModuleJSONPB, string(output))
+	}
+}
+
+func TestJSONPBNilModule(t *testing.T) {
+	if tf := newTestTempFile(t, "", "github.com-sysl-sysl2-sysl-sysl_test.go-TestJSONPB-*.json"); tf != nil {
+		filename := tf.Name()
+		tf.CloseAndRemove()
+		err := JSONPB(nil, filename)
+		_, err = os.Stat(filename)
+		assert.True(t, os.IsNotExist(err))
+	}
+}
+
+func TestFJSONPB(t *testing.T) {
+	var output bytes.Buffer
+	FJSONPB(&output, testModule)
+	assert.Equal(t, testModuleJSONPB, output.String())
+}
+
+func TestFJSONPBNilModule(t *testing.T) {
+	var output bytes.Buffer
+	err := FJSONPB(&output, nil)
+	assert.Error(t, err)
+	assert.Equal(t, "", output.String())
+}
+
+func TestTextPB(t *testing.T) {
+	if filename := testTempFilename(t, "", "github.com-sysl-sysl2-sysl-sysl_test.go-TestJSONPB-*.json"); filename != "" {
+		TextPB(testModule, filename)
+		output, err := ioutil.ReadFile(filename)
+		require.NoError(t, err)
+		assert.Equal(t, testModuleTextPB, string(output))
+	}
+}
+
+func TestTextPBNilModule(t *testing.T) {
+	if tf := newTestTempFile(t, "", "github.com-sysl-sysl2-sysl-sysl_test.go-TestTextPBNilModule-*.textpb"); tf != nil {
+		filename := tf.Name()
+		tf.CloseAndRemove()
+		err := TextPB(nil, filename)
+		assert.Error(t, err)
+		_, err = os.Stat(filename)
+		assert.True(t, os.IsNotExist(err))
+	}
+}
+
+func TestFTextPB(t *testing.T) {
+	var output bytes.Buffer
+	FTextPB(&output, testModule)
+	assert.Equal(t, testModuleTextPB, output.String())
+}
+
+func TestFTextPBNilModule(t *testing.T) {
+	var output bytes.Buffer
+	err := FTextPB(&output, nil)
+	assert.Error(t, err)
+	assert.Equal(t, "", output.String())
+}
+
+func testMain2(t *testing.T, args []string, golden string) {
+	if output := testTempFilename(t, "", "github.com-sysl-sysl2-sysl-sysl_test.go-TestTextPBNilModule-*.textpb"); output != "" {
+		var stdout, stderr bytes.Buffer
+		rc := main2(&stdout, &stderr, append([]string{"sysl", "-o", output}, args...), main3)
+		if !assert.Zero(t, rc) {
+			t.Error(stderr.String())
+		}
+		assert.True(t, stdout.Len() == 0)
+
+		actual, err := ioutil.ReadFile(output)
+		require.NoError(t, err)
+
+		expected, err := ioutil.ReadFile(golden)
+		require.NoError(t, err)
+
+		assert.Equal(t, string(expected), string(actual))
+	}
+}
+
+func TestMain2TextPB(t *testing.T) {
+	testMain2(t, []string{"tests/args.sysl"}, "tests/args.sysl.golden.textpb")
+}
+
+func TestMain2JSON(t *testing.T) {
+	testMain2(t, []string{"-mode", "json", "tests/args.sysl"}, "tests/args.sysl.golden.json")
+}
+
+func testMain2Stdout(t *testing.T, args []string, golden string) {
+	var stdout, stderr bytes.Buffer
+	rc := main2(&stdout, &stderr, append([]string{"sysl", "-o", "-"}, args...), main3)
+	if !assert.Zero(t, rc) {
+		t.Error(stderr.String())
+	}
+
+	expected, err := ioutil.ReadFile(golden)
+	require.NoError(t, err)
+
+	assert.Equal(t, string(expected), stdout.String())
+
+	_, err = os.Stat("-")
+	assert.True(t, os.IsNotExist(err), "Should not have created file '-'")
+}
+
+func TestMain2TextPBStdout(t *testing.T) {
+	testMain2Stdout(t, []string{"tests/args.sysl"}, "tests/args.sysl.golden.textpb")
+}
+
+func TestMain2JSONStdout(t *testing.T) {
+	testMain2Stdout(t, []string{"-mode", "json", "tests/args.sysl"}, "tests/args.sysl.golden.json")
+}
+
+func TestMain2BadMode(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	rc := main2(&stdout, &stderr, []string{"sysl", "-o", "-", "-mode", "BAD", "tests/args.sysl"}, main3)
+	assert.NotZero(t, rc)
+
+	_, err := os.Stat("-")
+	assert.True(t, os.IsNotExist(err), "Should not have created file '-'")
+}
+
+func TestMain2Fatal(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	assert.Equal(t, 1, main2(&stdout, &stderr, nil, func(_, _ io.Writer, _ []string) error {
+		return fmt.Errorf("Generic error")
+	}))
+	assert.Equal(t, "Generic error\n", stderr.String())
+	stderr.Reset()
+	assert.Equal(t, 42, main2(&stdout, &stderr, nil, func(_, _ io.Writer, _ []string) error {
+		return exitf(42, "Exit error")
+	}))
+	assert.Equal(t, "Exit error\n", stderr.String())
 }

--- a/sysl2/sysl/tests/args.sysl.golden.json
+++ b/sysl2/sysl/tests/args.sysl.golden.json
@@ -1,0 +1,228 @@
+{
+ "apps": {
+  "Client": {
+   "name": {
+    "part": [
+     "Client"
+    ]
+   },
+   "endpoints": {
+    "OnClick": {
+     "name": "OnClick",
+     "param": [
+      {
+       "name": "arg1",
+       "type": {
+        "typeRef": {
+         "ref": {
+          "appname": {
+           "part": [
+            "type1"
+           ]
+          }
+         }
+        }
+       }
+      },
+      {
+       "name": "arg2",
+       "type": {
+        "typeRef": {
+         "ref": {
+          "appname": {
+           "part": [
+            "type2"
+           ]
+          }
+         }
+        }
+       }
+      }
+     ],
+     "stmt": [
+      {
+       "call": {
+        "target": {
+         "part": [
+          "Server"
+         ]
+        },
+        "endpoint": "Endpoint",
+        "arg": [
+         {
+          "name": "id"
+         }
+        ]
+       },
+       "attrs": {
+        "patterns": {
+         "a": {
+          "elt": [
+           {
+            "s": "https"
+           },
+           {
+            "s": "soap"
+           }
+          ]
+         }
+        }
+       }
+      },
+      {
+       "call": {
+        "target": {
+         "part": [
+          "Server"
+         ]
+        },
+        "endpoint": "PUT /foo/"
+       }
+      },
+      {
+       "call": {
+        "target": {
+         "part": [
+          "Server"
+         ]
+        },
+        "endpoint": "PUT /foo",
+        "arg": [
+         {
+          "name": "bar"
+         }
+        ]
+       }
+      },
+      {
+       "call": {
+        "target": {
+         "part": [
+          "Server"
+         ]
+        },
+        "endpoint": "PUT /foo",
+        "arg": [
+         {
+          "name": "bar \u003c: String"
+         }
+        ]
+       }
+      }
+     ],
+     "sourceContext": {
+      "file": "tests/args.sysl",
+      "start": {
+       "line": 12,
+       "col": 4
+      }
+     }
+    }
+   },
+   "sourceContext": {
+    "file": "tests/args.sysl",
+    "start": {
+     "line": 11,
+     "col": 1
+    }
+   }
+  },
+  "Server": {
+   "name": {
+    "part": [
+     "Server"
+    ]
+   },
+   "endpoints": {
+    "Endpoint": {
+     "name": "Endpoint",
+     "stmt": [
+      {
+       "action": {
+        "action": "..."
+       }
+      }
+     ],
+     "sourceContext": {
+      "file": "tests/args.sysl",
+      "start": {
+       "line": 2,
+       "col": 4
+      }
+     }
+    },
+    "PUT /foo": {
+     "name": "PUT /foo",
+     "attrs": {
+      "patterns": {
+       "a": {
+        "elt": [
+         {
+          "s": "rest"
+         }
+        ]
+       }
+      }
+     },
+     "stmt": [
+      {
+       "action": {
+        "action": "..."
+       }
+      }
+     ],
+     "restParams": {
+      "method": "PUT",
+      "path": "/foo"
+     },
+     "sourceContext": {
+      "file": "tests/args.sysl",
+      "start": {
+       "line": 6,
+       "col": 8
+      }
+     }
+    },
+    "PUT /foo/": {
+     "name": "PUT /foo/",
+     "attrs": {
+      "patterns": {
+       "a": {
+        "elt": [
+         {
+          "s": "rest"
+         }
+        ]
+       }
+      }
+     },
+     "stmt": [
+      {
+       "action": {
+        "action": "..."
+       }
+      }
+     ],
+     "restParams": {
+      "method": "PUT",
+      "path": "/foo/"
+     },
+     "sourceContext": {
+      "file": "tests/args.sysl",
+      "start": {
+       "line": 9,
+       "col": 12
+      }
+     }
+    }
+   },
+   "sourceContext": {
+    "file": "tests/args.sysl",
+    "start": {
+     "line": 1,
+     "col": 1
+    }
+   }
+  }
+ }
+}

--- a/sysl2/sysl/tests/args.sysl.golden.textpb
+++ b/sysl2/sysl/tests/args.sysl.golden.textpb
@@ -1,0 +1,203 @@
+apps: <
+  key: "Client"
+  value: <
+    name: <
+      part: "Client"
+    >
+    endpoints: <
+      key: "OnClick"
+      value: <
+        name: "OnClick"
+        param: <
+          name: "arg1"
+          type: <
+            type_ref: <
+              ref: <
+                appname: <
+                  part: "type1"
+                >
+              >
+            >
+          >
+        >
+        param: <
+          name: "arg2"
+          type: <
+            type_ref: <
+              ref: <
+                appname: <
+                  part: "type2"
+                >
+              >
+            >
+          >
+        >
+        stmt: <
+          call: <
+            target: <
+              part: "Server"
+            >
+            endpoint: "Endpoint"
+            arg: <
+              name: "id"
+            >
+          >
+          attrs: <
+            key: "patterns"
+            value: <
+              a: <
+                elt: <
+                  s: "https"
+                >
+                elt: <
+                  s: "soap"
+                >
+              >
+            >
+          >
+        >
+        stmt: <
+          call: <
+            target: <
+              part: "Server"
+            >
+            endpoint: "PUT /foo/"
+          >
+        >
+        stmt: <
+          call: <
+            target: <
+              part: "Server"
+            >
+            endpoint: "PUT /foo"
+            arg: <
+              name: "bar"
+            >
+          >
+        >
+        stmt: <
+          call: <
+            target: <
+              part: "Server"
+            >
+            endpoint: "PUT /foo"
+            arg: <
+              name: "bar <: String"
+            >
+          >
+        >
+        source_context: <
+          file: "tests/args.sysl"
+          start: <
+            line: 12
+            col: 4
+          >
+        >
+      >
+    >
+    source_context: <
+      file: "tests/args.sysl"
+      start: <
+        line: 11
+        col: 1
+      >
+    >
+  >
+>
+apps: <
+  key: "Server"
+  value: <
+    name: <
+      part: "Server"
+    >
+    endpoints: <
+      key: "Endpoint"
+      value: <
+        name: "Endpoint"
+        stmt: <
+          action: <
+            action: "..."
+          >
+        >
+        source_context: <
+          file: "tests/args.sysl"
+          start: <
+            line: 2
+            col: 4
+          >
+        >
+      >
+    >
+    endpoints: <
+      key: "PUT /foo"
+      value: <
+        name: "PUT /foo"
+        attrs: <
+          key: "patterns"
+          value: <
+            a: <
+              elt: <
+                s: "rest"
+              >
+            >
+          >
+        >
+        stmt: <
+          action: <
+            action: "..."
+          >
+        >
+        rest_params: <
+          method: PUT
+          path: "/foo"
+        >
+        source_context: <
+          file: "tests/args.sysl"
+          start: <
+            line: 6
+            col: 8
+          >
+        >
+      >
+    >
+    endpoints: <
+      key: "PUT /foo/"
+      value: <
+        name: "PUT /foo/"
+        attrs: <
+          key: "patterns"
+          value: <
+            a: <
+              elt: <
+                s: "rest"
+              >
+            >
+          >
+        >
+        stmt: <
+          action: <
+            action: "..."
+          >
+        >
+        rest_params: <
+          method: PUT
+          path: "/foo/"
+        >
+        source_context: <
+          file: "tests/args.sysl"
+          start: <
+            line: 9
+            col: 12
+          >
+        >
+      >
+    >
+    source_context: <
+      file: "tests/args.sysl"
+      start: <
+        line: 1
+        col: 1
+      >
+    >
+  >
+>


### PR DESCRIPTION
Changes proposed in this pull request:
- Replace direct os calls in `sysl.Parse` with `http.FileSystem` parameter.
- Split main into three functions to improve support for testing.

@anz-bank/sysl-developers
