### PR TITLE
🎨 Cleaner parser tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,6 @@ build
 .eggs
 .gradle
 .antlr
-*.pb
 /tmp
 /docs/website/public
 .sysl-tmp

--- a/sysl2/sysl/.gitignore
+++ b/sysl2/sysl/.gitignore
@@ -1,2 +1,0 @@
-/generated.txt
-/golden.txt

--- a/sysl2/sysl/Parser_test.go
+++ b/sysl2/sysl/Parser_test.go
@@ -131,14 +131,19 @@ func parseAndCompareWithPython(filename, root string) (bool, error) {
 		return false, err
 	}
 	defer golden.Close()
-	defer os.Remove(golden.Name())
 
 	pyModule, err := pyParse(filename, root, golden.Name())
 	if err != nil {
+		fmt.Printf("%#v retained for checking", golden.Name())
 		return false, err
 	}
 
-	return parseAndCompare(filename, root, golden.Name(), pyModule)
+	equal, err := parseAndCompare(filename, root, golden.Name(), pyModule)
+	if err != nil {
+		fmt.Printf("%#v retained for checking", golden.Name())
+	}
+	os.Remove(golden.Name())
+	return equal, err
 }
 
 func parseAndCompareWithGolden(filename, root string) (bool, error) {

--- a/sysl2/sysl/Parser_test.go
+++ b/sysl2/sysl/Parser_test.go
@@ -31,12 +31,12 @@ func readSyslModule(filename string) (*sysl.Module, error) {
 	return module, nil
 }
 
-func pySysl() string {
-	if pySysl, found := os.LookupEnv("SYSL_PYTHON_BIN"); found {
+var pySysl = func() string {
+	if pySysl, ok := os.LookupEnv("SYSL_PYTHON_BIN"); ok {
 		return pySysl
 	}
 	return "sysl"
-}
+}()
 
 func pyParse(filename, root, output string) (*sysl.Module, error) {
 	args := []string{"textpb", "-o", output, filename}
@@ -46,11 +46,11 @@ func pyParse(filename, root, output string) (*sysl.Module, error) {
 		args = append(rootArg, args...)
 	}
 
-	cmd := exec.Command(pySysl(), args...)
+	cmd := exec.Command(pySysl, args...)
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	if err := cmd.Run(); err != nil {
-		return nil, fmt.Errorf("Error running %#v %#v: %s", pySysl(), args, err)
+		return nil, fmt.Errorf("Error running %#v %#v: %s", pySysl, args, err)
 	}
 
 	return readSyslModule(output)
@@ -124,7 +124,7 @@ func parseAndCompare(filename, root, golden string, goldenModule *sysl.Module) (
 }
 
 func parseAndCompareWithPython(filename, root string) (bool, error) {
-	fmt.Printf("%35s <=> $(%s %[1]s)\n", filename, pySysl())
+	fmt.Printf("%35s <=> $(%s %[1]s)\n", filename, pySysl)
 
 	golden, err := ioutil.TempFile("", "sysl-test-golden-*.textpb")
 	if err != nil {

--- a/sysl2/sysl/Parser_test.go
+++ b/sysl2/sysl/Parser_test.go
@@ -42,7 +42,6 @@ func pyParse(filename, root, output string) (*sysl.Module, error) {
 	args := []string{"textpb", "-o", output, filename}
 	if len(root) > 0 {
 		rootArg := []string{"--root", root}
-		output = args[2]
 		args = append(rootArg, args...)
 	}
 

--- a/sysl2/sysl/Parser_test.go
+++ b/sysl2/sysl/Parser_test.go
@@ -52,7 +52,7 @@ func pyParse(filename, root, output string) (*sysl.Module, error) {
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	if err := cmd.Run(); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("Error running %#v %#v: %s", pySysl(), args, err)
 	}
 
 	return readSyslModule(output)

--- a/sysl2/sysl/Parser_test.go
+++ b/sysl2/sysl/Parser_test.go
@@ -42,8 +42,6 @@ func pyParse(filename, root, output string) (*sysl.Module, error) {
 	args := []string{"textpb", "-o", output, filename}
 	if len(root) > 0 {
 		rootArg := []string{"--root", root}
-		// TODO: This looks dubious
-		args[2] = root + "/" + args[2]
 		output = args[2]
 		args = append(rootArg, args...)
 	}

--- a/sysl2/sysl/Parser_test.go
+++ b/sysl2/sysl/Parser_test.go
@@ -156,8 +156,14 @@ func parseAndPrint(t *testing.T, filename, root string) error {
 	return nil
 }
 
-func testParse(t *testing.T, filename, root string) {
+func testParseAgainstPython(t *testing.T, filename, root string) {
 	equal, err := parseAndCompareWithPython(filename, root)
+	assert.NoError(t, err)
+	assert.True(t, equal, "Mismatch")
+}
+
+func testParseAgainstGolden(t *testing.T, filename, root string) {
+	equal, err := parseAndCompareWithGolden(filename, root)
 	assert.NoError(t, err)
 	assert.True(t, equal, "Mismatch")
 }
@@ -173,102 +179,102 @@ func TestParseBadFile(t *testing.T) {
 }
 
 func TestSimpleEP(t *testing.T) {
-	testParse(t, "tests/test1.sysl", "")
+	testParseAgainstPython(t, "tests/test1.sysl", "")
 }
 
 func TestAttribs(t *testing.T) {
-	testParse(t, "tests/attribs.sysl", "")
+	testParseAgainstPython(t, "tests/attribs.sysl", "")
 }
 
 func TestIfElse(t *testing.T) {
-	testParse(t, "tests/if_else.sysl", "")
+	testParseAgainstPython(t, "tests/if_else.sysl", "")
 }
 
 func TestArgs(t *testing.T) {
-	testParse(t, "tests/args.sysl", "")
+	testParseAgainstPython(t, "tests/args.sysl", "")
 }
 
 func TestSimpleEPWithSpaces(t *testing.T) {
-	testParse(t, "tests/with_spaces.sysl", "")
+	testParseAgainstPython(t, "tests/with_spaces.sysl", "")
 }
 
 func TestSimpleEP2(t *testing.T) {
-	testParse(t, "tests/test4.sysl", "")
+	testParseAgainstPython(t, "tests/test4.sysl", "")
 }
 
 func TestSimpleEndpointParams(t *testing.T) {
-	testParse(t, "tests/ep_params.sysl", "")
+	testParseAgainstPython(t, "tests/ep_params.sysl", "")
 }
 
 func TestOneOfStatements(t *testing.T) {
-	testParse(t, "tests/oneof.sysl", "")
+	testParseAgainstPython(t, "tests/oneof.sysl", "")
 }
 
 func TestDuplicateEndpoints(t *testing.T) {
-	testParse(t, "tests/duplicate.sysl", "")
+	testParseAgainstPython(t, "tests/duplicate.sysl", "")
 }
 
 func TestEventing(t *testing.T) {
-	testParse(t, "tests/eventing.sysl", "")
+	testParseAgainstPython(t, "tests/eventing.sysl", "")
 }
 
 func TestCollector(t *testing.T) {
-	testParse(t, "tests/collector.sysl", "")
+	testParseAgainstPython(t, "tests/collector.sysl", "")
 }
 
 func TestPubSubCollector(t *testing.T) {
-	testParse(t, "tests/pubsub_collector.sysl", "")
+	testParseAgainstPython(t, "tests/pubsub_collector.sysl", "")
 }
 
 func TestDocstrings(t *testing.T) {
-	testParse(t, "tests/docstrings.sysl", "")
+	testParseAgainstPython(t, "tests/docstrings.sysl", "")
 }
 
 func TestMixins(t *testing.T) {
-	testParse(t, "tests/mixin.sysl", "")
+	testParseAgainstPython(t, "tests/mixin.sysl", "")
 }
 func TestForLoops(t *testing.T) {
-	testParse(t, "tests/for_loop.sysl", "")
+	testParseAgainstPython(t, "tests/for_loop.sysl", "")
 }
 
 func TestGroupStmt(t *testing.T) {
-	testParse(t, "tests/group_stmt.sysl", "")
+	testParseAgainstPython(t, "tests/group_stmt.sysl", "")
 }
 
 func TestUntilLoop(t *testing.T) {
-	testParse(t, "tests/until_loop.sysl", "")
+	testParseAgainstPython(t, "tests/until_loop.sysl", "")
 }
 
 func TestTuple(t *testing.T) {
-	testParse(t, "tests/test2.sysl", "")
+	testParseAgainstPython(t, "tests/test2.sysl", "")
 }
 
 func TestInplaceTuple(t *testing.T) {
-	testParse(t, "tests/inplace_tuple.sysl", "")
+	testParseAgainstPython(t, "tests/inplace_tuple.sysl", "")
 }
 
 func TestRelational(t *testing.T) {
-	testParse(t, "tests/school.sysl", "")
+	testParseAgainstPython(t, "tests/school.sysl", "")
 }
 
 func TestImports(t *testing.T) {
-	testParse(t, "tests/library.sysl", "")
+	testParseAgainstPython(t, "tests/library.sysl", "")
 }
 
 func TestRootArg(t *testing.T) {
-	testParse(t, "school.sysl", "tests")
+	testParseAgainstPython(t, "school.sysl", "tests")
 }
 
 func TestRestApi(t *testing.T) {
-	testParse(t, "tests/test_rest_api.sysl", "")
+	testParseAgainstPython(t, "tests/test_rest_api.sysl", "")
 }
 
 func TestRestApiQueryParams(t *testing.T) {
-	testParse(t, "tests/rest_api_query_params.sysl", "")
+	testParseAgainstPython(t, "tests/rest_api_query_params.sysl", "")
 }
 
 func TestSimpleProject(t *testing.T) {
-	testParse(t, "tests/project.sysl", "")
+	testParseAgainstPython(t, "tests/project.sysl", "")
 }
 
 func TestUrlParamOrder(t *testing.T) {
@@ -278,53 +284,53 @@ func TestUrlParamOrder(t *testing.T) {
 }
 
 func TestUrlParamOrderAgainstGolden(t *testing.T) {
-	parseAndCompareWithGolden("tests/rest_url_params.sysl", "")
+	testParseAgainstGolden(t, "tests/rest_url_params.sysl", "")
 }
 
 func TestRestApi_WrongOrder(t *testing.T) {
-	testParse(t, "tests/bad_order.sysl", "")
+	testParseAgainstPython(t, "tests/bad_order.sysl", "")
 }
 
 func TestTransform(t *testing.T) {
-	testParse(t, "tests/transform.sysl", "")
+	testParseAgainstPython(t, "tests/transform.sysl", "")
 }
 
 func TestImpliedDot(t *testing.T) {
-	testParse(t, "tests/implied.sysl", "")
+	testParseAgainstPython(t, "tests/implied.sysl", "")
 }
 
 func TestStmts(t *testing.T) {
-	testParse(t, "tests/stmts.sysl", "")
+	testParseAgainstPython(t, "tests/stmts.sysl", "")
 }
 
 func TestMath(t *testing.T) {
-	testParse(t, "tests/math.sysl", "")
+	testParseAgainstPython(t, "tests/math.sysl", "")
 }
 
 func TestTableof(t *testing.T) {
-	testParse(t, "tests/tableof.sysl", "")
+	testParseAgainstPython(t, "tests/tableof.sysl", "")
 }
 
 func TestRank(t *testing.T) {
-	testParse(t, "tests/rank.sysl", "")
+	testParseAgainstPython(t, "tests/rank.sysl", "")
 }
 
 func TestMatching(t *testing.T) {
-	testParse(t, "tests/matching.sysl", "")
+	testParseAgainstPython(t, "tests/matching.sysl", "")
 }
 
 func TestNavigate(t *testing.T) {
-	testParse(t, "tests/navigate.sysl", "")
+	testParseAgainstPython(t, "tests/navigate.sysl", "")
 }
 
 func TestFuncs(t *testing.T) {
-	testParse(t, "tests/funcs.sysl", "")
+	testParseAgainstPython(t, "tests/funcs.sysl", "")
 }
 
 func TestPetshop(t *testing.T) {
-	testParse(t, "petshop.sysl", "../../demo/petshop")
+	testParseAgainstPython(t, "petshop.sysl", "../../demo/petshop")
 }
 
 func TestCrash(t *testing.T) {
-	testParse(t, "tests/crash.sysl", "")
+	testParseAgainstPython(t, "tests/crash.sysl", "")
 }

--- a/sysl2/sysl/sysl.go
+++ b/sysl2/sysl/sysl.go
@@ -72,6 +72,7 @@ func TextPB(m *sysl.Module, filename string) error {
 	if err != nil {
 		return err
 	}
+	defer f.Close()
 	return FTextPB(f, m)
 }
 
@@ -585,7 +586,6 @@ func FSParse(filename string, fs http.FileSystem) (*sysl.Module, error) {
 	errorListener := SyslParserErrorListener{}
 
 	for {
-		fmt.Println(filename)
 		input, err := newFSFileStream(filename, fs)
 		if err != nil {
 			return nil, exitf(ImportError, fmt.Sprintf("error parsing %#v: %v\n", filename, err))

--- a/sysl2/sysl/tests/rest_url_params.sysl.golden.textpb
+++ b/sysl2/sysl/tests/rest_url_params.sysl.golden.textpb
@@ -1,0 +1,93 @@
+apps: <
+    key: "Server"
+    value: <
+        name: <
+            part: "Server"
+        >
+        endpoints: <
+            key: "GET /{id1}/{id2}/{aid3}/{id4}/{bid5}"
+            value: <
+                name: "GET /{id1}/{id2}/{aid3}/{id4}/{bid5}"
+                attrs: <
+                    key: "patterns"
+                    value: <
+                        a: <
+                            elt: <
+                                s: "rest"
+                            >
+                        >
+                    >
+                >
+                stmt: <
+                    action: <
+                        action: "..."
+                    >
+                >
+                rest_params: <
+                    method: GET
+                    path: "/{id1}/{id2}/{aid3}/{id4}/{bid5}"
+                    query_param: <
+                        name: "id1"
+                        type: <
+                            primitive: INT
+                            source_context: <
+                                start: <
+                                    line: 7
+                                >
+                            >
+                        >
+                        loc: true
+                    >
+                    query_param: <
+                        name: "id2"
+                        type: <
+                            primitive: INT
+                            source_context: <
+                                start: <
+                                    line: 7
+                                >
+                            >
+                        >
+                        loc: true
+                    >
+                    query_param: <
+                        name: "aid3"
+                        type: <
+                            primitive: INT
+                            source_context: <
+                                start: <
+                                    line: 7
+                                >
+                            >
+                        >
+                        loc: true
+                    >
+                    query_param: <
+                        name: "id4"
+                        type: <
+                            primitive: INT
+                            source_context: <
+                                start: <
+                                    line: 7
+                                >
+                            >
+                        >
+                        loc: true
+                    >
+                    query_param: <
+                        name: "bid5"
+                        type: <
+                            primitive: INT
+                            source_context: <
+                                start: <
+                                    line: 7
+                                >
+                            >
+                        >
+                        loc: true
+                    >
+                >
+            >
+        >
+    >
+>


### PR DESCRIPTION
Changes proposed in this pull request:
- Use computed temp filenames instead of g{olden,enerated}.txt.
- Enable golden-output regression tests.

Builds on yet-to-be-merged #168. Only commits after 979fc8c are specific to this PR.

@anz-bank/sysl-developers
