### PR TITLE
Go AST

### DIFF
--- a/sysl2/codegen/golang/ast_bootstrap.go
+++ b/sysl2/codegen/golang/ast_bootstrap.go
@@ -1,0 +1,574 @@
+package golang
+
+import "fmt"
+
+// // SliceOfString represents a slice of a file and its 0-based start position.
+// type SliceOfString struct {
+// 	Text string
+// 	Pos  int
+// }
+
+// Token ...
+type Token struct {
+	Kind string
+	// Text SliceOfString
+	Text string
+}
+
+// ArrayType ...
+type ArrayType struct {
+	Lbrack Token // "["
+	Len    Expr  // Ellipsis node for [...]T array types, nil for slice types
+	Elt    Expr  // element type
+}
+
+// AssignStmt ...
+type AssignStmt struct {
+	LHS []Expr
+	Tok Token
+	RHS []Expr
+}
+
+// BadDecl ...
+type BadDecl struct {
+	Token Token
+}
+
+// BadExpr ...
+type BadExpr struct {
+	Token Token
+}
+
+// BadStmt ...
+type BadStmt struct {
+	Token Token
+}
+
+// BasicLit ...
+type BasicLit struct {
+	Token Token
+}
+
+// BinaryExpr ...
+type BinaryExpr struct {
+	X  Expr
+	Op Token
+	Y  Expr
+}
+
+// BlockStmt ...
+type BlockStmt struct {
+	Lbrace Token // "{"
+	List   []Stmt
+	Rbrace Token // "}"
+}
+
+// BranchStmt ...
+type BranchStmt struct {
+	Tok   Token  // keyword token (BREAK, CONTINUE, GOTO, FALLTHROUGH)
+	Label *Ident // label name; or nil
+}
+
+// CallExpr ...
+type CallExpr struct {
+	Fun      Expr   // function expression
+	Lparen   Token  // "("
+	Args     []Expr // function arguments; or nil
+	Ellipsis Token  // "..." (token.NoPos if there is no "...")
+	Rparen   Token  // ")"
+}
+
+// CaseClause ...
+type CaseClause struct {
+	Case  Token  // "case" or "default" keyword
+	List  []Expr // list of expressions or types; nil means default case
+	Colon Token
+	Body  []Stmt // statement list; or nil
+}
+
+// ChanType ...
+type ChanType struct {
+	Begin Token // "chan" keyword or "<-" (whichever comes first)
+	Arrow Token // "<-" (token.NoPos if there is no "<-"); added in Go 1.1
+	// Dir         {|"SEND", "RECV"|} powerset without {||}
+	Dir   string
+	Value Expr // value type
+}
+
+// CommClause ...
+type CommClause struct {
+	Case  Token  // "case" or "default" keyword
+	Comm  Stmt   // send or receive statement; nil means default case
+	Colon Token  // ":"
+	Body  []Stmt // statement list; or nil
+}
+
+// Comment ...
+type Comment struct {
+	Token Token
+}
+
+// CommentGroup ...
+type CommentGroup struct {
+	List []Comment // len(List) > 0
+}
+
+// CompositeLit ...
+type CompositeLit struct {
+	Type       Expr   // literal type; or nil
+	Lbrace     Token  // "{"
+	Elts       []Expr // list of composite elements; or nil
+	Rbrace     Token  // "}"
+	Incomplete bool   // true if (source) expressions are missing in the Elts list; added in Go 1.11
+}
+
+// DeclStmt ...
+type DeclStmt struct {
+	Decl Decl // GenDecl with CONST, TYPE, or VAR token
+}
+
+// DeferStmt ...
+type DeferStmt struct {
+	Defer Token // "defer" keyword
+	Call  CallExpr
+}
+
+// Ellipsis ...
+type Ellipsis struct {
+	Ellipsis Token // "..."
+	Elt      Expr  // ellipsis element type (parameter lists only); or nil
+}
+
+// EmptyStmt ...
+type EmptyStmt struct {
+	Semicolon Token // following ";"
+	Implicit  bool  // if set, ";" was omitted in the source; added in Go 1.5
+}
+
+// ExprStmt ...
+type ExprStmt struct {
+	X Expr // expression
+}
+
+// Field ...
+type Field struct {
+	Doc     *CommentGroup // associated documentation; or nil
+	Names   []Ident       // field/method/parameter names; or nil
+	Type    Expr          // field/method/parameter type
+	Tag     *BasicLit     // field tag; or nil
+	Comment *CommentGroup // line comments; or nil
+}
+
+// FieldList ...
+type FieldList struct {
+	Opening Token   // opening parenthesis/brace, if any
+	List    []Field // field list; or nil
+	Closing Token   // closing parenthesis/brace, if any
+}
+
+// File ...
+type File struct {
+	Doc        *CommentGroup  // associated documentation; or nil
+	Package    Token          // "package" keyword
+	Name       Ident          // package name
+	Decls      []Decl         // top-level declarations; or nil
+	Imports    []ImportSpec   // imports in this file
+	Unresolved []Ident        // unresolved identifiers in this file
+	Comments   []CommentGroup // list of all comments in the source file
+}
+
+// ForStmt ...
+type ForStmt struct {
+	For  Token // "for" keyword
+	Init Stmt  // initialization statement; or nil
+	Cond Expr  // condition; or nil
+	Post Stmt  // post iteration statement; or nil
+	Body BlockStmt
+}
+
+// FuncDecl ...
+type FuncDecl struct {
+	Doc  *CommentGroup // associated documentation; or nil
+	Recv *FieldList    // receiver (methods); or nil (functions)
+	Name Ident         // function/method name
+	Type FuncType      // function signature: parameters, results, and "func" keyword
+	Body *BlockStmt    // function body; or nil for external (non-Go) function
+}
+
+// FuncLit ...
+type FuncLit struct {
+	Type FuncType  // function type
+	Body BlockStmt // function body
+}
+
+// FuncType ...
+type FuncType struct {
+	Func    Token      // "func" keyword (token.NoPos if there is no "func")
+	Params  FieldList  // (incoming) parameters; non-nil
+	Results *FieldList // (outgoing) results; or nil
+}
+
+// GenDecl ...
+type GenDecl struct {
+	Doc    *CommentGroup // associated documentation; or nil
+	Tok    Token         // IMPORT, CONST, TYPE, VAR
+	Lparen Token         // '(', if any
+	Specs  []Spec
+	Rparen Token // ')', if any
+}
+
+// GoStmt ...
+type GoStmt struct {
+	Go   Token // "go" keyword
+	Call CallExpr
+}
+
+// Ident ...
+type Ident struct {
+	Name Token // identifier name
+}
+
+// IfStmt ...
+type IfStmt struct {
+	If   Token // "if" keyword
+	Init Stmt  // initialization statement; or nil
+	Cond Expr  // condition
+	Body BlockStmt
+	Else Stmt // else branch; or nil
+}
+
+// ImportSpec ...
+type ImportSpec struct {
+	Doc     *CommentGroup // associated documentation; or nil
+	Name    *Ident        // local package name (including "."); or nil
+	Path    BasicLit      // import path
+	Comment *CommentGroup // line comments; or nil
+	EndPos  Token         // end of spec (overrides Path.Pos if nonzero)
+}
+
+// IncDecStmt ...
+type IncDecStmt struct {
+	X   Expr
+	Tok Token
+}
+
+// IndexExpr ...
+type IndexExpr struct {
+	X      Expr
+	Lbrack Token // "["
+	Index  Expr
+	Rbrack Token // "]"
+}
+
+// InterfaceType ...
+type InterfaceType struct {
+	Interface  Token     // "interface" keyword
+	Methods    FieldList // list of methods
+	Incomplete bool      // true if (source) methods are missing in the Methods list
+}
+
+// KeyValueExpr ...
+type KeyValueExpr struct {
+	Key   Expr
+	Colon Token
+	Value Expr
+}
+
+// LabeledStmt ...
+type LabeledStmt struct {
+	Label Ident
+	Colon Token
+	Stmt  Stmt
+}
+
+// MapType ...
+type MapType struct {
+	Map   Token // "map" keyword
+	Key   Expr
+	Value Expr
+}
+
+// ParenExpr ...
+type ParenExpr struct {
+	Lparen Token // "("
+	X      Expr  // parenthesized expression
+	Rparen Token // ")"
+}
+
+// RangeStmt ...
+type RangeStmt struct {
+	For   Token // "for" keyword
+	Key   Expr  // Key may be nil
+	Value Expr  // Value may be nil
+	Tok   Token // invalid if Key == nil
+	X     Expr  // value to range over
+	Body  BlockStmt
+}
+
+// ReturnStmt ...
+type ReturnStmt struct {
+	Return  Token  // "return" keyword
+	Results []Expr // result expressions; or nil
+}
+
+// SelectStmt ...
+type SelectStmt struct {
+	Select Token     // "select" keyword
+	Body   BlockStmt // CommClauses only
+}
+
+// SelectorExpr ...
+type SelectorExpr struct {
+	X   Expr  // expression
+	Sel Ident // field selector
+}
+
+// SendStmt ...
+type SendStmt struct {
+	Chan  Expr
+	Arrow Token // "<-"
+	Value Expr
+}
+
+// SliceExpr ...
+type SliceExpr struct {
+	X      Expr  // expression
+	Lbrack Token // "["
+	Low    Expr  // begin of slice range; or nil
+	High   Expr  // end of slice range; or nil
+	Max    Expr  // maximum capacity of slice; or nil; added in Go 1.2
+	Slice3 bool  // true if 3-index slice (2 colons present); added in Go 1.2
+	Rbrack Token // "]"
+}
+
+// StarExpr ...
+type StarExpr struct {
+	Star Token // "*"
+	X    Expr  // operand
+}
+
+// StructType ...
+type StructType struct {
+	Struct     Token     // "struct" keyword
+	Fields     FieldList // list of field declarations
+	Incomplete bool      // true if (source) fields are missing in the Fields list
+}
+
+// SwitchStmt ...
+type SwitchStmt struct {
+	Switch Token     // "switch" keyword
+	Init   Stmt      // initialization statement; or nil
+	Tag    Expr      // tag expression; or nil
+	Body   BlockStmt // CaseClauses only
+}
+
+// TypeAssertExpr ...
+type TypeAssertExpr struct {
+	X      Expr  // expression
+	Lparen Token // "("; added in Go 1.2
+	Type   Expr  // asserted type; nil means type switch X.(type)
+	Rparen Token // ")"; added in Go 1.2
+}
+
+// TypeSpec ...
+type TypeSpec struct {
+	Doc     *CommentGroup // associated documentation; or nil
+	Name    Ident         // type name
+	Assign  Token         // '=', if any; added in Go 1.9
+	Type    Expr          // Ident, ParenExpr, SelectorExpr, StarExpr, or any of the XxxTypes
+	Comment *CommentGroup // line comments; or nil
+}
+
+// TypeSwitchStmt ...
+type TypeSwitchStmt struct {
+	Switch Token     // "switch" keyword
+	Init   Stmt      // initialization statement; or nil
+	Assign Stmt      // x := y.(type) or y.(type)
+	Body   BlockStmt // CaseClauses only
+}
+
+// UnaryExpr ...
+type UnaryExpr struct {
+	Op Token
+	X  Expr
+}
+
+// ValueSpec ...
+type ValueSpec struct {
+	Doc     *CommentGroup // associated documentation; or nil
+	Names   []Ident       // value names (len(Names) > 0)
+	Type    Expr          // value type; or nil
+	Values  []Expr        // initial values; or nil
+	Comment *CommentGroup // line comments; or nil
+}
+
+// Expr ...
+type Expr interface {
+	fmt.Formatter
+	GoIsExpr()
+}
+
+// GoIsExpr ...
+func (*BadExpr) GoIsExpr() {}
+
+// GoIsExpr ...
+func (*Ident) GoIsExpr() {}
+
+// GoIsExpr ...
+func (*Ellipsis) GoIsExpr() {}
+
+// GoIsExpr ...
+func (*BasicLit) GoIsExpr() {}
+
+// GoIsExpr ...
+func (*FuncLit) GoIsExpr() {}
+
+// GoIsExpr ...
+func (*CompositeLit) GoIsExpr() {}
+
+// GoIsExpr ...
+func (*ParenExpr) GoIsExpr() {}
+
+// GoIsExpr ...
+func (*SelectorExpr) GoIsExpr() {}
+
+// GoIsExpr ...
+func (*IndexExpr) GoIsExpr() {}
+
+// GoIsExpr ...
+func (*SliceExpr) GoIsExpr() {}
+
+// GoIsExpr ...
+func (*TypeAssertExpr) GoIsExpr() {}
+
+// GoIsExpr ...
+func (*CallExpr) GoIsExpr() {}
+
+// GoIsExpr ...
+func (*StarExpr) GoIsExpr() {}
+
+// GoIsExpr ...
+func (*UnaryExpr) GoIsExpr() {}
+
+// GoIsExpr ...
+func (*BinaryExpr) GoIsExpr() {}
+
+// GoIsExpr ...
+func (*KeyValueExpr) GoIsExpr() {}
+
+// GoIsExpr ...
+func (*ArrayType) GoIsExpr() {}
+
+// GoIsExpr ...
+func (*StructType) GoIsExpr() {}
+
+// GoIsExpr ...
+func (*FuncType) GoIsExpr() {}
+
+// GoIsExpr ...
+func (*InterfaceType) GoIsExpr() {}
+
+// GoIsExpr ...
+func (*MapType) GoIsExpr() {}
+
+// GoIsExpr ...
+func (*ChanType) GoIsExpr() {}
+
+// Stmt ...
+type Stmt interface {
+	fmt.Formatter
+	GoIsStmt()
+}
+
+// GoIsStmt ...
+func (*AssignStmt) GoIsStmt() {}
+
+// GoIsStmt ...
+func (*BadStmt) GoIsStmt() {}
+
+// GoIsStmt ...
+func (*BlockStmt) GoIsStmt() {}
+
+// GoIsStmt ...
+func (*BranchStmt) GoIsStmt() {}
+
+// GoIsStmt ...
+func (*CaseClause) GoIsStmt() {}
+
+// GoIsStmt ...
+func (*CommClause) GoIsStmt() {}
+
+// GoIsStmt ...
+func (*DeclStmt) GoIsStmt() {}
+
+// GoIsStmt ...
+func (*DeferStmt) GoIsStmt() {}
+
+// GoIsStmt ...
+func (*EmptyStmt) GoIsStmt() {}
+
+// GoIsStmt ...
+func (*ExprStmt) GoIsStmt() {}
+
+// GoIsStmt ...
+func (*ForStmt) GoIsStmt() {}
+
+// GoIsStmt ...
+func (*GoStmt) GoIsStmt() {}
+
+// GoIsStmt ...
+func (*IfStmt) GoIsStmt() {}
+
+// GoIsStmt ...
+func (*IncDecStmt) GoIsStmt() {}
+
+// GoIsStmt ...
+func (*LabeledStmt) GoIsStmt() {}
+
+// GoIsStmt ...
+func (*RangeStmt) GoIsStmt() {}
+
+// GoIsStmt ...
+func (*ReturnStmt) GoIsStmt() {}
+
+// GoIsStmt ...
+func (*SelectStmt) GoIsStmt() {}
+
+// GoIsStmt ...
+func (*SendStmt) GoIsStmt() {}
+
+// GoIsStmt ...
+func (*SwitchStmt) GoIsStmt() {}
+
+// GoIsStmt ...
+func (*TypeSwitchStmt) GoIsStmt() {}
+
+// Decl ...
+type Decl interface {
+	fmt.Formatter
+	GoIsDecl()
+}
+
+// GoIsDecl ...
+func (*BadDecl) GoIsDecl() {}
+
+// GoIsDecl ...
+func (*FuncDecl) GoIsDecl() {}
+
+// GoIsDecl ...
+func (*GenDecl) GoIsDecl() {}
+
+// Spec ...
+type Spec interface {
+	fmt.Formatter
+	GoIsSpec()
+}
+
+// GoIsSpec ...
+func (*ImportSpec) GoIsSpec() {}
+
+// GoIsSpec ...
+func (*TypeSpec) GoIsSpec() {}
+
+// GoIsSpec ...
+func (*ValueSpec) GoIsSpec() {}

--- a/sysl2/codegen/golang/ast_helpers.go
+++ b/sysl2/codegen/golang/ast_helpers.go
@@ -1,0 +1,378 @@
+package golang
+
+import (
+	"fmt"
+	"regexp"
+)
+
+var idRE = regexp.MustCompile("^[\\pL_][\\pL_\\pN]*$")
+
+// ArrayN creates a `[n]elt` ArrayType.
+func ArrayN(n int, elt Expr) *ArrayType {
+	return &ArrayType{Len: Int(n), Elt: elt}
+}
+
+// ArrayEllipsis creates a `[...]elt` ArrayType.
+func ArrayEllipsis(elt Expr) *ArrayType {
+	return &ArrayType{Len: &Ellipsis{}, Elt: elt}
+}
+
+// Assert creates a TypeAssertExpr.
+func Assert(x, t Expr) *TypeAssertExpr {
+	return &TypeAssertExpr{X: x, Type: t}
+}
+
+// AssertType creates a TypeAssertExpr.
+func AssertType(x Expr) *TypeAssertExpr {
+	return &TypeAssertExpr{X: x}
+}
+
+// Assign creates an = AssignStmt.
+func Assign(lhs []Expr, rhs ...Expr) *AssignStmt {
+	if len(rhs) == 0 {
+		panic("Missing rhs")
+	}
+	return &AssignStmt{LHS: lhs, Tok: *T("="), RHS: rhs}
+}
+
+// Binary creates a BinaryExpr.
+func Binary(x Expr, op string, y Expr) *BinaryExpr {
+	return &BinaryExpr{X: x, Op: *T(op), Y: y}
+}
+
+// Block creates a BlockStmt.
+func Block(stmt ...Stmt) *BlockStmt {
+	return &BlockStmt{List: stmt}
+}
+
+// Break creates a `break` BranchStmt.
+func Break() *BranchStmt {
+	return &BranchStmt{Tok: *T("break")}
+}
+
+// BreakTo creates a `break label` BranchStmt.
+func BreakTo(label string) *BranchStmt {
+	return &BranchStmt{Tok: *T("break"), Label: I(label)}
+}
+
+// Call creates a CallStmt.
+func Call(fun Expr, args ...Expr) *CallExpr {
+	return &CallExpr{Fun: fun, Args: args}
+}
+
+// CallVararg creates an `arg...` CallStmt.
+func CallVararg(fun Expr, args ...Expr) *CallExpr {
+	return &CallExpr{Fun: fun, Args: args, Ellipsis: *T("...")}
+}
+
+// Case creates a `case x, y, z:` CaseClause.
+func Case(list []Expr, stmts ...Stmt) *CaseClause {
+	return &CaseClause{List: list, Body: stmts}
+}
+
+// Const creates a `const` GenDecl.
+func Const(values ...ValueSpec) *GenDecl {
+	specs := make([]Spec, 0, len(values))
+	for _, spec := range values {
+		c := spec
+		specs = append(specs, &c)
+	}
+	return &GenDecl{Tok: *T("const"), Specs: specs}
+}
+
+// Continue creates a `continue` BranchStmt.
+func Continue() *BranchStmt {
+	return &BranchStmt{Tok: *T("continue")}
+}
+
+// ContinueTo creates a `continue label` BranchStmt.
+func ContinueTo(label string) *BranchStmt {
+	return &BranchStmt{Tok: *T("continue"), Label: I(label)}
+}
+
+// Composite creates a CompositeLit.
+func Composite(t Expr, elts ...Expr) *CompositeLit {
+	return &CompositeLit{Type: t, Elts: elts}
+}
+
+// CopyChain copies an IfStmt and, recursively, n.Else if it is an IfStmt.
+// Returns the copy and the last node in the chain.
+func (n *IfStmt) CopyChain() (head, last *IfStmt) {
+	if n == nil {
+		return n, n
+	}
+	c := *n
+	head, last = &c, &c
+	for i, ok := last.Else.(*IfStmt); ok; i, ok = last.Else.(*IfStmt) {
+		last.Else, last = i.CopyChain()
+	}
+	return head, last
+}
+
+// DefaultCase creates a `default:` CaseClause.
+func DefaultCase(stmts ...Stmt) *CaseClause {
+	return &CaseClause{Body: stmts}
+}
+
+// DefaultComm creates a `default:` CommClause.
+func DefaultComm(stmts ...Stmt) *CommClause {
+	return &CommClause{Body: stmts}
+}
+
+// Defer creates a DeferStmt.
+func Defer(fun Expr, args ...Expr) *DeferStmt {
+	return &DeferStmt{Call: *Call(fun, args...)}
+}
+
+// DeferVararg creates an `arg...` DeferStmt.
+func DeferVararg(fun Expr, args ...Expr) *DeferStmt {
+	return &DeferStmt{Call: *CallVararg(fun, args...)}
+}
+
+// Dec creates an `x--` IncDecStmt.
+func Dec(x Expr) *IncDecStmt {
+	return &IncDecStmt{X: x, Tok: *T("--")}
+}
+
+// Dot creates a SelectorExpr.
+func Dot(x Expr, id string) *SelectorExpr {
+	return &SelectorExpr{X: x, Sel: *I(id)}
+}
+
+// Fallthrough creates a `fallthrough` BranchStmt.
+func Fallthrough() *BranchStmt {
+	return &BranchStmt{Tok: *T("fallthrough")}
+}
+
+// Float creates a BasicLit for a float64.
+func Float(v float64) *BasicLit {
+	return &BasicLit{Token{Text: fmt.Sprintf("%#v", v)}}
+}
+
+// Func creates a FuncLit.
+func Func(params FieldList, results *FieldList, stmts ...Stmt) *FuncLit {
+	return &FuncLit{
+		Type: FuncType{Params: params, Results: results},
+		Body: BlockStmt{List: stmts},
+	}
+}
+
+// Goto creates a `goto label` BranchStmt.
+func Goto(label string) *BranchStmt {
+	return &BranchStmt{Tok: *T("goto"), Label: I(label)}
+}
+
+// I creates an Ident.
+func I(id string) *Ident {
+	if !idRE.MatchString(id) {
+		panic(fmt.Sprintf("Not a valid ident: %#v", id))
+	}
+	return &Ident{Token{Text: id}}
+}
+
+// Idents creates an []Ident from ids.
+func Idents(ids ...string) []Ident {
+	idents := make([]Ident, 0, len(ids))
+	for _, id := range ids {
+		idents = append(idents, Ident{Token{Text: id}})
+	}
+	return idents
+}
+
+// If creates an IfStmt.
+func If(init Stmt, cond Expr, stmts ...Stmt) *IfStmt {
+	return &IfStmt{Init: init, Cond: cond, Body: *Block(stmts...)}
+}
+
+// WithElseIf creates a copy of IfStmt with an Else stmt added.
+func (n *IfStmt) WithElseIf(init Stmt, cond Expr, stmts ...Stmt) *IfStmt {
+	head, last := n.CopyChain()
+	if last.Else != nil {
+		panic("Cannot chain else to else-tail")
+	}
+	last.Else = &IfStmt{Init: init, Cond: cond, Body: *Block(stmts...)}
+	return head
+}
+
+// WithElse creates a copy of IfStmt with an Else stmt added.
+func (n *IfStmt) WithElse(stmts ...Stmt) *IfStmt {
+	head, last := n.CopyChain()
+	if last.Else != nil {
+		panic("Cannot chain else to else-tail")
+	}
+	last.Else = Block(stmts...)
+	return head
+}
+
+// Import creates an `import` GenDecl.
+func Import(imports ...ImportSpec) *GenDecl {
+	specs := make([]Spec, 0, len(imports))
+	for _, spec := range imports {
+		c := spec
+		specs = append(specs, &c)
+	}
+	return &GenDecl{Tok: *T("import"), Specs: specs}
+}
+
+// Inc creates an `x++` IncDecStmt.
+func Inc(x Expr) *IncDecStmt {
+	return &IncDecStmt{X: x, Tok: *T("++")}
+}
+
+// Index creates an IndexExpr.
+func Index(a, b Expr) *IndexExpr {
+	return &IndexExpr{X: a, Index: b}
+}
+
+// Init creates an := AssignStmt.
+func Init(idents []string, rhs ...Expr) *AssignStmt {
+	lhs := make([]Expr, 0, len(idents))
+	for _, ident := range idents {
+		lhs = append(lhs, I(ident))
+	}
+	return &AssignStmt{LHS: lhs, Tok: *T(":="), RHS: rhs}
+}
+
+// Int creates a BasicLit for an int.
+func Int(v int) *BasicLit {
+	return &BasicLit{Token{Text: fmt.Sprintf("%#v", v)}}
+}
+
+// KV creates a KeyValueExpr
+func KV(key, value Expr) *KeyValueExpr {
+	return &KeyValueExpr{Key: key, Value: value}
+}
+
+// Map creates a MapType.
+func Map(key, value Expr) *MapType {
+	return &MapType{Key: key, Value: value}
+}
+
+// Nil creates a `nil` Ident.
+func Nil() *Ident {
+	return I("nil")
+}
+
+// ParenFields creates a ()-delimited FieldList.
+func ParenFields(fields ...Field) *FieldList {
+	return &FieldList{
+		Opening: *T("("),
+		List:    fields,
+		Closing: *T(")"),
+	}
+}
+
+// Range creates a RangeStmt.
+func Range(key, value Expr, tok string, x Expr, body ...Stmt) *RangeStmt {
+	return &RangeStmt{Key: key, Value: value, Tok: *T(tok), X: x, Body: *Block(body...)}
+}
+
+// Recv creates a `<-ch` UnaryExpr.
+func Recv(ch Expr) *UnaryExpr {
+	return Unary("<-", ch)
+}
+
+// RecvAssignComm creates a `case x, y = <-ch:` CommClause.
+func RecvAssignComm(lhs []Expr, ch Expr, stmts ...Stmt) *CommClause {
+	return &CommClause{Comm: Assign(lhs, Recv(ch)), Body: stmts}
+}
+
+// RecvInitComm creates a `case x, y := <-ch:` CommClause.
+func RecvInitComm(lhs []string, ch Expr, stmts ...Stmt) *CommClause {
+	return &CommClause{Comm: Init(lhs, Recv(ch)), Body: stmts}
+}
+
+// Return creates a ReturnStmt.
+func Return(results ...Expr) *ReturnStmt {
+	return &ReturnStmt{Results: results}
+}
+
+// Select creates a SelectStmt.
+func Select(body ...Stmt) *SelectStmt {
+	return &SelectStmt{Body: *Block(body...)}
+}
+
+// Send creates a SendStmt.
+func Send(ch, value Expr) *SendStmt {
+	return &SendStmt{Chan: ch, Value: value}
+}
+
+// SendComm creates a `case ch <- value:` CommClause.
+func SendComm(ch, value Expr, stmts ...Stmt) *CommClause {
+	return &CommClause{Comm: Send(ch, value), Body: stmts}
+}
+
+// SliceType creates a `[]elt` ArrayType.
+func SliceType(elt Expr) *ArrayType {
+	return &ArrayType{Elt: elt}
+}
+
+// Slice creates a SliceExpr.
+func Slice(x Expr, args ...Expr) *SliceExpr {
+	if len(args) > 3 {
+		panic("Too many slice args")
+	}
+	args = append(args, nil, nil, nil)[:3]
+	return &SliceExpr{X: x, Low: args[0], High: args[1], Max: args[2]}
+}
+
+// Star creates a StarExpr.
+func Star(x Expr) *StarExpr {
+	return &StarExpr{X: x}
+}
+
+// String creates a BasicLit for a string.
+func String(v string) *BasicLit {
+	return &BasicLit{Token{Text: fmt.Sprintf("%#v", v)}}
+}
+
+// Struct creates a StructType.
+func Struct(fields ...Field) *StructType {
+	return &StructType{Fields: FieldList{List: fields}}
+}
+
+// Switch creates a SwitchStmt.
+func Switch(init Expr, body ...Stmt) *SwitchStmt {
+	return &SwitchStmt{Body: *Block(body...)}
+}
+
+// T creates a Token.
+func T(text string) *Token {
+	return &Token{Text: text}
+}
+
+// Types creates a `type` GenDecl.
+func Types(types ...TypeSpec) *GenDecl {
+	specs := make([]Spec, 0, len(types))
+	for _, spec := range types {
+		c := spec
+		specs = append(specs, &c)
+	}
+	return &GenDecl{Tok: *T("type"), Specs: specs}
+}
+
+// TypeSwitch creates a TypeSwitchStmt.
+func TypeSwitch(init Stmt, x string, y Expr, body ...Stmt) *TypeSwitchStmt {
+	var assign Stmt
+	if x != "" {
+		assign = Init([]string{x}, AssertType(y))
+	} else {
+		assign = &ExprStmt{AssertType(y)}
+	}
+	return &TypeSwitchStmt{Init: init, Assign: assign, Body: *Block(body...)}
+}
+
+// Unary creates a UnaryExpr.
+func Unary(op string, x Expr) *UnaryExpr {
+	return &UnaryExpr{Op: *T(op), X: x}
+}
+
+// Var creates a `var` GenDecl.
+func Var(values ...ValueSpec) *GenDecl {
+	specs := make([]Spec, 0, len(values))
+	for _, spec := range values {
+		c := spec
+		specs = append(specs, &c)
+	}
+	return &GenDecl{Tok: *T("var"), Specs: specs}
+}

--- a/sysl2/codegen/golang/ast_to_source.go
+++ b/sysl2/codegen/golang/ast_to_source.go
@@ -1,0 +1,670 @@
+package golang
+
+import (
+	"bytes"
+	"fmt"
+	"go/format"
+	"io"
+	"strings"
+)
+
+type genFormatter struct {
+	I interface{}
+}
+
+func (f genFormatter) Format(s fmt.State, c rune) {
+	fmt.Fprintf(s, "%"+string(c), f.I)
+}
+
+// Format formats a node as a snippet of Go source code.
+func Format(node fmt.Formatter) []byte {
+	var buf bytes.Buffer
+	fmt.Fprintf(&buf, "%s", node)
+	formatted, err := format.Source(buf.Bytes())
+	if err != nil {
+		panic(err)
+	}
+	return formatted
+}
+
+// fixupFormat replaces `"%c"` with `"%"+c`, but skips `/(?<!%)(%%)+c/`.
+func fixupFormat(format string, c rune) string {
+	var b strings.Builder
+	b.Grow(len(format))
+	percent := false
+	for _, r := range format {
+		if percent {
+			percent = false
+			if r == 'c' {
+				b.WriteRune(c)
+				continue
+			}
+		} else {
+			percent = r == '%'
+		}
+		b.WriteRune(r)
+	}
+	return b.String()
+}
+
+func scPrintf(w io.Writer, c rune, format string, args ...fmt.Formatter) {
+	args2 := make([]interface{}, 0, len(args))
+	for _, arg := range args {
+		args2 = append(args2, arg)
+	}
+	fmt.Fprintf(w, fixupFormat(format, c), args2...)
+}
+
+func cSprintf(c rune, format string, args ...fmt.Formatter) string {
+	var b strings.Builder
+	scPrintf(&b, c, format, args...)
+	return b.String()
+}
+
+func separator(w io.Writer, i int, sep string) {
+	if i > 0 {
+		w.Write([]byte(sep))
+	}
+}
+
+func sepFormat(s fmt.State, c rune, i int, f fmt.Formatter, sep string) {
+	separator(s, i, sep)
+	if f != nil {
+		f.Format(s, c)
+	}
+}
+
+func emptyNil(n interface{}) fmt.Formatter {
+	if n != nil {
+		return genFormatter{n}
+	}
+	return genFormatter{""}
+}
+
+// Format formats a Token as a snippet of Go source code.
+func (n *Token) Format(s fmt.State, c rune) {
+	if n == nil {
+		return
+	}
+	scPrintf(s, c, "%c", genFormatter{n.Text})
+}
+
+// Format formats an ArrayType as a snippet of Go source code.
+func (n *ArrayType) Format(s fmt.State, c rune) {
+	if n == nil {
+		return
+	}
+	scPrintf(s, c, "[%c]%c", emptyNil(n.Len), n.Elt)
+}
+
+// Format formats an AssignStmt as a snippet of Go source code.
+func (n *AssignStmt) Format(s fmt.State, c rune) {
+	if n == nil {
+		return
+	}
+	for i, expr := range n.LHS {
+		sepFormat(s, c, i, expr, ", ")
+	}
+	n.Tok.Format(s, c)
+	for i, expr := range n.RHS {
+		sepFormat(s, c, i, expr, ", ")
+	}
+}
+
+// Format formats a BadDecl as a snippet of Go source code.
+func (n *BadDecl) Format(s fmt.State, c rune) {
+	if n == nil {
+		return
+	}
+	panic("BadDecl.Format Not implemented")
+}
+
+// Format formats a BadExpr as a snippet of Go source code.
+func (n *BadExpr) Format(s fmt.State, c rune) {
+	if n == nil {
+		return
+	}
+	panic("BadExpr.Format Not implemented")
+}
+
+// Format formats a BadStmt as a snippet of Go source code.
+func (n *BadStmt) Format(s fmt.State, c rune) {
+	if n == nil {
+		return
+	}
+	panic("BadStmt.Format Not implemented")
+}
+
+// Format formats a BasicLit as a snippet of Go source code.
+func (n *BasicLit) Format(s fmt.State, c rune) {
+	if n == nil {
+		return
+	}
+	n.Token.Format(s, c)
+}
+
+// Format formats a BinaryExpr as a snippet of Go source code.
+func (n *BinaryExpr) Format(s fmt.State, c rune) {
+	if n == nil {
+		return
+	}
+	scPrintf(s, c, "(%c %c %c)", n.X, &n.Op, n.Y)
+}
+
+// Format formats a BlockStmt as a snippet of Go source code.
+func (n *BlockStmt) Format(s fmt.State, c rune) {
+	if n == nil {
+		return
+	}
+	fmt.Fprint(s, "{")
+	for _, stmt := range n.List {
+		scPrintf(s, c, "\n%c", stmt)
+	}
+	fmt.Fprint(s, "}")
+}
+
+// Format formats a BranchStmt as a snippet of Go source code.
+func (n *BranchStmt) Format(s fmt.State, c rune) {
+	if n == nil {
+		return
+	}
+	scPrintf(s, c, "%c %c", &n.Tok, n.Label)
+}
+
+// Format formats a CallExpr as a snippet of Go source code.
+func (n *CallExpr) Format(s fmt.State, c rune) {
+	if n == nil {
+		return
+	}
+	scPrintf(s, c, "%c(", n.Fun)
+	for i, expr := range n.Args {
+		sepFormat(s, c, i, expr, ", ")
+	}
+	scPrintf(s, c, "%c)", &n.Ellipsis)
+}
+
+// Format formats a CaseClause as a snippet of Go source code.
+func (n *CaseClause) Format(s fmt.State, c rune) {
+	if n == nil {
+		return
+	}
+	if len(n.List) == 0 {
+		fmt.Fprint(s, "default:")
+	} else {
+		fmt.Fprint(s, "case ")
+		for i, expr := range n.List {
+			sepFormat(s, c, i, expr, ", ")
+		}
+		fmt.Fprint(s, ":")
+	}
+	for _, stmt := range n.Body {
+		scPrintf(s, c, "\n%c", stmt)
+	}
+}
+
+// Format formats a ChanType as a snippet of Go source code.
+func (n *ChanType) Format(s fmt.State, c rune) {
+	if n == nil {
+		return
+	}
+	switch n.Dir {
+	case "":
+		scPrintf(s, c, "chan %c", n.Value)
+	case "SEND":
+		scPrintf(s, c, "chan<- %c", n.Value)
+	case "RECV":
+		scPrintf(s, c, "<-chan %c", n.Value)
+	default:
+		panic(fmt.Sprintf("Unknown channel type %#v", n.Dir))
+	}
+}
+
+// Format formats a CommClause as a snippet of Go source code.
+func (n *CommClause) Format(s fmt.State, c rune) {
+	if n == nil {
+		return
+	}
+	if n.Comm == nil {
+		fmt.Fprint(s, "default:")
+	} else {
+		scPrintf(s, c, "case %c:", n.Comm)
+	}
+	for _, stmt := range n.Body {
+		scPrintf(s, c, "\n%c", stmt)
+	}
+}
+
+// Format formats a Comment as a snippet of Go source code.
+func (n *Comment) Format(s fmt.State, c rune) {
+	if n == nil {
+		return
+	}
+	scPrintf(s, c, "%c\n", &n.Token)
+}
+
+// Format formats a CommentGroup as a snippet of Go source code.
+func (n *CommentGroup) Format(s fmt.State, c rune) {
+	if n == nil {
+		return
+	}
+	for _, comment := range n.List {
+		scPrintf(s, c, "%c", &comment)
+	}
+}
+
+// Format formats a CompositeLit as a snippet of Go source code.
+func (n *CompositeLit) Format(s fmt.State, c rune) {
+	if n == nil {
+		return
+	}
+	scPrintf(s, c, "%c{", emptyNil(n.Type))
+	for i, expr := range n.Elts {
+		sepFormat(s, c, i, expr, ", ")
+	}
+	fmt.Fprint(s, "}")
+}
+
+// Format formats a DeclStmt as a snippet of Go source code.
+func (n *DeclStmt) Format(s fmt.State, c rune) {
+	if n == nil {
+		return
+	}
+	n.Decl.Format(s, c)
+}
+
+// Format formats a DeferStmt as a snippet of Go source code.
+func (n *DeferStmt) Format(s fmt.State, c rune) {
+	if n == nil {
+		return
+	}
+	scPrintf(s, c, "defer %c", &n.Call)
+}
+
+// Format formats an Ellipsis as a snippet of Go source code.
+func (n *Ellipsis) Format(s fmt.State, c rune) {
+	if n == nil {
+		return
+	}
+	scPrintf(s, c, "...%c", emptyNil(n.Elt))
+}
+
+// Format formats an EmptyStmt as a snippet of Go source code.
+func (n *EmptyStmt) Format(s fmt.State, c rune) {
+	if n == nil {
+		return
+	}
+	fmt.Fprint(s, ";")
+}
+
+// Format formats an ExprStmt as a snippet of Go source code.
+func (n *ExprStmt) Format(s fmt.State, c rune) {
+	if n == nil {
+		return
+	}
+	n.X.Format(s, c)
+}
+
+// Format formats a Field as a snippet of Go source code.
+func (n *Field) Format(s fmt.State, c rune) {
+	if n == nil {
+		return
+	}
+	n.Doc.Format(s, c)
+	for i, name := range n.Names {
+		sepFormat(s, c, i, &name, ", ")
+	}
+	scPrintf(s, c, " %c %c", n.Type, n.Tag)
+}
+
+// Format formats a FieldList as a snippet of Go source code.
+func (n *FieldList) Format(s fmt.State, c rune) {
+	if n == nil {
+		return
+	}
+	n.Opening.Format(s, c)
+	for i, field := range n.List {
+		sepFormat(s, c, i, &field, ", ")
+	}
+	n.Closing.Format(s, c)
+}
+
+// NoCommaSepFieldList ...
+type NoCommaSepFieldList FieldList
+
+// Format ...
+func (n *NoCommaSepFieldList) Format(s fmt.State, c rune) {
+	if n == nil {
+		return
+	}
+	n.Opening.Format(s, c)
+	for _, field := range n.List {
+		scPrintf(s, c, "%c\n", &field)
+	}
+	n.Closing.Format(s, c)
+}
+
+// Format formats a File as a snippet of Go source code.
+func (n *File) Format(s fmt.State, c rune) {
+	if n == nil {
+		return
+	}
+	n.Doc.Format(s, c)
+	scPrintf(s, c, "package %s\n\nimport (\n", &n.Name)
+	for _, importSpec := range n.Imports {
+		scPrintf(s, c, "%c\n", &importSpec)
+	}
+	fmt.Fprint(s, ")\n\n")
+	for i, decl := range n.Decls {
+		sepFormat(s, c, i, decl, ", ")
+	}
+}
+
+// Format formats a ForStmt as a snippet of Go source code.
+func (n *ForStmt) Format(s fmt.State, c rune) {
+	if n == nil {
+		return
+	}
+	scPrintf(s, c, "for %c ; %c ; %c %c",
+		genFormatter{strings.TrimSpace(cSprintf(c, "%c", emptyNil(n.Init)))},
+		emptyNil(n.Cond),
+		genFormatter{strings.TrimSpace(cSprintf(c, "%c", emptyNil(n.Post)))},
+		&n.Body,
+	)
+}
+
+// Format formats a FuncDecl as a snippet of Go source code.
+func (n *FuncDecl) Format(s fmt.State, c rune) {
+	if n == nil {
+		return
+	}
+	scPrintf(s, c, "%cfunc %c %c %c %c", n.Doc, n.Recv, &n.Name, &n.Type, n.Body)
+}
+
+// Format formats a FuncLit as a snippet of Go source code.
+func (n *FuncLit) Format(s fmt.State, c rune) {
+	if n == nil {
+		return
+	}
+	scPrintf(s, c, "func %c %c", &n.Type, &n.Body)
+}
+
+// Format formats a FuncType as a snippet of Go source code.
+func (n *FuncType) Format(s fmt.State, c rune) {
+	if n == nil {
+		return
+	}
+	scPrintf(s, c, "%c %c", &n.Params, n.Results)
+}
+
+// Format formats a GenDecl as a snippet of Go source code.
+func (n *GenDecl) Format(s fmt.State, c rune) {
+	if n == nil {
+		return
+	}
+	if len(n.Specs) == 1 {
+		scPrintf(s, c, "%c%c %c", n.Doc, &n.Tok, n.Specs[0])
+	} else {
+		scPrintf(s, c, "%c%c (\n", n.Doc, &n.Tok)
+		for _, spec := range n.Specs {
+			scPrintf(s, c, "%c\n", spec)
+		}
+		fmt.Fprint(s, ")")
+	}
+}
+
+// Format formats a GoStmt as a snippet of Go source code.
+func (n *GoStmt) Format(s fmt.State, c rune) {
+	if n == nil {
+		return
+	}
+	scPrintf(s, c, "go %c", &n.Call)
+}
+
+// Format formats an Ident as a snippet of Go source code.
+func (n *Ident) Format(s fmt.State, c rune) {
+	if n == nil {
+		return
+	}
+	n.Name.Format(s, c)
+}
+
+// Format formats an IfStmt as a snippet of Go source code.
+func (n *IfStmt) Format(s fmt.State, c rune) {
+	if n == nil {
+		return
+	}
+	ifBlock := cSprintf(c, "if %c ; %c %c",
+		emptyNil(n.Init), emptyNil(n.Cond), &n.Body,
+	)
+	if n.Else == nil {
+		fmt.Fprint(s, ifBlock)
+	} else if _, ok := n.Else.(*BlockStmt); ok {
+		fmt.Fprint(s)
+		scPrintf(s, c, "%s else %c",
+			genFormatter{strings.TrimSpace(ifBlock)}, n.Else,
+		)
+	} else {
+		scPrintf(s, c, "%c else\n%c",
+			genFormatter{strings.TrimSpace(ifBlock)}, n.Else,
+		)
+	}
+}
+
+// Format formats an ImportSpec as a snippet of Go source code.
+func (n *ImportSpec) Format(s fmt.State, c rune) {
+	if n == nil {
+		return
+	}
+	scPrintf(s, c, "%c %c %c %c", n.Doc, n.Name, &n.Path, n.Comment)
+}
+
+// Format formats an IncDecStmt as a snippet of Go source code.
+func (n *IncDecStmt) Format(s fmt.State, c rune) {
+	if n == nil {
+		return
+	}
+	scPrintf(s, c, "%c%c", n.X, &n.Tok)
+}
+
+// Format formats an IndexExpr as a snippet of Go source code.
+func (n *IndexExpr) Format(s fmt.State, c rune) {
+	if n == nil {
+		return
+	}
+	scPrintf(s, c, "%c[%c]", n.X, n.Index)
+}
+
+// Format formats an InterfaceType as a snippet of Go source code.
+func (n *InterfaceType) Format(s fmt.State, c rune) {
+	if n == nil {
+		return
+	}
+	if len(n.Methods.List) == 0 {
+		scPrintf(s, c, "interface{}")
+	} else {
+		methods := NoCommaSepFieldList(n.Methods)
+		scPrintf(s, c, "interface {\n%c}\n", &methods)
+	}
+}
+
+// Format formats a KeyValueExpr as a snippet of Go source code.
+func (n *KeyValueExpr) Format(s fmt.State, c rune) {
+	if n == nil {
+		return
+	}
+	scPrintf(s, c, "%c: %c", n.Key, n.Value)
+}
+
+// Format formats a LabeledStmt as a snippet of Go source code.
+func (n *LabeledStmt) Format(s fmt.State, c rune) {
+	if n == nil {
+		return
+	}
+	scPrintf(s, c, "%c:\n%c", &n.Label, n.Stmt)
+}
+
+// Format formats a MapType as a snippet of Go source code.
+func (n *MapType) Format(s fmt.State, c rune) {
+	if n == nil {
+		return
+	}
+	scPrintf(s, c, "map[%c]%c", n.Key, n.Value)
+}
+
+// Format formats a ParenExpr as a snippet of Go source code.
+func (n *ParenExpr) Format(s fmt.State, c rune) {
+	if n == nil {
+		return
+	}
+	// All Exprs protect themselves with parens. Not required here.
+	n.X.Format(s, c)
+}
+
+// Format formats a RangeStmt as a snippet of Go source code.
+func (n *RangeStmt) Format(s fmt.State, c rune) {
+	if n == nil {
+		return
+	}
+	if n.Key == nil {
+		scPrintf(s, c, "for range %c %c", emptyNil(n.X), &n.Body)
+	} else if n.Value == nil {
+		scPrintf(s, c, "for %c %c range %c %c",
+			emptyNil(n.Key), &n.Tok, emptyNil(n.X), &n.Body,
+		)
+	} else {
+		scPrintf(s, c, "for %c, %c %c range %c %c",
+			emptyNil(n.Key), emptyNil(n.Value), &n.Tok, emptyNil(n.X), &n.Body,
+		)
+	}
+}
+
+// Format formats a ReturnStmt as a snippet of Go source code.
+func (n *ReturnStmt) Format(s fmt.State, c rune) {
+	if n == nil {
+		return
+	}
+	scPrintf(s, c, "return ")
+	for i, expr := range n.Results {
+		sepFormat(s, c, i, expr, ", ")
+	}
+}
+
+// Format formats a SelectStmt as a snippet of Go source code.
+func (n *SelectStmt) Format(s fmt.State, c rune) {
+	if n == nil {
+		return
+	}
+	scPrintf(s, c, "select %c", &n.Body)
+}
+
+// Format formats a SelectorExpr as a snippet of Go source code.
+func (n *SelectorExpr) Format(s fmt.State, c rune) {
+	if n == nil {
+		return
+	}
+	scPrintf(s, c, "%c.%c", n.X, &n.Sel)
+}
+
+// Format formats a SendStmt as a snippet of Go source code.
+func (n *SendStmt) Format(s fmt.State, c rune) {
+	if n == nil {
+		return
+	}
+	scPrintf(s, c, "%c <- %c", n.Chan, n.Value)
+}
+
+// Format formats a SliceExpr as a snippet of Go source code.
+func (n *SliceExpr) Format(s fmt.State, c rune) {
+	if n == nil {
+		return
+	}
+	scPrintf(s, c, "%c[%c:%c", n.X, emptyNil(n.Low), emptyNil(n.High))
+	if n.Max != nil {
+		scPrintf(s, c, ":%c", emptyNil(n.Max))
+	}
+	fmt.Fprint(s, "]")
+}
+
+// Format formats a StarExpr as a snippet of Go source code.
+func (n *StarExpr) Format(s fmt.State, c rune) {
+	if n == nil {
+		return
+	}
+	scPrintf(s, c, "*%c", n.X)
+}
+
+// Format formats a StructType as a snippet of Go source code.
+func (n *StructType) Format(s fmt.State, c rune) {
+	if n == nil {
+		return
+	}
+	if len(n.Fields.List) == 0 {
+		scPrintf(s, c, "struct{}")
+	} else {
+		f := NoCommaSepFieldList(n.Fields)
+		scPrintf(s, c, "struct{\n%c}", &f)
+	}
+}
+
+// Format formats a SwitchStmt as a snippet of Go source code.
+func (n *SwitchStmt) Format(s fmt.State, c rune) {
+	if n == nil {
+		return
+	}
+	scPrintf(s, c, "switch %c ; %c %c", emptyNil(n.Init), emptyNil(n.Tag), &n.Body)
+}
+
+// Format formats a TypeAssertExpr as a snippet of Go source code.
+func (n *TypeAssertExpr) Format(s fmt.State, c rune) {
+	if n == nil {
+		return
+	}
+	if n.Type == nil {
+		scPrintf(s, c, "%c.(type)", n.X)
+	} else {
+		scPrintf(s, c, "%c.(%c)", n.X, n.Type)
+	}
+}
+
+// Format formats a TypeSpec as a snippet of Go source code.
+func (n *TypeSpec) Format(s fmt.State, c rune) {
+	if n == nil {
+		return
+	}
+	scPrintf(s, c, "%c%c %c", n.Doc, &n.Name, emptyNil(n.Type))
+}
+
+// Format formats a TypeSwitchStmt as a snippet of Go source code.
+func (n *TypeSwitchStmt) Format(s fmt.State, c rune) {
+	if n == nil {
+		return
+	}
+	scPrintf(s, c, "switch %c ; %c %c",
+		genFormatter{strings.TrimSpace(cSprintf(c, "%c", emptyNil(n.Init)))},
+		genFormatter{strings.TrimSpace(cSprintf(c, "%c", n.Assign))},
+		&n.Body,
+	)
+}
+
+// Format formats an UnaryExpr as a snippet of Go source code.
+func (n *UnaryExpr) Format(s fmt.State, c rune) {
+	if n == nil {
+		return
+	}
+	scPrintf(s, c, "%c%c", &n.Op, n.X)
+}
+
+// Format formats a ValueSpec as a snippet of Go source code.
+func (n *ValueSpec) Format(s fmt.State, c rune) {
+	if n == nil {
+		return
+	}
+	n.Doc.Format(s, c)
+	for i, name := range n.Names {
+		sepFormat(s, c, i, &name, ", ")
+	}
+	scPrintf(s, c, " %c = ", emptyNil(n.Type))
+	for i, value := range n.Values {
+		sepFormat(s, c, i, value, ", ")
+	}
+}

--- a/sysl2/codegen/golang/ast_to_source_test.go
+++ b/sysl2/codegen/golang/ast_to_source_test.go
@@ -1,0 +1,1064 @@
+package golang
+
+import (
+	"fmt"
+	"go/format"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func testFormat(t *testing.T, n interface{}, expected string) {
+	expected = strings.TrimSpace(expected)
+	expected = strings.Replace(expected, "\n\t\t", "\n", -1)
+	actual := fmt.Sprintf("%s", n)
+	formatted, err := format.Source([]byte(actual))
+	if assert.NoError(t, err, "unformatted: %s", actual) {
+		trimmed := strings.TrimSpace(string(formatted))
+		assert.Equal(t, expected, trimmed, "unformatted: %s", actual)
+	}
+}
+
+func testFormatEmpty(t *testing.T, n interface{}) {
+	assert.Zero(t, fmt.Sprintf("%s", n))
+}
+
+func testFormatPanics(t *testing.T, n interface{}) {
+	actual := fmt.Sprintf("%s", n)
+	assert.True(t, strings.Contains(actual, "%!s(PANIC="), "%s", actual)
+}
+
+func testFormatInfix(t *testing.T, n interface{}, prefix, expected, suffix string) bool {
+	expected = strings.TrimSpace(expected)
+	expected = strings.Replace(expected, "\n\t\t", "\n", -1)
+	output := fmt.Sprintf("%s", n)
+	formatted, err := format.Source([]byte(output))
+	if !assert.NoError(t, err, "unformatted: %s", output) {
+		return false
+	}
+	actual := strings.TrimSpace(string(formatted))
+	if !assert.True(t, strings.HasPrefix(actual, prefix)) ||
+		!assert.True(t, strings.HasSuffix(actual, suffix)) {
+		t.Errorf("unformatted: %#v\nformatted: %#v", output, actual)
+		return false
+	}
+	return assert.Equal(t,
+		expected, strings.TrimSpace(actual[len(prefix):len(actual)-len(suffix)]),
+		"unformatted: %s", output)
+}
+
+func testFormatType(t *testing.T, typ Expr, expected string) {
+	testFormatInfix(t,
+		&GenDecl{
+			Tok:   *T("var"),
+			Specs: []Spec{&TypeSpec{Name: *I("_"), Type: typ}},
+		},
+		`var _ `, expected, ``,
+	)
+}
+
+func TestToken(t *testing.T) {
+	testFormatEmpty(t, (*Token)(nil))
+	testFormat(t, T("foo"), `foo`)
+}
+
+func TestArrayType(t *testing.T) {
+	testFormatEmpty(t, (*ArrayType)(nil))
+	testFormatType(t, SliceType(I("int")), `[]int`)
+	testFormatType(t, ArrayN(10, I("string")), `[10]string`)
+}
+
+func TestAssignStmt(t *testing.T) {
+	testFormatEmpty(t, (*AssignStmt)(nil))
+	testFormat(t, Assign([]Expr{I("x")}, Int(42)), `x = 42`)
+	testFormat(t, Init([]string{"x"}, Int(42)), `x := 42`)
+	testFormat(t,
+		Init([]string{"a", "b"}, Int(42), String("hello")),
+		`a, b := 42, "hello"`,
+	)
+}
+
+func TestBadDecl(t *testing.T) {
+	testFormatEmpty(t, (*BadDecl)(nil))
+	testFormatPanics(t, &BadDecl{})
+}
+
+func TestBadExpr(t *testing.T) {
+	testFormatEmpty(t, (*BadExpr)(nil))
+	testFormatPanics(t, &BadExpr{})
+}
+
+func TestBadStmt(t *testing.T) {
+	testFormatEmpty(t, (*BadStmt)(nil))
+	testFormatPanics(t, &BadStmt{})
+}
+
+func TestBasicLit(t *testing.T) {
+	testFormatEmpty(t, (*BasicLit)(nil))
+	testFormat(t, &BasicLit{*T("123.45")}, `123.45`)
+	testFormat(t, &BasicLit{*T(`"123.45"`)}, `"123.45"`)
+}
+
+func TestBinaryExpr(t *testing.T) {
+	testFormatEmpty(t, (*BinaryExpr)(nil))
+	// https://golang.org/ref/spec#Operator_precedence
+	for _, op := range []string{
+		"*", "/", "%", "<<", ">>", "&", "&^",
+		"+", "-", "*", "/",
+		"==", "!=", "<", "<=", ">", ">=",
+		"&&",
+		"||",
+	} {
+		testFormat(t, Binary(Int(1), op, Int(2)), fmt.Sprintf(`(1 %s 2)`, op))
+	}
+}
+
+func TestBlockStmt(t *testing.T) {
+	testFormatEmpty(t, (*BlockStmt)(nil))
+	testFormat(t,
+		&BlockStmt{},
+		`{
+		}`,
+	)
+	testFormat(t,
+		&BlockStmt{List: []Stmt{&ExprStmt{X: I("x")}}},
+		`{
+			x
+		}`,
+	)
+	testFormat(t,
+		&BlockStmt{
+			List: []Stmt{Init([]string{"x"}, Int(42)), Return(I("x"), Nil())},
+		},
+		`{
+			x := 42
+			return x, nil
+		}`,
+	)
+}
+
+func TestBranchStmt(t *testing.T) {
+	testFormatEmpty(t, (*BranchStmt)(nil))
+	testFormat(t, Break(), `break`)
+	testFormat(t, BreakTo("fast"), `break fast`)
+	testFormat(t, Continue(), `continue`)
+	testFormat(t, ContinueTo("dreaming"), `continue dreaming`)
+	testFormat(t, Goto("jail"), `goto jail`)
+	testFormat(t, Fallthrough(), `fallthrough`)
+}
+
+func TestCallExpr(t *testing.T) {
+	testFormatEmpty(t, (*CallExpr)(nil))
+	testFormat(t, &CallExpr{Fun: I("f")}, `f()`)
+	testFormat(t, Call(I("sin"), I("π")), `sin(π)`)
+	testFormat(t, Call(Dot(I("math"), "Atan2"), I("y"), I("x")), `math.Atan2(y, x)`)
+	testFormat(t,
+		CallVararg(Dot(I("fmt"), "Sprintf"), String("Hi %s and %s."), I("names")),
+		`fmt.Sprintf("Hi %s and %s.", names...)`,
+	)
+}
+
+func TestCaseClause(t *testing.T) {
+	testFormatEmpty(t, (*CaseClause)(nil))
+
+	testFormatCaseClause := func(n *CaseClause, expected string) {
+		testFormatInfix(t,
+			&SwitchStmt{Body: BlockStmt{List: []Stmt{n}}},
+			`switch {`, expected, `}`,
+		)
+	}
+
+	testFormatCaseClause(DefaultCase(), `default:`)
+	testFormatCaseClause(
+		DefaultCase(&BlockStmt{}),
+		`default:
+			{
+			}`,
+	)
+	testFormatCaseClause(
+		DefaultCase(Return(I("π"))),
+		`default:
+			return π`,
+	)
+	testFormatCaseClause(
+		Case([]Expr{Binary(I("π"), "<", Int(4))},
+			&ExprStmt{
+				X: Call(Dot(I("log"), "Info"), String("π seems about right!")),
+			},
+			Return(I("π")),
+		),
+		`case (π < 4):
+			log.Info("π seems about right!")
+			return π`,
+	)
+}
+
+func TestChanType(t *testing.T) {
+	testFormatEmpty(t, (*ChanType)(nil))
+	value := Struct()
+	testFormatType(t, &ChanType{Value: value, Dir: ""}, `chan struct{}`)
+	testFormatType(t, &ChanType{Value: value, Dir: "SEND"}, `chan<- struct{}`)
+	testFormatType(t, &ChanType{Value: value, Dir: "RECV"}, `<-chan struct{}`)
+	testFormatPanics(t, &ChanType{Value: value, Dir: "TRANSCEIVE"})
+}
+
+func TestCommClause(t *testing.T) {
+	testFormatEmpty(t, (*CommClause)(nil))
+
+	testFormatCommClause := func(n *CommClause, expected string) {
+		testFormatInfix(t,
+			&SelectStmt{Body: BlockStmt{List: []Stmt{n}}},
+			`select {`, expected, `}`,
+		)
+	}
+
+	testFormatCommClause(DefaultComm(), `default:`)
+	testFormatCommClause(
+		DefaultComm(&BlockStmt{}),
+		`default:
+			{
+			}`,
+	)
+	testFormatCommClause(
+		DefaultComm(Return(I("π"))),
+		`default:
+			return π`,
+	)
+
+	body := []Stmt{
+		&ExprStmt{X: Call(Dot(I("log"), "Info"), String("They need π!"))},
+		Return(I("π")),
+	}
+	bodySource := `
+			log.Info("They need π!")
+			return π`
+
+	testFormatCommClause(
+		SendComm(I("ch"), I("π"), body...),
+		`case ch <- π:`+bodySource)
+	testFormatCommClause(
+		RecvAssignComm([]Expr{I("x")}, I("ch"), body...),
+		`case x = <-ch:`+bodySource,
+	)
+	testFormatCommClause(
+		RecvInitComm([]string{"x"}, Call(I("ch")), body...),
+		`case x := <-ch():`+bodySource,
+	)
+}
+
+func TestComment(t *testing.T) {
+	testFormatEmpty(t, (*Comment)(nil))
+
+	testFormat(t, &Comment{*T("//")}, `//`)
+	testFormat(t, &Comment{*T("// Hmmmm")}, `// Hmmmm`)
+	testFormat(t, &Comment{*T("/* Hmmmm */")}, `/* Hmmmm */`)
+}
+
+func TestCommentGroup(t *testing.T) {
+	testFormatEmpty(t, (*CommentGroup)(nil))
+
+	testFormat(t, &CommentGroup{}, ``)
+	testFormat(t,
+		&CommentGroup{List: []Comment{{*T("// Comment 1")}}},
+		`// Comment 1`,
+	)
+	testFormat(t,
+		&CommentGroup{
+			List: []Comment{
+				{*T("// Comment 1")},
+				{*T("// Comment 2")},
+			},
+		},
+		`// Comment 1
+		// Comment 2`,
+	)
+}
+
+func TestCompositeLit(t *testing.T) {
+	testFormatEmpty(t, (*CompositeLit)(nil))
+	testFormat(t, Composite(I("Foo"), KV(I("X"), Int(42))), `Foo{X: 42}`)
+	testFormat(t,
+		Composite(I("Foo"), KV(I("X"), Int(42)), KV(I("Y"), Float(3.14159))),
+		`Foo{X: 42, Y: 3.14159}`,
+	)
+	testFormat(t,
+		Composite(ArrayEllipsis(I("string")), String("hello"), String("world")),
+		`[...]string{"hello", "world"}`,
+	)
+}
+
+func TestDeclStmt(t *testing.T) {
+	testFormatEmpty(t, (*DeclStmt)(nil))
+	testFormat(t,
+		&DeclStmt{
+			&GenDecl{
+				Tok:   *T("var"),
+				Specs: []Spec{&TypeSpec{Name: *I("x"), Type: I("int")}},
+			},
+		},
+		`var x int`,
+	)
+}
+
+func TestDeferStmt(t *testing.T) {
+	testFormatEmpty(t, (*DeferStmt)(nil))
+	testFormat(t, Defer(I("f"), I("x")), `defer f(x)`)
+	testFormat(t,
+		Defer(
+			Func(
+				*ParenFields(Field{Names: Idents("a", "b"), Type: I("int")}),
+				nil,
+				&ExprStmt{
+					X: Call(Dot(I("log"), "Infof"), String("(%d, %d)"), I("a"), I("b"))},
+			),
+			I("x"), I("y"),
+		),
+		`defer func(a, b int) {
+			log.Infof("(%d, %d)", a, b)
+		}(x, y)`,
+	)
+}
+
+func TestEllipsis(t *testing.T) {
+	testFormatEmpty(t, (*Ellipsis)(nil))
+	// Tested via ArrayType
+}
+
+func TestEmptyStmt(t *testing.T) {
+	testFormatEmpty(t, (*EmptyStmt)(nil))
+	testFormat(t, &EmptyStmt{}, `;`)
+}
+
+func TestExprStmt(t *testing.T) {
+	testFormatEmpty(t, (*ExprStmt)(nil))
+	testFormat(t, &ExprStmt{X: Int(0)}, `0`)
+	testFormat(t,
+		&ExprStmt{X: Composite(&ArrayType{Elt: &InterfaceType{}})},
+		`[]interface{}{}`,
+	)
+}
+
+func TestField(t *testing.T) {
+	testFormatEmpty(t, (*Field)(nil))
+}
+
+func TestFieldList(t *testing.T) {
+	testFormatEmpty(t, (*FieldList)(nil))
+}
+
+func TestFile(t *testing.T) {
+	testFormatEmpty(t, (*File)(nil))
+	testFormat(t,
+		&File{
+			Name: *I("main"),
+			Imports: []ImportSpec{
+				{Path: *String("fmt")},
+				{Path: *String("math")},
+			},
+			Decls: []Decl{
+				&FuncDecl{
+					Name: *I("main"),
+					Type: FuncType{Params: *ParenFields()},
+					Body: &BlockStmt{
+						List: []Stmt{
+							&ExprStmt{
+								X: Call(
+									Dot(I("fmt"), "Printf"),
+									String("Hello, %g\n"),
+									Dot(I("math"), "PI"),
+								),
+							},
+						},
+					},
+				},
+			},
+		},
+		`package main
+
+		import (
+			"fmt"
+			"math"
+		)
+
+		func main() {
+			fmt.Printf("Hello, %g\n", math.PI)
+		}`,
+	)
+}
+
+func TestForStmt(t *testing.T) {
+	testFormatEmpty(t, (*ForStmt)(nil))
+
+	testFormat(t,
+		&ForStmt{},
+		`for {
+		}`,
+	)
+	testFormat(t,
+		&ForStmt{Body: *Block(&ExprStmt{X: Int(0)})},
+		`for {
+			0
+		}`,
+	)
+}
+
+func TestFuncDecl(t *testing.T) {
+	testFormatEmpty(t, (*FuncDecl)(nil))
+
+	testFormat(t,
+		&FuncDecl{
+			Name: *I("f"),
+			Type: FuncType{
+				Params: *ParenFields(
+					Field{Names: Idents("a", "b"), Type: I("int")},
+				),
+			},
+			Body: Block(
+				&ExprStmt{
+					X: Call(Dot(I("log"), "Infof"),
+						&BasicLit{Token{Text: `"(%d, %d)"`}}, I("a"), I("b"),
+					),
+				},
+			),
+		},
+		`func f(a, b int) {
+			log.Infof("(%d, %d)", a, b)
+		}`,
+	)
+	testFormat(t,
+		&FuncDecl{
+			Name: *I("f"),
+			Type: FuncType{
+				Params: *ParenFields(
+					Field{Names: Idents("a"), Type: I("int")},
+					Field{Names: Idents("b"), Type: &Ellipsis{Elt: I("int")}},
+				),
+			},
+			Body: Block(),
+		},
+		`func f(a int, b ...int) {}`,
+	)
+}
+
+func TestFuncLit(t *testing.T) {
+	testFormatEmpty(t, (*FuncLit)(nil))
+	testFormat(t,
+		Composite(
+			&ArrayType{Elt: &InterfaceType{}},
+			Func(
+				*ParenFields(Field{Names: Idents("a", "b"), Type: I("int")}),
+				nil,
+				&ExprStmt{
+					X: Call(Dot(I("log"), "Infof"),
+						&BasicLit{Token{Text: `"(%d, %d)"`}}, I("a"), I("b"),
+					),
+				},
+			),
+		),
+		`[]interface{}{func(a, b int) {
+			log.Infof("(%d, %d)", a, b)
+		}}`,
+	)
+}
+
+func TestFuncType(t *testing.T) {
+	testFormatEmpty(t, (*FuncType)(nil))
+	// Tested via FuncDecl and FuncLit.
+}
+
+func TestGenDeclImport(t *testing.T) {
+	testFormatEmpty(t, (*GenDecl)(nil))
+
+	testFormat(t, Import(ImportSpec{Path: *String("fmt")}), `import "fmt"`)
+	testFormat(t,
+		Import(
+			ImportSpec{Name: I("queries"), Path: *String("database/sql")},
+			ImportSpec{Path: *String("fmt")},
+			ImportSpec{Path: *String("io")},
+			ImportSpec{Path: *String("math")},
+		),
+		`import (
+			queries "database/sql"
+			"fmt"
+			"io"
+			"math"
+		)`,
+	)
+}
+
+func TestGenDeclVar(t *testing.T) {
+	testFormatEmpty(t, (*GenDecl)(nil))
+
+	testFormat(t,
+		Var(ValueSpec{Names: Idents("x"), Values: []Expr{Int(42)}}),
+		`var x = 42`,
+	)
+	testFormat(t,
+		Var(
+			ValueSpec{Names: Idents("x"), Values: []Expr{Int(42)}},
+			ValueSpec{
+				Names:  Idents("r, g, b"),
+				Type:   I("string"),
+				Values: []Expr{String("red"), String("green"), String("blue")},
+			},
+		),
+		`var (
+			x              = 42
+			r, g, b string = "red", "green", "blue"
+		)`,
+	)
+}
+
+func TestGenDeclConst(t *testing.T) {
+	testFormatEmpty(t, (*GenDecl)(nil))
+
+	testFormat(t,
+		Const(ValueSpec{Names: Idents("x"), Values: []Expr{Int(42)}}),
+		`const x = 42`,
+	)
+	testFormat(t,
+		Const(
+			ValueSpec{Names: Idents("x"), Values: []Expr{Int(42)}},
+			ValueSpec{
+				Names:  Idents("r, g, b"),
+				Type:   I("string"),
+				Values: []Expr{String("red"), String("green"), String("blue")},
+			},
+		),
+		`const (
+			x              = 42
+			r, g, b string = "red", "green", "blue"
+		)`,
+	)
+}
+
+func TestGenDeclType(t *testing.T) {
+	testFormatEmpty(t, (*GenDecl)(nil))
+
+	testFormat(t,
+		Types(TypeSpec{Name: *I("id"), Type: I("uint64")}),
+		`type id uint64`,
+	)
+
+	coords := Idents("x", "y", "z", "w")
+
+	testFormat(t,
+		Types(
+			TypeSpec{
+				Name: *I("vec2"),
+				Type: Struct(Field{Names: coords[:2], Type: I("float32")}),
+			},
+			TypeSpec{
+				Name: *I("vec3"),
+				Type: Struct(Field{Names: coords[:3], Type: I("float32")}),
+			},
+			TypeSpec{
+				Name: *I("vec4"),
+				Type: Struct(Field{Names: coords[:4], Type: I("float32")}),
+			},
+		),
+		`type (
+			vec2 struct {
+				x, y float32
+			}
+			vec3 struct {
+				x, y, z float32
+			}
+			vec4 struct {
+				x, y, z, w float32
+			}
+		)`,
+	)
+}
+
+func TestGoStmt(t *testing.T) {
+	testFormatEmpty(t, (*GoStmt)(nil))
+	testFormat(t, &GoStmt{Call: CallExpr{Fun: I("f")}}, `go f()`)
+}
+
+func TestIdent(t *testing.T) {
+	testFormatEmpty(t, (*Ident)(nil))
+	testFormat(t, I("x"), `x`)
+	testFormat(t, I("fooBarBaz"), `fooBarBaz`)
+	testFormat(t, I("π"), `π`)
+}
+
+func TestIfStmt(t *testing.T) {
+	testFormatEmpty(t, (*IfStmt)(nil))
+
+	testFormat(t,
+		If(nil, I("ok"), Return(Int(0))),
+		`if ok {
+			return 0
+		}`,
+	)
+	testFormat(t,
+		If(
+			Init([]string{"x", "ok"}, Call(I("f"))),
+			I("ok"), Return(Int(0)),
+		),
+		`if x, ok := f(); ok {
+			return 0
+		}`,
+	)
+	testFormat(t,
+		If(
+			Init([]string{"x", "ok"}, Call(I("f"))),
+			I("ok"), Return(Int(0)),
+		),
+		`if x, ok := f(); ok {
+			return 0
+		}`,
+	)
+}
+
+func TestIfElse(t *testing.T) {
+	testFormat(t,
+		If(
+			Init([]string{"x", "ok"}, Call(I("f"))),
+			I("ok"),
+			Return(Int(0)),
+		).WithElse(
+			Return(Int(1)),
+		),
+		`if x, ok := f(); ok {
+			return 0
+		} else {
+			return 1
+		}`,
+	)
+	testFormat(t,
+		If(
+			Init([]string{"x", "ok"}, Call(I("f"))),
+			I("ok"),
+			Init([]string{"y"}, Binary(Int(1), "/", I("x"))),
+			Return(I("y")),
+		).WithElse(
+			&ExprStmt{
+				X: Call(
+					Dot(I("fmt"), "Printf"),
+					String("Oops! (%d)"),
+					I("x"),
+				),
+			},
+			Return(Int(1)),
+		),
+		`if x, ok := f(); ok {
+			y := (1 / x)
+			return y
+		} else {
+			fmt.Printf("Oops! (%d)", x)
+			return 1
+		}`,
+	)
+}
+
+func TestIfElseIf(t *testing.T) {
+	testFormat(t,
+		If(
+			Init([]string{"x", "ok"}, Call(I("f"))),
+			I("ok"),
+			Init([]string{"y"}, Binary(Int(1), "/", I("x"))),
+			Return(I("y")),
+		).WithElseIf(
+			nil,
+			I("panicOnError"),
+			&ExprStmt{X: Call(I("panic"), String("Ouch!"))},
+		),
+		`if x, ok := f(); ok {
+			y := (1 / x)
+			return y
+		} else if panicOnError {
+			panic("Ouch!")
+		}`,
+	)
+}
+
+func TestIfElseIfElse(t *testing.T) {
+	testFormat(t,
+		If(
+			Init([]string{"x", "ok"}, Call(I("f"))),
+			I("ok"),
+			Init([]string{"y"}, Binary(Int(1), "/", I("x"))),
+			Return(I("y")),
+		).WithElseIf(
+			nil,
+			I("panicOnError"),
+			&ExprStmt{X: Call(I("panic"), String("Ouch!"))},
+		).WithElse(
+			&ExprStmt{
+				X: Call(
+					Dot(I("fmt"), "Printf"),
+					String("Oops! (%d)"),
+					I("x"),
+				),
+			},
+			Return(Int(1)),
+		),
+		`if x, ok := f(); ok {
+			y := (1 / x)
+			return y
+		} else if panicOnError {
+			panic("Ouch!")
+		} else {
+			fmt.Printf("Oops! (%d)", x)
+			return 1
+		}`,
+	)
+}
+
+func TestIfElseIfElseIf(t *testing.T) {
+	testFormat(t,
+		If(
+			Init([]string{"x", "ok"}, Call(I("f"))),
+			I("ok"),
+			Init([]string{"y"}, Binary(Int(1), "/", I("x"))),
+			Return(I("y"), Nil()),
+		).WithElseIf(
+			nil,
+			I("panicOnError"),
+			&ExprStmt{X: Call(I("panic"), String("Ouch!"))},
+		).WithElseIf(
+			nil,
+			I("defaultOnError"),
+			&ExprStmt{
+				X: Call(Dot(I("fmt"), "Printf"), String("Oops! (%d)"), I("x")),
+			},
+			Return(Int(1), Nil()),
+		),
+		`if x, ok := f(); ok {
+			y := (1 / x)
+			return y, nil
+		} else if panicOnError {
+			panic("Ouch!")
+		} else if defaultOnError {
+			fmt.Printf("Oops! (%d)", x)
+			return 1, nil
+		}`,
+	)
+}
+
+func TestIfElseIfElseIfElse(t *testing.T) {
+	testFormat(t,
+		If(
+			Init([]string{"x", "ok"}, Call(I("f"))),
+			I("ok"),
+			Init([]string{"y"}, Binary(Int(1), "/", I("x"))),
+			Return(I("y"), Nil()),
+		).WithElseIf(
+			nil,
+			I("panicOnError"),
+			&ExprStmt{X: Call(I("panic"), String("Ouch!"))},
+		).WithElseIf(
+			nil,
+			I("defaultOnError"),
+			&ExprStmt{
+				X: Call(Dot(I("fmt"), "Printf"), String("Oops! (%d)"), I("x")),
+			},
+			Return(Int(1), Nil()),
+		).WithElse(
+			Return(Int(0), Call(Dot(I("fmt"), "Errorf"), String("Oops! (%d)"), I("x"))),
+		),
+		`if x, ok := f(); ok {
+			y := (1 / x)
+			return y, nil
+		} else if panicOnError {
+			panic("Ouch!")
+		} else if defaultOnError {
+			fmt.Printf("Oops! (%d)", x)
+			return 1, nil
+		} else {
+			return 0, fmt.Errorf("Oops! (%d)", x)
+		}`,
+	)
+}
+
+func TestImportSpec(t *testing.T) {
+	testFormatEmpty(t, (*ImportSpec)(nil))
+	testFormat(t, &ImportSpec{}, ``)
+}
+
+func TestIncDecStmt(t *testing.T) {
+	testFormatEmpty(t, (*IncDecStmt)(nil))
+	testFormat(t, Inc(I("x")), `x++`)
+	testFormat(t, Dec(I("x")), `x--`)
+}
+
+func TestIndexExpr(t *testing.T) {
+	testFormatEmpty(t, (*IndexExpr)(nil))
+	testFormat(t, Index(I("x"), I("y")), `x[y]`)
+}
+
+func TestInterfaceType(t *testing.T) {
+	testFormatEmpty(t, (*InterfaceType)(nil))
+	testFormatType(t, &InterfaceType{}, `interface{}`)
+	testFormatType(t,
+		&InterfaceType{
+			Methods: FieldList{
+				List: []Field{
+					{
+						Names: Idents("Foo"),
+						Type: &FuncType{
+							Params: *ParenFields(
+								Field{Names: Idents("a", "b"), Type: I("int")},
+							),
+							Results: ParenFields(
+								Field{Type: I("int")},
+								Field{Type: I("string")},
+							),
+						},
+					},
+				},
+			},
+		},
+		`interface {
+			Foo(a, b int) (int, string)
+		}`,
+	)
+}
+
+func TestKeyValueExpr(t *testing.T) {
+	testFormatEmpty(t, (*KeyValueExpr)(nil))
+}
+
+func TestLabeledStmt(t *testing.T) {
+	testFormatEmpty(t, (*LabeledStmt)(nil))
+
+	testFormat(t,
+		&LabeledStmt{Label: *I("here"), Stmt: Return(I("x"), I("y"))},
+		`here:
+		return x, y`,
+	)
+	testFormat(t,
+		&LabeledStmt{Label: *I("here"), Stmt: Block(Return(I("x"), I("y")))},
+		`here:
+		{
+			return x, y
+		}`,
+	)
+}
+
+func TestMapType(t *testing.T) {
+	testFormatEmpty(t, (*MapType)(nil))
+
+	testFormatType(t, Map(I("int"), I("string")), `map[int]string`)
+	testFormatType(t,
+		Map(I("int"), Map(I("float"), I("string"))),
+		`map[int]map[float]string`,
+	)
+}
+
+func TestParenExpr(t *testing.T) {
+	testFormatEmpty(t, (*ParenExpr)(nil))
+	testFormat(t, &ParenExpr{X: I("x")}, `x`)
+	testFormat(t, &ParenExpr{X: Binary(I("x"), "^", I("y"))}, `(x ^ y)`)
+}
+
+func TestRangeStmt(t *testing.T) {
+	testFormatEmpty(t, (*RangeStmt)(nil))
+
+	testFormat(t,
+		Range(nil, nil, "", I("records"), &IncDecStmt{X: I("x"), Tok: *T("++")}),
+		`for range records {
+			x++
+		}`)
+	testFormat(t,
+		Range(I("i"), nil, ":=", I("input"),
+			Assign([]Expr{Index(I("output"), I("i"))}, Index(I("input"), I("i"))),
+		),
+		`for i := range input {
+			output[i] = input[i]
+		}`)
+	testFormat(t,
+		Range(I("_"), I("x"), ":=", I("input"),
+			Assign(
+				[]Expr{I("output")},
+				Call(I("append"), I("output"), Call(I("f"), I("x"))),
+			),
+		),
+		`for _, x := range input {
+			output = append(output, f(x))
+		}`)
+	testFormat(t,
+		Range(I("i"), I("elt"), "=", Dot(I("os"), "Args"),
+			If(nil, Binary(I("i"), ">", Int(0)), &ExprStmt{X: Call(I("process"), I("elt"))}),
+		),
+		`for i, elt = range os.Args {
+			if i > 0 {
+				process(elt)
+			}
+		}`)
+}
+
+func TestReturnStmt(t *testing.T) {
+	testFormatEmpty(t, (*ReturnStmt)(nil))
+	testFormat(t, Return(), `return`)
+	testFormat(t, Return(I("x")), `return x`)
+}
+
+func TestSelectStmt(t *testing.T) {
+	testFormatEmpty(t, (*SelectStmt)(nil))
+
+	testFormat(t, Select(), `select {}`)
+	testFormat(t,
+		Select(SendComm(I("ch"), I("value"))),
+		`select {
+		case ch <- value:
+		}`,
+	)
+	testFormat(t,
+		Select(SendComm(I("ch"), I("value"), Inc(I("x")))),
+		`select {
+		case ch <- value:
+			x++
+		}`,
+	)
+	testFormat(t,
+		Select(RecvInitComm([]string{"value"}, I("ch"), Return(I("value")))),
+		`select {
+		case value := <-ch:
+			return value
+		}`,
+	)
+	testFormat(t,
+		Select(
+			SendComm(I("ch"), I("value"), Inc(I("x"))),
+			RecvInitComm([]string{"value"}, I("ch"), Return(I("value"))),
+			DefaultComm(&ExprStmt{Call(I("panic"), String("I can't wait!"))}),
+		),
+		`select {
+		case ch <- value:
+			x++
+		case value := <-ch:
+			return value
+		default:
+			panic("I can't wait!")
+		}`,
+	)
+}
+
+func TestSelectorExpr(t *testing.T) {
+	testFormatEmpty(t, (*SelectorExpr)(nil))
+	testFormat(t, Dot(I("x"), "y"), `x.y`)
+}
+
+func TestSendStmt(t *testing.T) {
+	testFormatEmpty(t, (*SendStmt)(nil))
+	testFormat(t, Send(I("ch"), I("x")), `ch <- x`)
+}
+
+func TestSliceExpr(t *testing.T) {
+	testFormatEmpty(t, (*SliceExpr)(nil))
+
+	x := I("x")
+	low := I("low")
+	high := I("high")
+	max := I("max")
+
+	testFormat(t, Slice(x), `x[:]`)
+	testFormat(t, Slice(x, low), `x[low:]`)
+	testFormat(t, Slice(x, nil, high), `x[:high]`)
+	testFormat(t, Slice(x, low, high), `x[low:high]`)
+	testFormat(t, Slice(x, nil, high, max), `x[:high:max]`)
+	testFormat(t, Slice(x, low, high, max), `x[low:high:max]`)
+
+	assert.Panics(t, func() { Slice(x, low, high, max, I("wat")) })
+}
+
+func TestStarExpr(t *testing.T) {
+	testFormatEmpty(t, (*StarExpr)(nil))
+	testFormat(t, Star(I("x")), `*x`)
+	testFormat(t, Star(Binary(I("x"), "+", I("y"))), `*(x + y)`)
+}
+
+func TestStructType(t *testing.T) {
+	testFormatEmpty(t, (*StructType)(nil))
+
+	testFormatType(t, Struct(), `struct{}`)
+	testFormatType(t, Struct(Field{Names: Idents("X"), Type: I("int")}),
+		`struct {
+			X int
+		}`)
+	testFormatType(t,
+		Struct(
+			Field{Names: Idents("X", "Y"), Type: I("int")},
+			Field{Names: Idents("Z"), Type: I("int"), Tag: String(`json:"id"`)},
+		),
+		`struct {
+			X, Y int
+			Z    int "json:\"id\""
+		}`)
+}
+
+func TestSwitchStmt(t *testing.T) {
+	testFormatEmpty(t, (*SwitchStmt)(nil))
+	testFormat(t,
+		&SwitchStmt{},
+		`switch {
+		}`,
+	)
+	testFormat(t,
+		&SwitchStmt{Body: *Block(DefaultCase(&BlockStmt{}))},
+		`switch {
+		default:
+			{
+			}
+		}`,
+	)
+	testFormat(t,
+		&SwitchStmt{Body: *Block(DefaultCase(&BlockStmt{}))},
+		`switch {
+		default:
+			{
+			}
+		}`,
+	)
+}
+
+func TestTypeAssertExpr(t *testing.T) {
+	testFormatEmpty(t, (*TypeAssertExpr)(nil))
+	testFormat(t, Assert(I("x"), I("y")), `x.(y)`)
+	testFormat(t, AssertType(I("x")), `x.(type)`)
+}
+
+func TestTypeSpec(t *testing.T) {
+	testFormatEmpty(t, (*TypeSpec)(nil))
+}
+
+func TestTypeSwitchStmt(t *testing.T) {
+	testFormatEmpty(t, (*TypeSwitchStmt)(nil))
+
+	testFormat(t,
+		TypeSwitch(nil, "", I("y")),
+		`switch y.(type) {
+		}`,
+	)
+	testFormat(t,
+		TypeSwitch(nil, "x", I("y")),
+		`switch x := y.(type) {
+		}`,
+	)
+	testFormat(t,
+		TypeSwitch(
+			Init([]string{"y"}, Int(1)), "x", I("y"),
+			Case([]Expr{I("int"), I("float")}, Return(Int(0))),
+		),
+		`switch y := 1; x := y.(type) {
+		case int, float:
+			return 0
+		}`,
+	)
+}
+
+func TestUnaryExpr(t *testing.T) {
+	testFormatEmpty(t, (*UnaryExpr)(nil))
+	// https://golang.org/ref/spec#Operators
+	for _, op := range []string{"+", "-", "!", "^", "*", "&", "<-"} {
+		testFormat(t, Unary(op, I("x")), op+`x`)
+	}
+}
+
+func TestValueSpec(t *testing.T) {
+	testFormatEmpty(t, (*ValueSpec)(nil))
+}

--- a/sysl2/language/go/ast.sysl
+++ b/sysl2/language/go/ast.sysl
@@ -1,0 +1,341 @@
+Go [package="golang"]:
+    !type Token:
+        kind <: string
+        # TODO: Update text to commented version, after implementing "slice of".
+        # text <: slice of string
+        text <: string
+
+    !type ArrayType:
+        lbrack     <: Token             # "["
+        len        <: Expr?             # Ellipsis node for [...]T array types, nil for slice types
+        elt        <: Expr              # element type
+
+    !type AssignStmt:
+        lhs        <: sequence of Expr
+        tok        <: Token
+        rhs        <: sequence of Expr
+
+    !type BadDecl:
+        token      <: Token
+
+    !type BadExpr:
+        token      <: Token
+
+    !type BadStmt:
+        token      <: Token
+
+    !type BasicLit:
+        token      <: Token
+
+    !type BinaryExpr:
+        x          <: Expr
+        op         <: Token
+        y          <: Expr
+
+    !type BlockStmt:
+        lbrace     <: Token             # "{"
+        list       <: sequence of Stmt
+        rbrace     <: Token             # "}"
+
+    !type BranchStmt:
+        tok        <: Token             # keyword token (BREAK, CONTINUE, GOTO, FALLTHROUGH)
+        label      <: Ident?            # label name; or nil
+
+    !type CallExpr:
+        fun        <: Expr              # function expression
+        lparen     <: Token             # "("
+        args       <: sequence of Expr  # function arguments; or nil
+        ellipsis   <: Token             # "..." (token.NoPos if there is no "...")
+        rparen     <: Token             # ")"
+
+    !type CaseClause:
+        case       <: Token             # "case" or "default" keyword
+        list       <: sequence of Expr  # list of expressions or types; nil means default case
+        colon      <: Token
+        body       <: sequence of Stmt  # statement list; or nil
+
+    !type ChanType:
+        begin      <: Token             # "chan" keyword or "<-" (whichever comes first)
+        arrow      <: Token             # "<-" (token.NoPos if there is no "<-"); added in Go 1.1
+        #dir        <: {|"SEND", "RECV"|} powerset without {||}
+        value      <: Expr              # value type
+
+    !type CommClause:
+        case       <: Token             # "case" or "default" keyword
+        comm       <: Stmt?             # send or receive statement; nil means default case
+        colon      <: Token             # ":"
+        body       <: sequence of Stmt  # statement list; or nil
+
+    !type Comment:
+        token      <: Token
+
+    !type CommentGroup:
+        list       <: sequence of Comment  # len(List) > 0
+
+    !type CompositeLit:
+        type       <: Expr?             # literal type; or nil
+        lbrace     <: Token             # "{"
+        elts       <: sequence of Expr  # list of composite elements; or nil
+        rbrace     <: Token             # "}"
+        incomplete <: bool              # true if (source) expressions are missing in the Elts list; added in Go 1.11
+
+    !type DeclStmt:
+        decl       <: Decl              # GenDecl with CONST, TYPE, or VAR token
+
+    !type DeferStmt:
+        defer      <: Token             # "defer" keyword
+        call       <: CallExpr
+
+    !type Ellipsis:
+        ellipsis   <: Token             # "..."
+        elt        <: Expr?             # ellipsis element type (parameter lists only); or nil
+
+    !type EmptyStmt:
+        semicolon  <: Token             # following ";"
+        implicit   <: bool              # if set, ";" was omitted in the source; added in Go 1.5
+
+    !type ExprStmt:
+        x          <: Expr              # expression
+
+    !type Field:
+        doc        <: CommentGroup?     # associated documentation; or nil
+        names      <: sequence of Ident # field/method/parameter names; or nil
+        type       <: Expr              # field/method/parameter type
+        tag        <: BasicLit?         # field tag; or nil
+        comment    <: CommentGroup?     # line comments; or nil
+
+    !type FieldList:
+        opening    <: Token             # opening parenthesis/brace, if any
+        list       <: sequence of Field # field list; or nil
+        closing    <: Token             # closing parenthesis/brace, if any
+
+    !type File:
+        doc        <: CommentGroup?             # associated documentation; or nil
+        package    <: Token                     # "package" keyword
+        name       <: Ident                     # package name
+        decls      <: sequence of Decl          # top-level declarations; or nil
+        imports    <: sequence of ImportSpec    # imports in this file
+        unresolved <: sequence of Ident         # unresolved identifiers in this file
+        comments   <: sequence of CommentGroup  # list of all comments in the source file
+
+    !type ForStmt:
+        for_       <: Token             # "for" keyword
+        init       <: Stmt?             # initialization statement; or nil
+        cond       <: Expr              # condition; or nil
+        post       <: Stmt?             # post iteration statement; or nil
+        body       <: BlockStmt
+
+    !type FuncDecl:
+        doc        <: CommentGroup?     # associated documentation; or nil
+        recv       <: FieldList?        # receiver (methods); or nil (functions)
+        name       <: Ident             # function/method name
+        type       <: FuncType          # function signature: parameters, results, and "func" keyword
+        body       <: BlockStmt?        # function body; or nil for external (non-Go) function
+
+    !type FuncLit:
+        type       <: FuncType          # function type
+        body       <: BlockStmt         # function body
+
+    !type FuncType:
+        func       <: Token             # "func" keyword (token.NoPos if there is no "func")
+        params     <: FieldList         # (incoming) parameters; non-nil
+        results    <: FieldList?        # (outgoing) results; or nil
+
+    !type GenDecl:
+        doc        <: CommentGroup?     # associated documentation; or nil
+        tok        <: Token             # IMPORT, CONST, TYPE, VAR
+        lparen     <: Token             # '(', if any
+        specs      <: sequence of Spec
+        rparen     <: Token             # ')', if any
+
+    !type GoStmt:
+        go         <: Token             # "go" keyword
+        call       <: CallExpr
+
+    !type Ident:
+        name       <: Token             # identifier name
+
+    !type IfStmt:
+        if_        <: Token             # "if" keyword
+        init       <: Stmt?             # initialization statement; or nil
+        cond       <: Expr              # condition
+        body       <: BlockStmt
+        else_      <: Stmt?             # else branch; or nil
+
+    !type ImportSpec:
+        doc        <: CommentGroup?     # associated documentation; or nil
+        name       <: Ident?            # local package name (including "."); or nil
+        path       <: BasicLit          # import path
+        comment    <: CommentGroup?     # line comments; or nil
+        endPos     <: Token             # end of spec (overrides Path.Pos if nonzero)
+
+    !type IncDecStmt:
+        x          <: Expr
+        tok        <: Token
+
+    !type IndexExpr:
+        x          <: Expr
+        lbrack     <: Token             # "["
+        index      <: Expr
+        rbrack     <: Token             # "]"
+
+    !type InterfaceType:
+        interface  <: Token             # "interface" keyword
+        methods    <: FieldList         # list of methods
+        incomplete <: bool              # true if (source) methods are missing in the Methods list
+
+    !type KeyValueExpr:
+        key        <: Expr
+        colon      <: Token
+        value      <: Expr
+
+    !type LabeledStmt:
+        label      <: Ident
+        colon      <: Token
+        stmt       <: Stmt
+
+    !type MapType:
+        map        <: Token             # "map" keyword
+        key        <: Expr
+        value      <: Expr
+
+    !type ParenExpr:
+        lparen     <: Token             # "("
+        x          <: Expr              # parenthesized expression
+        rparen     <: Token             # ")"
+
+    !type RangeStmt:
+        for_        <: Token            # "for" keyword
+        key        <: Expr?             # Key may be nil
+        value      <: Expr?             # Value may be nil
+        tok        <: Token             # invalid if Key == nil
+        x          <: Expr              # value to range over
+        body       <: BlockStmt
+
+    !type ReturnStmt:
+        return_     <: Token            # "return" keyword
+        results    <: sequence of Expr  # result expressions; or nil
+
+    !type SelectStmt:
+        select     <: Token             # "select" keyword
+        body       <: BlockStmt         # CommClauses only
+
+    !type SelectorExpr:
+        x          <: Expr              # expression
+        sel        <: Ident             # field selector
+
+    !type SendStmt:
+        chan       <: Expr
+        arrow      <: Token             # "<-"
+        value      <: Expr
+
+    !type SliceExpr:
+        x          <: Expr              # expression
+        lbrack     <: Token             # "["
+        low        <: Expr?             # begin of slice range; or nil
+        high       <: Expr?             # end of slice range; or nil
+        max        <: Expr?             # maximum capacity of slice; or nil; added in Go 1.2
+        slice3     <: bool              # true if 3-index slice (2 colons present); added in Go 1.2
+        rbrack     <: Token             # "]"
+
+    !type StarExpr:
+        star       <: Token             # "*"
+        x          <: Expr              # operand
+
+    !type StructType:
+        struct     <: Token             # "struct" keyword
+        fields     <: FieldList         # list of field declarations
+        incomplete <: bool              # true if (source) fields are missing in the Fields list
+
+    !type SwitchStmt:
+        switch     <: Token             # "switch" keyword
+        init       <: Stmt?             # initialization statement; or nil
+        tag        <: Expr?             # tag expression; or nil
+        body       <: BlockStmt         # CaseClauses only
+
+    !type TypeAssertExpr:
+        x          <: Expr              # expression
+        lparen     <: Token             # "("; added in Go 1.2
+        type       <: Expr              # asserted type; nil means type switch X.(type)
+        rparen     <: Token             # ")"; added in Go 1.2
+
+    !type TypeSpec:
+        doc        <: CommentGroup?     # associated documentation; or nil
+        name       <: Ident             # type name
+        assign     <: Token             # '=', if any; added in Go 1.9
+        type       <: Expr              # Ident, ParenExpr, SelectorExpr, StarExpr, or any of the XxxTypes
+        comment    <: CommentGroup?     # line comments; or nil
+
+    !type TypeSwitchStmt:
+        switch     <: Token             # "switch" keyword
+        init       <: Stmt?             # initialization statement; or nil
+        assign     <: Stmt              # x := y.(type) or y.(type)
+        body       <: BlockStmt         # CaseClauses only
+
+    !type UnaryExpr:
+        op         <: Token
+        x          <: Expr
+
+    !type ValueSpec:
+        doc        <: CommentGroup?     # associated documentation; or nil
+        names      <: sequence of Ident # value names (len(Names) > 0)
+        type       <: Expr?             # value type; or nil
+        values     <: sequence of Expr  # initial values; or nil
+        comment    <: CommentGroup?     # line comments; or nil
+
+    !union Expr:
+        BadExpr
+        Ident
+        Ellipsis
+        BasicLit
+        FuncLit
+        CompositeLit
+        ParenExpr
+        SelectorExpr
+        IndexExpr
+        SliceExpr
+        TypeAssertExpr
+        CallExpr
+        StarExpr
+        UnaryExpr
+        BinaryExpr
+        KeyValueExpr
+        ArrayType
+        StructType
+        FuncType
+        InterfaceType
+        MapType
+        ChanType
+
+    !union Stmt:
+        AssignStmt
+        BadStmt
+        BlockStmt
+        BranchStmt
+        CaseClause
+        CommClause
+        DeclStmt
+        DeferStmt
+        EmptyStmt
+        ExprStmt
+        ForStmt
+        GoStmt
+        IfStmt
+        IncDecStmt
+        LabeledStmt
+        RangeStmt
+        ReturnStmt
+        SelectStmt
+        SendStmt
+        SwitchStmt
+        TypeSwitchStmt
+
+    !union Decl:
+        BadDecl
+        FuncDecl
+        GenDecl
+
+    !union Spec:
+        ImportSpec
+        TypeSpec
+        ValueSpec


### PR DESCRIPTION
Changes proposed in this pull request:

- Sysl data model representing Go AST
- Bootstrap Go data model mirroring Go AST
  - Closely mirrors the standard go/ast package. However, the intent is to replace it with a model generated from the Sysl Go AST model.
- Go AST to Go source file (*.go) generator
- Helper function library to simplify Go AST generation

@anz-bank/sysl-developers 