### PR TITLE
Update gradle bintray plugin version to 1.8.4 (latest)

### DIFF
--- a/src/libs/java/build.gradle
+++ b/src/libs/java/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id "com.jfrog.bintray" version "1.7"
+    id "com.jfrog.bintray" version "1.8.4"
 }
 repositories {
     jcenter()


### PR DESCRIPTION
Gradle gives following error during maven publish
```message:Unable to upload files: Maven group, artifact or version defined in the pom file do not match the file path```

The issue has been fixed from 1.8.1
bintray/gradle-bintray-plugin#242 (comment)