### PR TITLE
Move 9 files into eval package

### DIFF
--- a/sysl2/proto/grammar.pb.go
+++ b/sysl2/proto/grammar.pb.go
@@ -5,10 +5,11 @@ package sysl
 
 import (
 	fmt "fmt"
+	math "math"
+
 	proto "github.com/golang/protobuf/proto"
 	descriptor "github.com/golang/protobuf/protoc-gen-go/descriptor"
 	empty "github.com/golang/protobuf/ptypes/empty"
-	math "math"
 )
 
 // Reference imports to suppress errors if they are not otherwise used.

--- a/sysl2/sysl/Codegen_test.go
+++ b/sysl2/sysl/Codegen_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"testing"
 
+	"github.com/anz-bank/sysl/sysl2/sysl/eval"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -115,12 +116,12 @@ func TestSerialize(t *testing.T) {
 
 func TestOutputForPureTokenOnlyRule(t *testing.T) {
 	g := readGrammar("tests/token_only_rule.g", "gen", "pureToken")
-	obj := MakeValueMap()
-	m := MakeValueMap()
-	addItemToValueMap(m, "text", MakeValueString("hello"))
-	addItemToValueMap(obj, "header", MakeValueBool(true))
-	addItemToValueMap(obj, "tail", MakeValueBool(true))
-	addItemToValueMap(obj, "body", m)
+	obj := eval.MakeValueMap()
+	m := eval.MakeValueMap()
+	eval.AddItemToValueMap(m, "text", eval.MakeValueString("hello"))
+	eval.AddItemToValueMap(obj, "header", eval.MakeValueBool(true))
+	eval.AddItemToValueMap(obj, "tail", eval.MakeValueBool(true))
+	eval.AddItemToValueMap(obj, "body", m)
 	output := processRule(g, obj, "pureToken")
 	assert.NotNil(t, output)
 

--- a/sysl2/sysl/codegen.go
+++ b/sysl2/sysl/codegen.go
@@ -10,6 +10,7 @@ import (
 	sysl "github.com/anz-bank/sysl/src/proto"
 	parser "github.com/anz-bank/sysl/sysl2/naive"
 	ebnfGrammar "github.com/anz-bank/sysl/sysl2/proto"
+	"github.com/anz-bank/sysl/sysl2/sysl/eval"
 	"github.com/anz-bank/sysl/sysl2/sysl/parse"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
@@ -141,7 +142,7 @@ func processRule(g *ebnfGrammar.Grammar, obj *sysl.Value, ruleName string) Node 
 	rule := g.Rules[ruleName]
 	if rule == nil {
 		root := Node{}
-		if IsCollectionType(obj) {
+		if eval.IsCollectionType(obj) {
 			return nil
 		}
 		// Should we convert int and bools to string and return?
@@ -167,14 +168,14 @@ func applyTranformToModel(modelName, transformAppName, viewName string, model, t
 	if view == nil {
 		panic(errors.Errorf("Cannot execute missing view: %s, in app %s", viewName, transformAppName))
 	}
-	s := Scope{}
+	s := eval.Scope{}
 	s.AddApp("app", modelApp)
 	var result *sysl.Value
 	// assume args are
 	//  app <: sysl.App and
 	//  type <: sysl.Type
 	if len(view.Param) >= 2 {
-		result = MakeValueList()
+		result = eval.MakeValueList()
 		var tNames []string
 		for tName := range modelApp.Types {
 			tNames = append(tNames, tName)
@@ -182,12 +183,12 @@ func applyTranformToModel(modelName, transformAppName, viewName string, model, t
 		sort.Strings(tNames)
 		for _, tName := range tNames {
 			t := modelApp.Types[tName]
-			s["typeName"] = MakeValueString(tName)
-			s["type"] = typeToValue(t)
-			appendItemToValueList(result.GetList(), EvalView(transform, transformAppName, viewName, s))
+			s["typeName"] = eval.MakeValueString(tName)
+			s["type"] = eval.TypeToValue(t)
+			eval.AppendItemToValueList(result.GetList(), eval.EvaluateView(transform, transformAppName, viewName, s))
 		}
 	} else {
-		result = EvalView(transform, transformAppName, viewName, s)
+		result = eval.EvaluateView(transform, transformAppName, viewName, s)
 	}
 
 	return result

--- a/sysl2/sysl/eval/ValueUtil_test.go
+++ b/sysl2/sysl/eval/ValueUtil_test.go
@@ -1,4 +1,4 @@
-package main
+package eval
 
 import (
 	"testing"
@@ -73,7 +73,7 @@ func TestIsCollectionType(t *testing.T) {
 
 func TestAddItemToValueMap(t *testing.T) {
 	m := MakeValueMap()
-	addItemToValueMap(m, "key", MakeValueString("value"))
+	AddItemToValueMap(m, "key", MakeValueString("value"))
 	assert.Equal(t,
 		&sysl.Value{Value: &sysl.Value_Map_{Map: &sysl.Value_Map{
 			Items: map[string]*sysl.Value{
@@ -82,7 +82,7 @@ func TestAddItemToValueMap(t *testing.T) {
 		}}},
 		m,
 	)
-	addItemToValueMap(m, "key2", MakeValueString("value2"))
+	AddItemToValueMap(m, "key2", MakeValueString("value2"))
 	assert.Equal(t,
 		&sysl.Value{Value: &sysl.Value_Map_{Map: &sysl.Value_Map{
 			Items: map[string]*sysl.Value{
@@ -96,7 +96,7 @@ func TestAddItemToValueMap(t *testing.T) {
 
 func TestAppendItemToValueList(t *testing.T) {
 	m := MakeValueList()
-	appendItemToValueList(m.GetList(), MakeValueI64(42))
+	AppendItemToValueList(m.GetList(), MakeValueI64(42))
 	assert.Equal(t,
 		&sysl.Value{Value: &sysl.Value_List_{List: &sysl.Value_List{
 			Value: []*sysl.Value{
@@ -105,7 +105,7 @@ func TestAppendItemToValueList(t *testing.T) {
 		}}},
 		m,
 	)
-	appendItemToValueList(m.GetList(), MakeValueString("value"))
+	AppendItemToValueList(m.GetList(), MakeValueString("value"))
 	assert.Equal(t,
 		&sysl.Value{Value: &sysl.Value_List_{List: &sysl.Value_List{
 			Value: []*sysl.Value{

--- a/sysl2/sysl/eval/binexprEval.go
+++ b/sysl2/sysl/eval/binexprEval.go
@@ -1,4 +1,4 @@
-package main
+package eval
 
 import (
 	"fmt"
@@ -16,21 +16,21 @@ type evalExprFunc func(
 	rhs *sysl.Expr,
 ) *sysl.Value
 
-// EvalStrategy interface to evaluate binary expr
-type EvalStrategy interface {
+// Strategy interface to evaluate binary expr
+type Strategy interface {
 	eval(*sysl.Application, Scope, *sysl.Expr_BinExpr) *sysl.Value
 }
 
 // DefaultBinExprStrategy is to evaluate lhs and rhs expr's first and then pass it to fn
 type DefaultBinExprStrategy struct{}
 
-// EvalLHSOverRHSStrategy binds rhs expression over each element of the LHS.
+// LHSOverRHSStrategy binds rhs expression over each element of the LHS.
 // Assumes lhs is a collection
-type EvalLHSOverRHSStrategy struct{}
+type LHSOverRHSStrategy struct{}
 
 //nolint:gochecknoglobals
 var (
-	functionEvalStrategy = map[sysl.Expr_BinExpr_Op]EvalStrategy{
+	functionEvalStrategy = map[sysl.Expr_BinExpr_Op]Strategy{
 		sysl.Expr_BinExpr_EQ:      DefaultBinExprStrategy{},
 		sysl.Expr_BinExpr_ADD:     DefaultBinExprStrategy{},
 		sysl.Expr_BinExpr_SUB:     DefaultBinExprStrategy{},
@@ -45,8 +45,8 @@ var (
 		sysl.Expr_BinExpr_LE:      DefaultBinExprStrategy{},
 		sysl.Expr_BinExpr_NE:      DefaultBinExprStrategy{},
 		sysl.Expr_BinExpr_AND:     DefaultBinExprStrategy{},
-		sysl.Expr_BinExpr_FLATTEN: EvalLHSOverRHSStrategy{},
-		sysl.Expr_BinExpr_WHERE:   EvalLHSOverRHSStrategy{},
+		sysl.Expr_BinExpr_FLATTEN: LHSOverRHSStrategy{},
+		sysl.Expr_BinExpr_WHERE:   LHSOverRHSStrategy{},
 	}
 
 	// key = op, lhs & rhs types
@@ -117,7 +117,7 @@ func (op DefaultBinExprStrategy) eval(txApp *sysl.Application, assign Scope, bin
 	panic(errors.Errorf("Unsupported operation:DefaultBinExprStrategy: %s", key))
 }
 
-func (op EvalLHSOverRHSStrategy) eval(txApp *sysl.Application, assign Scope, binexpr *sysl.Expr_BinExpr) *sysl.Value {
+func (op LHSOverRHSStrategy) eval(txApp *sysl.Application, assign Scope, binexpr *sysl.Expr_BinExpr) *sysl.Value {
 	lhsValue := Eval(txApp, assign, binexpr.Lhs)
 	vType := getValueType(lhsValue)
 	itemType := getContainedType(lhsValue)

--- a/sysl2/sysl/eval/exprEval.go
+++ b/sysl2/sysl/eval/exprEval.go
@@ -1,4 +1,4 @@
-package main
+package eval
 
 import (
 	"sort"
@@ -23,7 +23,7 @@ func evalTransformStmts(txApp *sysl.Application, assign Scope, tform *sysl.Expr_
 			logrus.Debugf("Evaluating %s", ss.Assign.Name)
 			res := Eval(txApp, assign, ss.Assign.Expr)
 			logrus.Tracef("Eval Result %s =:\n\t\t %v:\n", ss.Assign.Name, res)
-			addItemToValueMap(result, ss.Assign.Name, res)
+			AddItemToValueMap(result, ss.Assign.Name, res)
 			// TODO: case *sysl.Expr_Transform_Stmt_Inject:
 		}
 	}
@@ -124,11 +124,11 @@ func evalTransform(txApp *sysl.Application, assign Scope, x *sysl.Expr_Transform
 				logrus.Debugf("Evaluation Argvalue %s", key)
 				a := MakeValueMap()
 				logrus.Tracef("Evaluation Argvalue as a map: key=(%s), value=(%v)\n", key, item)
-				addItemToValueMap(a, "key", MakeValueString(key))
-				addItemToValueMap(a, "value", item)
+				AddItemToValueMap(a, "key", MakeValueString(key))
+				AddItemToValueMap(a, "value", item)
 				assign[scopeVar] = a
 				res := evalTransformStmts(txApp, assign, x.Transform)
-				appendItemToValueList(resultList, res)
+				AppendItemToValueList(resultList, res)
 			}
 			delete(assign, scopeVar)
 			if e.Type.GetSet() != nil {
@@ -188,7 +188,7 @@ func evalCall(txApp *sysl.Application, assign Scope, x *sysl.Expr_Call_) *sysl.V
 	}
 	list := MakeValueList()
 	for _, argExpr := range x.Call.Arg {
-		appendItemToValueList(list.GetList(), Eval(txApp, assign, argExpr))
+		AppendItemToValueList(list.GetList(), Eval(txApp, assign, argExpr))
 	}
 	return evalGoFunc(x.Call.Func, list)
 }
@@ -235,7 +235,7 @@ func evalSet(txApp *sysl.Application, assign Scope, x *sysl.Expr_Set) *sysl.Valu
 	{
 		setResult := MakeValueSet()
 		for _, s := range x.Set.Expr {
-			appendItemToValueList(setResult.GetSet(), Eval(txApp, assign, s))
+			AppendItemToValueList(setResult.GetSet(), Eval(txApp, assign, s))
 		}
 		return setResult
 	}
@@ -245,14 +245,14 @@ func evalList(txApp *sysl.Application, assign Scope, x *sysl.Expr_List_) *sysl.V
 	{
 		listResult := MakeValueList()
 		for _, s := range x.List.Expr {
-			appendItemToValueList(listResult.GetList(), Eval(txApp, assign, s))
+			AppendItemToValueList(listResult.GetList(), Eval(txApp, assign, s))
 		}
 		return listResult
 	}
 }
 
-// EvalView evaluate the view using the Scope
-func EvalView(mod *sysl.Module, appName, viewName string, s Scope) *sysl.Value {
+// EvaluateView evaluate the view using the Scope
+func EvaluateView(mod *sysl.Module, appName, viewName string, s Scope) *sysl.Value {
 	txApp := mod.Apps[appName]
 	view := txApp.Views[viewName]
 	if view.Expr.Type == nil {

--- a/sysl2/sysl/eval/exprEval_test.go
+++ b/sysl2/sysl/eval/exprEval_test.go
@@ -1,4 +1,4 @@
-package main
+package eval
 
 import (
 	"strings"
@@ -31,7 +31,7 @@ func TestEvalStrategySetup(t *testing.T) {
 }
 
 func TestScopeAddApp(t *testing.T) {
-	mod, _ := parse.Parse("tests/eval_expr.sysl", "")
+	mod, _ := parse.Parse("tests/eval_expr.sysl", "../")
 	s := Scope{}
 	s.AddApp("app", mod.Apps[modelAppName])
 	app := s["app"].GetMap().Items
@@ -76,7 +76,7 @@ func TestScopeAddApp(t *testing.T) {
 }
 
 func TestEvalIntegerMath(t *testing.T) {
-	mod, _ := parse.Parse("tests/eval_expr.sysl", "")
+	mod, _ := parse.Parse("tests/eval_expr.sysl", "../")
 	assert.NotNil(t, mod, "Module not loaded")
 	txApp := mod.Apps["TransformApp"]
 	viewName := "math"
@@ -97,7 +97,7 @@ func TestEvalIntegerMath(t *testing.T) {
 }
 
 func TestEvalCompare(t *testing.T) {
-	mod, _ := parse.Parse("tests/eval_expr.sysl", "")
+	mod, _ := parse.Parse("tests/eval_expr.sysl", "../")
 	assert.NotNil(t, mod, "Module not loaded")
 	txApp := mod.Apps["TransformApp"]
 	viewName := "compare"
@@ -116,7 +116,7 @@ func TestEvalCompare(t *testing.T) {
 }
 
 func TestEvalListSetOps(t *testing.T) {
-	mod, _ := parse.Parse("tests/eval_expr.sysl", "")
+	mod, _ := parse.Parse("tests/eval_expr.sysl", "../")
 	assert.NotNil(t, mod, "Module not loaded")
 	txApp := mod.Apps["TransformApp"]
 	viewName := "ListSetOps"
@@ -145,7 +145,7 @@ func TestEvalListSetOps(t *testing.T) {
 }
 
 func TestEvalIsKeyword(t *testing.T) {
-	mod, _ := parse.Parse("tests/eval_expr.sysl", "")
+	mod, _ := parse.Parse("tests/eval_expr.sysl", "../")
 	assert.NotNil(t, mod, "Module not loaded")
 	txApp := mod.Apps["TransformApp"]
 	viewName := "IsKeyword"
@@ -159,7 +159,7 @@ func TestEvalIsKeyword(t *testing.T) {
 }
 
 func TestEvalIfElseAlt(t *testing.T) {
-	mod, _ := parse.Parse("tests/eval_expr.sysl", "")
+	mod, _ := parse.Parse("tests/eval_expr.sysl", "../")
 	assert.NotNil(t, mod, "Module not loaded")
 	txApp := mod.Apps["TransformApp"]
 	viewName := "JavaType"
@@ -178,11 +178,11 @@ func TestEvalIfElseAlt(t *testing.T) {
 }
 
 func TestEvalGetAppAttributes(t *testing.T) {
-	mod, _ := parse.Parse("tests/eval_expr.sysl", "")
+	mod, _ := parse.Parse("tests/eval_expr.sysl", "../")
 
 	s := Scope{}
 	s.AddApp("app", mod.Apps[modelAppName])
-	out := EvalView(mod, "TransformApp", "GetAppAttributes", s)
+	out := EvaluateView(mod, "TransformApp", "GetAppAttributes", s)
 	assert.Equal(t, "com.example.gen", out.GetMap().Items["out"].GetS())
 	assert.Nil(t, out.GetMap().Items["Nil"])
 	assert.False(t, out.GetMap().Items["stringInNull"].GetB())
@@ -231,11 +231,11 @@ func TestEvalGetAppAttributes(t *testing.T) {
 }
 
 func TestEvalNullCheckAppAttrs(t *testing.T) {
-	mod, _ := parse.Parse("tests/eval_expr.sysl", "")
+	mod, _ := parse.Parse("tests/eval_expr.sysl", "../")
 
 	s := Scope{}
 	s.AddApp("app", mod.Apps[modelAppName])
-	out := EvalView(mod, "TransformApp", "NullCheckAppAttrs", s)
+	out := EvaluateView(mod, "TransformApp", "NullCheckAppAttrs", s)
 
 	assert.False(t, out.GetMap().Items["NotHasAttrName"].GetB())
 	assert.True(t, out.GetMap().Items["NotHasAttrFoo"].GetB())
@@ -244,7 +244,7 @@ func TestEvalNullCheckAppAttrs(t *testing.T) {
 }
 
 func TestScopeAddRestApp(t *testing.T) {
-	mod, _ := parse.Parse("tests/eval_expr.sysl", "")
+	mod, _ := parse.Parse("tests/eval_expr.sysl", "../")
 	s := Scope{}
 	s.AddApp("app", mod.Apps[todoAppName])
 	app := s["app"].GetMap().Items
@@ -296,11 +296,11 @@ func TestScopeAddRestApp(t *testing.T) {
 }
 
 func TestEvalStringOps(t *testing.T) {
-	mod, _ := parse.Parse("tests/eval_expr.sysl", "")
+	mod, _ := parse.Parse("tests/eval_expr.sysl", "../")
 
 	s := Scope{}
 	s.AddApp("app", mod.Apps[todoAppName])
-	out := EvalView(mod, "TransformApp", "StringOps", s)
+	out := EvaluateView(mod, "TransformApp", "StringOps", s)
 	assert.NotNil(t, out.GetMap())
 	items := out.GetMap().Items
 
@@ -339,11 +339,11 @@ func TestEvalStringOps(t *testing.T) {
 }
 
 func TestIncorrectArgsToGoFunc(t *testing.T) {
-	mod, _ := parse.Parse("tests/eval_expr.sysl", "")
+	mod, _ := parse.Parse("tests/eval_expr.sysl", "../")
 
 	s := Scope{}
 	s.AddApp("app", mod.Apps[todoAppName])
-	out := EvalView(mod, "TransformApp", "IncorrectArgsToGoFunc", s)
+	out := EvaluateView(mod, "TransformApp", "IncorrectArgsToGoFunc", s)
 	assert.NotNil(t, out.GetMap())
 	items := out.GetMap().Items
 	contains, has := items["Contains"]
@@ -355,11 +355,11 @@ func TestIncorrectArgsToGoFunc(t *testing.T) {
 }
 
 func TestEvalFlatten(t *testing.T) {
-	mod, _ := parse.Parse("tests/eval_expr.sysl", "")
+	mod, _ := parse.Parse("tests/eval_expr.sysl", "../")
 
 	s := Scope{}
 	s.AddApp("app", mod.Apps[todoAppName])
-	out := EvalView(mod, "TransformApp", "Flatten", s)
+	out := EvaluateView(mod, "TransformApp", "Flatten", s)
 	assert.NotNil(t, out.GetMap().Items["names"].GetSet())
 	l := out.GetMap().Items["names"].GetSet().Value
 	assert.Equal(t, 4, len(l))
@@ -382,11 +382,11 @@ func TestEvalFlatten(t *testing.T) {
 }
 
 func TestEvalWhere(t *testing.T) {
-	mod, _ := parse.Parse("tests/eval_expr.sysl", "")
+	mod, _ := parse.Parse("tests/eval_expr.sysl", "../")
 
 	s := Scope{}
 	s.AddApp("app", mod.Apps[modelAppName])
-	out := EvalView(mod, "TransformApp", "Where", s)
+	out := EvaluateView(mod, "TransformApp", "Where", s)
 
 	numbers1 := out.GetMap().Items["greaterThanOne"].GetSet().Value
 	assert.Equal(t, 2, len(numbers1))
@@ -408,11 +408,11 @@ func TestEvalWhere(t *testing.T) {
 }
 
 func TestEvalLinks(t *testing.T) {
-	mod, _ := parse.Parse("tests/eval_expr.sysl", "")
+	mod, _ := parse.Parse("tests/eval_expr.sysl", "../")
 
 	s := Scope{}
 	s.AddApp("app", mod.Apps[modelAppName])
-	out := EvalView(mod, "TransformApp", "Links", s)
+	out := EvaluateView(mod, "TransformApp", "Links", s)
 	assert.NotNil(t, out.GetMap().Items["links"].GetSet())
 	l := out.GetMap().Items["links"].GetSet().Value
 	assert.Equal(t, 5, len(l))
@@ -433,20 +433,20 @@ func TestEvalLinks(t *testing.T) {
 }
 
 func TestDotScope(t *testing.T) {
-	mod, _ := parse.Parse("tests/eval_expr.sysl", "")
+	mod, _ := parse.Parse("tests/eval_expr.sysl", "../")
 
 	s := Scope{}
 	s.AddApp("app", mod.Apps[modelAppName])
-	out := EvalView(mod, "TransformApp", "TestDotScope", s).GetMap().Items
+	out := EvaluateView(mod, "TransformApp", "TestDotScope", s).GetMap().Items
 	assert.Equal(t, 3, len(out))
 }
 
 func TestListOfTypeNames(t *testing.T) {
-	mod, _ := parse.Parse("tests/eval_expr.sysl", "")
+	mod, _ := parse.Parse("tests/eval_expr.sysl", "../")
 
 	s := Scope{}
 	s.AddApp("app", mod.Apps[modelAppName])
-	out := EvalView(mod, "TransformApp", "ListOfTypeNames", s)
+	out := EvaluateView(mod, "TransformApp", "ListOfTypeNames", s)
 	l := out.GetList()
 	assert.NotNil(t, l)
 	assert.Equal(t, 2, len(l.Value))

--- a/sysl2/sysl/eval/exprOp.go
+++ b/sysl2/sysl/eval/exprOp.go
@@ -1,4 +1,4 @@
-package main
+package eval
 
 import (
 	"encoding/json"
@@ -89,7 +89,7 @@ func flattenListMap(
 	listResult := MakeValueList()
 	for _, l := range list.GetList().Value {
 		assign[scopeVar] = l
-		appendItemToValueList(listResult.GetList(), Eval(txApp, assign, rhs))
+		AppendItemToValueList(listResult.GetList(), Eval(txApp, assign, rhs))
 	}
 	return listResult
 }
@@ -105,7 +105,7 @@ func flattenListList(
 	for _, l := range list.GetList().Value {
 		for _, ll := range l.GetList().Value {
 			assign[scopeVar] = ll
-			appendItemToValueList(listResult.GetList(), Eval(txApp, assign, rhs))
+			AppendItemToValueList(listResult.GetList(), Eval(txApp, assign, rhs))
 		}
 	}
 	return listResult
@@ -122,7 +122,7 @@ func flattenListSet(
 	for _, l := range list.GetList().Value {
 		for _, ll := range l.GetSet().Value {
 			assign[scopeVar] = ll
-			appendItemToValueList(listResult.GetList(), Eval(txApp, assign, rhs))
+			AppendItemToValueList(listResult.GetList(), Eval(txApp, assign, rhs))
 		}
 	}
 	return listResult
@@ -145,10 +145,10 @@ func flattenSetMap(
 		switch x := res.Value.(type) {
 		case *sysl.Value_Set:
 			for _, ll := range x.Set.Value {
-				appendItemToValueList(setResult.GetSet(), ll)
+				AppendItemToValueList(setResult.GetSet(), ll)
 			}
 		default:
-			appendItemToValueList(setResult.GetSet(), res)
+			AppendItemToValueList(setResult.GetSet(), res)
 		}
 	}
 	return setResult
@@ -164,7 +164,7 @@ func flattenSetSet(txApp *sysl.Application,
 	for _, l := range list.GetSet().Value {
 		for _, ll := range l.GetSet().Value {
 			assign[scopeVar] = ll
-			appendItemToValueList(setResult.GetSet(), Eval(txApp, assign, rhs))
+			AppendItemToValueList(setResult.GetSet(), Eval(txApp, assign, rhs))
 		}
 	}
 	return setResult
@@ -244,7 +244,7 @@ func intSetToValueSet(lhs map[int64]struct{}) *sysl.Value {
 	sort.Ints(keys)
 
 	for _, key := range keys {
-		appendItemToValueList(m.GetSet(), MakeValueI64(int64(key)))
+		AppendItemToValueList(m.GetSet(), MakeValueI64(int64(key)))
 	}
 	return m
 }
@@ -276,7 +276,7 @@ func stringSetToValueSet(lhs map[string]struct{}) *sysl.Value {
 	sort.Strings(keys)
 
 	for _, key := range keys {
-		appendItemToValueList(m.GetSet(), MakeValueString(key))
+		AppendItemToValueList(m.GetSet(), MakeValueString(key))
 	}
 	return m
 }
@@ -309,7 +309,7 @@ func mapSetToValueSet(lhs map[string]*sysl.Value) *sysl.Value {
 	sort.Strings(keys)
 
 	for _, key := range keys {
-		appendItemToValueList(m.GetSet(), lhs[key])
+		AppendItemToValueList(m.GetSet(), lhs[key])
 	}
 	return m
 }
@@ -334,7 +334,7 @@ func whereSet(txApp *sysl.Application, assign Scope, list *sysl.Value, scopeVar 
 		assign[scopeVar] = l
 		predicate := Eval(txApp, assign, rhs)
 		if predicate.GetB() {
-			appendItemToValueList(setResult.GetSet(), l)
+			AppendItemToValueList(setResult.GetSet(), l)
 		}
 	}
 	return setResult
@@ -347,7 +347,7 @@ func whereList(txApp *sysl.Application, assign Scope, list *sysl.Value, scopeVar
 		assign[scopeVar] = l
 		predicate := Eval(txApp, assign, rhs)
 		if predicate.GetB() {
-			appendItemToValueList(listResult.GetList(), l)
+			AppendItemToValueList(listResult.GetList(), l)
 		}
 	}
 	return listResult
@@ -358,12 +358,12 @@ func whereMap(txApp *sysl.Application, assign Scope, m *sysl.Value, scopeVar str
 	logrus.Printf("scope: %s, list len: %d", scopeVar, len(m.GetMap().Items))
 	for key, val := range m.GetMap().Items {
 		m := MakeValueMap()
-		addItemToValueMap(m, "key", MakeValueString(key))
-		addItemToValueMap(m, "value", val)
+		AddItemToValueMap(m, "key", MakeValueString(key))
+		AddItemToValueMap(m, "value", val)
 		assign[scopeVar] = m
 		predicate := Eval(txApp, assign, rhs)
 		if predicate.GetB() {
-			addItemToValueMap(mapResult, key, val)
+			AddItemToValueMap(mapResult, key, val)
 		}
 	}
 	return mapResult

--- a/sysl2/sysl/eval/goFuncs.go
+++ b/sysl2/sysl/eval/goFuncs.go
@@ -1,4 +1,4 @@
-package main
+package eval
 
 import (
 	"reflect"
@@ -194,7 +194,7 @@ func reflectToValue(r reflect.Value, typ *sysl.Type) *sysl.Value {
 		primitiveType := typ.GetList().GetType()
 
 		for i := 0; i < r.Len(); i++ {
-			appendItemToValueList(list.GetList(), reflectToValue(r.Index(i), primitiveType))
+			AppendItemToValueList(list.GetList(), reflectToValue(r.Index(i), primitiveType))
 		}
 		return list
 	}

--- a/sysl2/sysl/eval/unaryEval.go
+++ b/sysl2/sysl/eval/unaryEval.go
@@ -1,4 +1,4 @@
-package main
+package eval
 
 import (
 	sysl "github.com/anz-bank/sysl/src/proto"

--- a/sysl2/sysl/eval/valueType.go
+++ b/sysl2/sysl/eval/valueType.go
@@ -1,4 +1,4 @@
-package main
+package eval
 
 import (
 	sysl "github.com/anz-bank/sysl/src/proto"


### PR DESCRIPTION
Fixes #274

Changes proposed in this pull request:

- Move 9 files into eval package
- Refactor affected src and test files

### Moved files

1. binexprEval.go
2. exprEval.go
3. exprEval_test.go
4. exprOp.go
5. goFuncs.go
6. unaryEval.go
7. valueType.go
8. ValueUtil.go
9. ValueUtil_test.go

@anz-bank/sysl-developers
