### PR TITLE
Refactor sysl cmd line, Merge sysl binaries.

### DIFF
--- a/sysl2/sysl/Codegen_test.go
+++ b/sysl2/sysl/Codegen_test.go
@@ -145,3 +145,19 @@ func TestOutputForPureTokenOnlyRule(t *testing.T) {
 	assert.Equal(t, 1, len(tail))
 	assert.Equal(t, "tail", tail[0].(Node)[0].(string))
 }
+
+func GenerateCodeWithParams(rootModel, model, rootTransform, transform, grammar, start string, loglevel string,
+	isVerbose bool,
+) []*CodeGenOutput {
+	cmdContextParamCodegen := &CmdContextParamCodegen{
+		rootModel:     &rootModel,
+		model:         &model,
+		rootTransform: &rootTransform,
+		transform:     &transform,
+		grammar:       &grammar,
+		start:         &start,
+		loglevel:      &loglevel,
+		isVerbose:     &isVerbose,
+	}
+	return GenerateCode(cmdContextParamCodegen)
+}

--- a/sysl2/sysl/Codegen_test.go
+++ b/sysl2/sysl/Codegen_test.go
@@ -9,7 +9,8 @@ import (
 )
 
 func TestGenerateCode(t *testing.T) {
-	output := GenerateCode(".", "tests/model.sysl", ".", "tests/test.gen.sysl", "tests/test.gen.g", "javaFile")
+	output := GenerateCodeWithParams(".", "tests/model.sysl", ".", "tests/test.gen.sysl",
+		"tests/test.gen.g", "javaFile", "warn", false)
 	root := output[0].output
 	assert.Equal(t, 1, len(output), "unexpected length of output")
 	assert.Equal(t, 1, len(root), "unexpected length of root")
@@ -45,7 +46,8 @@ func TestGenerateCode(t *testing.T) {
 }
 
 func TestGenerateCodeNoComment(t *testing.T) {
-	output := GenerateCode(".", "tests/model.sysl", ".", "tests/test.gen_no_comment.sysl", "tests/test.gen.g", "javaFile")
+	output := GenerateCodeWithParams(".", "tests/model.sysl", ".", "tests/test.gen_no_comment.sysl",
+		"tests/test.gen.g", "javaFile", "warn", false)
 	assert.Equal(t, 1, len(output), "unexpected length of output")
 	root := output[0].output
 	assert.Equal(t, 1, len(root), "unexpected length of root")
@@ -72,20 +74,22 @@ func TestGenerateCodeNoComment(t *testing.T) {
 }
 
 func TestGenerateCodeNoPackage(t *testing.T) {
-	output := GenerateCode(".", "tests/model.sysl", ".", "tests/test.gen_no_package.sysl", "tests/test.gen.g", "javaFile")
+	output := GenerateCodeWithParams(".", "tests/model.sysl", ".", "tests/test.gen_no_package.sysl",
+		"tests/test.gen.g", "javaFile", "warn", false)
 	root := output[0].output
 	assert.Nil(t, root, "unexpected root")
 }
 
 func TestGenerateCodeMultipleAnnotations(t *testing.T) {
-	output := GenerateCode(
-		".", "tests/model.sysl", ".", "tests/test.gen_multiple_annotations.sysl", "tests/test.gen.g", "javaFile")
+	output := GenerateCodeWithParams(".", "tests/model.sysl", ".", "tests/test.gen_multiple_annotations.sysl",
+		"tests/test.gen.g", "javaFile", "warn", false)
 	root := output[0].output
 	assert.Nil(t, root, "unexpected root")
 }
 
 func TestGenerateCodePerType(t *testing.T) {
-	output := GenerateCode(".", "tests/model.sysl", ".", "tests/multiple_file.gen.sysl", "tests/test.gen.g", "javaFile")
+	output := GenerateCodeWithParams(".", "tests/model.sysl", ".", "tests/multiple_file.gen.sysl",
+		"tests/test.gen.g", "javaFile", "warn", false)
 	assert.Equal(t, 1, len(output), "unexpected length of output")
 	assert.Equal(t, "Request.java", output[0].filename, "unexpected length of output")
 
@@ -106,7 +110,8 @@ func TestGenerateCodePerType(t *testing.T) {
 }
 
 func TestSerialize(t *testing.T) {
-	output := GenerateCode(".", "tests/model.sysl", ".", "tests/test.gen.sysl", "tests/test.gen.g", "javaFile")
+	output := GenerateCodeWithParams(".", "tests/model.sysl", ".", "tests/test.gen.sysl",
+		"tests/test.gen.g", "javaFile", "warn", false)
 	out := new(bytes.Buffer)
 	require.NoError(t, Serialize(out, " ", output[0].output))
 	golden := "package com.example.gen \n comment1 comment2 import import1 \n import import2 \n some_value "

--- a/sysl2/sysl/codegen.go
+++ b/sysl2/sysl/codegen.go
@@ -234,18 +234,19 @@ func loadAndGetDefaultApp(root, model string) (*sysl.Module, string) {
 func GenerateCode(codegenParams *CmdContextParamCodegen) []*CodeGenOutput {
 	var codeOutput []*CodeGenOutput
 
-	logrus.Warnf("root-model: %s\n", *codegenParams.rootModel)
-	logrus.Warnf("root-transform: %s\n", *codegenParams.rootTransform)
-	logrus.Warnf("model: %s\n", *codegenParams.model)
-	logrus.Warnf("transform: %s\n", *codegenParams.transform)
-	logrus.Warnf("grammar: %s\n", *codegenParams.grammar)
-	logrus.Warnf("start: %s\n", *codegenParams.start)
-	logrus.Warnf("loglevel: %s\n", *codegenParams.loglevel)
+	logrus.Debugf("root-model: %s\n", *codegenParams.rootModel)
+	logrus.Debugf("root-transform: %s\n", *codegenParams.rootTransform)
+	logrus.Debugf("model: %s\n", *codegenParams.model)
+	logrus.Debugf("transform: %s\n", *codegenParams.transform)
+	logrus.Debugf("grammar: %s\n", *codegenParams.grammar)
+	logrus.Debugf("start: %s\n", *codegenParams.start)
+	logrus.Debugf("loglevel: %s\n", *codegenParams.loglevel)
 
-	if *codegenParams.verbose {
+	if *codegenParams.isVerbose {
 		*codegenParams.loglevel = debug
 	}
-	if level, has := defaultLevel[*codegenParams.loglevel]; has {
+	// Default info
+	if level, has := logLevels[*codegenParams.loglevel]; has {
 		logrus.SetLevel(level)
 	}
 
@@ -274,22 +275,6 @@ func GenerateCode(codegenParams *CmdContextParamCodegen) []*CodeGenOutput {
 		}
 	}
 	return codeOutput
-}
-
-func GenerateCodeWithParams(rootModel, model, rootTransform, transform, grammar, start string, loglevel string,
-	verbose bool,
-) []*CodeGenOutput {
-	cmdContextParamCodegen := &CmdContextParamCodegen{
-		rootModel:     &rootModel,
-		model:         &model,
-		rootTransform: &rootTransform,
-		transform:     &transform,
-		grammar:       &grammar,
-		start:         &start,
-		loglevel:      &loglevel,
-		verbose:       &verbose,
-	}
-	return GenerateCode(cmdContextParamCodegen)
 }
 
 func outputToFiles(outDir string, output []*CodeGenOutput) error {
@@ -322,8 +307,8 @@ func configureCmdlineForCodegen(sysl *kingpin.Application) *CmdContextParamCodeg
 	returnValues.grammar = gen.Flag("grammar", "grammar.g").Default(".").String()
 	returnValues.start = gen.Flag("start", "start rule for the grammar").Default(".").String()
 	returnValues.outDir = gen.Flag("outdir", "output directory").Default(".").String()
-	returnValues.loglevel = gen.Flag("log", "log level[debug,info,warn,off]").Default("warn").String()
-	returnValues.verbose = gen.Flag("verbose", "show output").Short('v').Default("false").Bool()
+	returnValues.loglevel = gen.Flag("log", "log level[debug,info,warn,off]").Default("info").String()
+	returnValues.isVerbose = gen.Flag("verbose", "show output").Short('v').Default("false").Bool()
 
 	return returnValues
 }

--- a/sysl2/sysl/codegen.go
+++ b/sysl2/sysl/codegen.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"flag"
 	"io"
 	"io/ioutil"
 	"os"
@@ -13,6 +12,7 @@ import (
 	"github.com/anz-bank/sysl/sysl2/sysl/parse"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
+	"gopkg.in/alecthomas/kingpin.v2"
 )
 
 // Node can be string or node
@@ -231,12 +231,27 @@ func loadAndGetDefaultApp(root, model string) (*sysl.Module, string) {
 
 // GenerateCode transform input sysl model to code in the target language described by
 // grammar and a sysl transform
-func GenerateCode(rootModel, model, rootTransform, transform, grammar, start string) []*CodeGenOutput {
+func GenerateCode(codegenParams *CmdContextParamCodegen) []*CodeGenOutput {
 	var codeOutput []*CodeGenOutput
 
-	mod, modelAppName := loadAndGetDefaultApp(rootModel, model)
-	tx, transformAppName := loadAndGetDefaultApp(rootTransform, transform)
-	g := readGrammar(grammar, "gen", start)
+	logrus.Warnf("root-model: %s\n", *codegenParams.rootModel)
+	logrus.Warnf("root-transform: %s\n", *codegenParams.rootTransform)
+	logrus.Warnf("model: %s\n", *codegenParams.model)
+	logrus.Warnf("transform: %s\n", *codegenParams.transform)
+	logrus.Warnf("grammar: %s\n", *codegenParams.grammar)
+	logrus.Warnf("start: %s\n", *codegenParams.start)
+	logrus.Warnf("loglevel: %s\n", *codegenParams.loglevel)
+
+	if *codegenParams.verbose {
+		*codegenParams.loglevel = debug
+	}
+	if level, has := defaultLevel[*codegenParams.loglevel]; has {
+		logrus.SetLevel(level)
+	}
+
+	mod, modelAppName := loadAndGetDefaultApp(*codegenParams.rootModel, *codegenParams.model)
+	tx, transformAppName := loadAndGetDefaultApp(*codegenParams.rootTransform, *codegenParams.transform)
+	g := readGrammar(*codegenParams.grammar, "gen", *codegenParams.start)
 	if g == nil {
 		panic(errors.Errorf("Unable to load grammar"))
 	}
@@ -261,6 +276,22 @@ func GenerateCode(rootModel, model, rootTransform, transform, grammar, start str
 	return codeOutput
 }
 
+func GenerateCodeWithParams(rootModel, model, rootTransform, transform, grammar, start string, loglevel string,
+	verbose bool,
+) []*CodeGenOutput {
+	cmdContextParamCodegen := &CmdContextParamCodegen{
+		rootModel:     &rootModel,
+		model:         &model,
+		rootTransform: &rootTransform,
+		transform:     &transform,
+		grammar:       &grammar,
+		start:         &start,
+		loglevel:      &loglevel,
+		verbose:       &verbose,
+	}
+	return GenerateCode(cmdContextParamCodegen)
+}
+
 func outputToFiles(outDir string, output []*CodeGenOutput) error {
 	for _, o := range output {
 		f, err := os.Create(outDir + "/" + o.filename)
@@ -278,28 +309,21 @@ func outputToFiles(outDir string, output []*CodeGenOutput) error {
 	return nil
 }
 
-// DoGenerateCode generate code for the given model, using transform
-// and the grammar of the target language
-// TODO: Remove nolint when code that uses stdout and stderr is added.
-//nolint:unparam
-func DoGenerateCode(flags *flag.FlagSet, args []string) error {
-	rootModel := flags.String("root-model", ".", "sysl root directory for input model file (default: .)")
-	rootTransform := flags.String("root-transform", ".", "sysl root directory for input transform file (default: .)")
-	model := flags.String("model", ".", "model.sysl")
-	transform := flags.String("transform", ".", "transform.sysl")
-	grammar := flags.String("grammar", ".", "grammar.g")
-	start := flags.String("start", ".", "start rule for the grammar")
-	outDir := flags.String("outdir", ".", "output directory")
+func configureCmdlineForCodegen(sysl *kingpin.Application) *CmdContextParamCodegen {
+	gen := sysl.Command("gen", "Generate code")
+	returnValues := &CmdContextParamCodegen{}
 
-	if err := flags.Parse(args[1:]); err != nil {
-		return err
-	}
-	logrus.Warnf("root-model: %s\n", *rootModel)
-	logrus.Warnf("root-transform: %s\n", *rootTransform)
-	logrus.Warnf("model: %s\n", *model)
-	logrus.Warnf("transform: %s\n", *transform)
-	logrus.Warnf("grammar: %s\n", *grammar)
-	logrus.Warnf("start: %s\n", *start)
-	output := GenerateCode(*rootModel, *model, *rootTransform, *transform, *grammar, *start)
-	return outputToFiles(*outDir, output)
+	returnValues.rootModel = gen.Flag("root-model",
+		"sysl root directory for input model file (default: .)").Default(".").String()
+	returnValues.rootTransform = gen.Flag("root-transform",
+		"sysl root directory for input transform file (default: .)").Default(".").String()
+	returnValues.model = gen.Flag("model", "model.sysl").Default(".").String()
+	returnValues.transform = gen.Flag("transform", "grammar.g").Default(".").String()
+	returnValues.grammar = gen.Flag("grammar", "grammar.g").Default(".").String()
+	returnValues.start = gen.Flag("start", "start rule for the grammar").Default(".").String()
+	returnValues.outDir = gen.Flag("outdir", "output directory").Default(".").String()
+	returnValues.loglevel = gen.Flag("log", "log level[debug,info,warn,off]").Default("warn").String()
+	returnValues.verbose = gen.Flag("verbose", "show output").Short('v').Default("false").Bool()
+
+	return returnValues
 }

--- a/sysl2/sysl/ints.go
+++ b/sysl2/sysl/ints.go
@@ -14,16 +14,16 @@ const endpointWildcard = ".. * <- *"
 func GenerateIntegrations(intgenParams *CmdContextParamIntgen) (map[string]string, error) {
 	r := make(map[string]string)
 
-	log.Infof("root: %s\n", *intgenParams.root)
-	log.Infof("project: %v\n", *intgenParams.project)
-	log.Infof("clustered: %t\n", *intgenParams.clustered)
-	log.Infof("exclude: %s\n", *intgenParams.exclude)
-	log.Infof("epa: %t\n", *intgenParams.epa)
-	log.Infof("title: %s\n", *intgenParams.title)
-	log.Infof("filter: %s\n", *intgenParams.filter)
-	log.Infof("modules: %s\n", *intgenParams.modules)
-	log.Infof("output: %s\n", *intgenParams.output)
-	log.Infof("loglevel: %s\n", *intgenParams.loglevel)
+	log.Debugf("root: %s\n", *intgenParams.root)
+	log.Debugf("project: %v\n", *intgenParams.project)
+	log.Debugf("clustered: %t\n", *intgenParams.clustered)
+	log.Debugf("exclude: %s\n", *intgenParams.exclude)
+	log.Debugf("epa: %t\n", *intgenParams.epa)
+	log.Debugf("title: %s\n", *intgenParams.title)
+	log.Debugf("filter: %s\n", *intgenParams.filter)
+	log.Debugf("modules: %s\n", *intgenParams.modules)
+	log.Debugf("output: %s\n", *intgenParams.output)
+	log.Debugf("loglevel: %s\n", *intgenParams.loglevel)
 
 	if intgenParams.plantuml == nil {
 		plantuml := os.Getenv("SYSL_PLANTUML")
@@ -32,12 +32,13 @@ func GenerateIntegrations(intgenParams *CmdContextParamIntgen) (map[string]strin
 			*intgenParams.plantuml = "http://localhost:8080/plantuml"
 		}
 	}
-	log.Infof("plantuml: %s\n", *intgenParams.plantuml)
+	log.Debugf("plantuml: %s\n", *intgenParams.plantuml)
 
-	if *intgenParams.verbose {
+	if *intgenParams.isVerbose {
 		*intgenParams.loglevel = debug
 	}
-	if level, has := defaultLevel[*intgenParams.loglevel]; has {
+	// Default info
+	if level, has := logLevels[*intgenParams.loglevel]; has {
 		log.SetLevel(level)
 	}
 
@@ -74,28 +75,6 @@ func GenerateIntegrations(intgenParams *CmdContextParamIntgen) (map[string]strin
 	return r, nil
 }
 
-func GenerateIntegrationsWithParams(rootModel, title, output, project, filter, modules string,
-	exclude []string,
-	clustered, epa bool,
-	loglevel string,
-	verbose bool,
-) (map[string]string, error) {
-	cmdContextParamIntgen := &CmdContextParamIntgen{
-		root:      &rootModel,
-		title:     &title,
-		output:    &output,
-		project:   &project,
-		filter:    &filter,
-		modules:   &modules,
-		exclude:   &exclude,
-		clustered: &clustered,
-		epa:       &epa,
-		loglevel:  &loglevel,
-		verbose:   &verbose,
-	}
-	return GenerateIntegrations(cmdContextParamIntgen)
-}
-
 func configureCmdlineForIntgen(sysl *kingpin.Application) *CmdContextParamIntgen {
 	defer func() {
 		if err := recover(); err != nil {
@@ -122,8 +101,8 @@ func configureCmdlineForIntgen(sysl *kingpin.Application) *CmdContextParamIntgen
 	returnValues.clustered = ints.Flag("clustered",
 		"group integration components into clusters").Short('c').Default("false").Bool()
 	returnValues.epa = ints.Flag("epa", "produce and EPA integration view").Default("false").Bool()
-	returnValues.loglevel = ints.Flag("log", "log level[debug,info,warn,off]").Default("warn").String()
-	returnValues.verbose = ints.Flag("verbose", "show output").Short('v').Default("false").Bool()
+	returnValues.loglevel = ints.Flag("log", "log level[debug,info,warn,off]").Default("info").String()
+	returnValues.isVerbose = ints.Flag("verbose", "show output").Short('v').Default("false").Bool()
 
 	return returnValues
 }

--- a/sysl2/sysl/ints.go
+++ b/sysl2/sysl/ints.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"fmt"
 	"os"
 	"regexp"
 	"strings"
@@ -12,31 +11,54 @@ import (
 
 const endpointWildcard = ".. * <- *"
 
-func GenerateIntegrations(
-	rootModel, title, output, project, filter, modules string,
-	exclude []string,
-	clustered, epa bool,
-) (map[string]string, error) {
+func GenerateIntegrations(intgenParams *CmdContextParamIntgen) (map[string]string, error) {
 	r := make(map[string]string)
 
-	mod, err := loadApp(rootModel, modules)
+	log.Infof("root: %s\n", *intgenParams.root)
+	log.Infof("project: %v\n", *intgenParams.project)
+	log.Infof("clustered: %t\n", *intgenParams.clustered)
+	log.Infof("exclude: %s\n", *intgenParams.exclude)
+	log.Infof("epa: %t\n", *intgenParams.epa)
+	log.Infof("title: %s\n", *intgenParams.title)
+	log.Infof("filter: %s\n", *intgenParams.filter)
+	log.Infof("modules: %s\n", *intgenParams.modules)
+	log.Infof("output: %s\n", *intgenParams.output)
+	log.Infof("loglevel: %s\n", *intgenParams.loglevel)
+
+	if intgenParams.plantuml == nil {
+		plantuml := os.Getenv("SYSL_PLANTUML")
+		intgenParams.plantuml = &plantuml
+		if *intgenParams.plantuml == "" {
+			*intgenParams.plantuml = "http://localhost:8080/plantuml"
+		}
+	}
+	log.Infof("plantuml: %s\n", *intgenParams.plantuml)
+
+	if *intgenParams.verbose {
+		*intgenParams.loglevel = debug
+	}
+	if level, has := defaultLevel[*intgenParams.loglevel]; has {
+		log.SetLevel(level)
+	}
+
+	mod, err := loadApp(*intgenParams.root, *intgenParams.modules)
 	if err != nil {
 		return nil, err
 	}
 
-	if len(exclude) == 0 && project != "" {
-		exclude = []string{project}
+	if len(*intgenParams.exclude) == 0 && *intgenParams.project != "" {
+		*intgenParams.exclude = []string{*intgenParams.project}
 	}
-	excludeStrSet := MakeStrSet(exclude...)
+	excludeStrSet := MakeStrSet(*intgenParams.exclude...)
 
 	// The "project" app that specifies the required view of the integration
-	app := mod.GetApps()[project]
-	of := MakeFormatParser(output)
+	app := mod.GetApps()[*intgenParams.project]
+	of := MakeFormatParser(*intgenParams.output)
 	// Iterate over each endpoint within the selected project
 	for epname, endpt := range app.GetEndpoints() {
-		outputDir := of.FmtOutput(project, epname, endpt.GetLongName(), endpt.GetAttrs())
-		if filter != "" {
-			re := regexp.MustCompile(filter)
+		outputDir := of.FmtOutput(*intgenParams.project, epname, endpt.GetLongName(), endpt.GetAttrs())
+		if *intgenParams.filter != "" {
+			re := regexp.MustCompile(*intgenParams.filter)
 			if !re.MatchString(outputDir) {
 				continue
 			}
@@ -45,69 +67,63 @@ func GenerateIntegrations(
 		passthroughs := MakeStrSetFromAttr("passthrough", endpt.GetAttrs())
 		b := makeBuilderfromStmt(mod, endpt.GetStmt(), excludeStrSet.Union(excludes), passthroughs)
 		intsParam := &IntsParam{b.finalApps, b.seedAppsMap, b.depsOut, app, endpt}
-		args := &Args{title, project, clustered, epa}
+		args := &Args{*intgenParams.title, *intgenParams.project, *intgenParams.clustered, *intgenParams.epa}
 		r[outputDir] = GenerateView(args, intsParam, mod)
 	}
 
 	return r, nil
 }
 
-func DoGenerateIntegrations(args []string) error {
-	ints := kingpin.New("ints", "Generate integrations")
-	root := ints.Flag("root", "sysl root directory for input model file (default: .)").Default(".").String()
-	title := ints.Flag("title", "diagram title").Short('t').String()
-	plantuml := ints.Flag("plantuml", strings.Join([]string{"base url of plantuml server",
+func GenerateIntegrationsWithParams(rootModel, title, output, project, filter, modules string,
+	exclude []string,
+	clustered, epa bool,
+	loglevel string,
+	verbose bool,
+) (map[string]string, error) {
+	cmdContextParamIntgen := &CmdContextParamIntgen{
+		root:      &rootModel,
+		title:     &title,
+		output:    &output,
+		project:   &project,
+		filter:    &filter,
+		modules:   &modules,
+		exclude:   &exclude,
+		clustered: &clustered,
+		epa:       &epa,
+		loglevel:  &loglevel,
+		verbose:   &verbose,
+	}
+	return GenerateIntegrations(cmdContextParamIntgen)
+}
+
+func configureCmdlineForIntgen(sysl *kingpin.Application) *CmdContextParamIntgen {
+	defer func() {
+		if err := recover(); err != nil {
+			log.Errorln(err)
+		}
+	}()
+	ints := sysl.Command("ints", "Generate integrations")
+	returnValues := &CmdContextParamIntgen{}
+
+	returnValues.root = ints.Flag("root", "sysl root directory for input model file (default: .)").Default(".").String()
+	returnValues.title = ints.Flag("title", "diagram title").Short('t').String()
+	returnValues.plantuml = ints.Flag("plantuml", strings.Join([]string{"base url of plantuml server",
 		"(default: $SYSL_PLANTUML or http://localhost:8080/plantuml",
 		"see http://plantuml.com/server.html#install for more info)"}, "\n")).Short('p').String()
-	output := ints.Flag("output", "output file(default: %(epname).png)").Default("%(epname).png").Short('o').String()
-	project := ints.Flag("project", "project pseudo-app to render").Short('j').String()
-	filter := ints.Flag("filter", "Only generate diagrams whose output paths match a pattern").String()
-	modules := ints.Arg("modules", strings.Join([]string{"input files without .sysl extension and with leading /",
-		"eg: /project_dir/my_models",
-		"combine with --root if needed"}, "\n")).String()
-	exclude := ints.Flag("exclude", "apps to exclude").Short('e').Strings()
-	clustered := ints.Flag("clustered", "group integration components into clusters").Short('c').Default("false").Bool()
-	epa := ints.Flag("epa", "produce and EPA integration view").Default("false").Bool()
-	loglevel := ints.Flag("log", "log level[debug,info,warn,off]").Default("warn").String()
-	verbose := ints.Flag("verbose", "show output").Short('v').Default("false").Bool()
+	returnValues.output = ints.Flag("output",
+		"output file(default: %(epname).png)").Default("%(epname).png").Short('o').String()
+	returnValues.project = ints.Flag("project", "project pseudo-app to render").Short('j').String()
+	returnValues.filter = ints.Flag("filter", "Only generate diagrams whose output paths match a pattern").String()
+	returnValues.modules = ints.Arg("modules",
+		strings.Join([]string{"input files without .sysl extension and with leading /",
+			"eg: /project_dir/my_models",
+			"combine with --root if needed"}, "\n")).String()
+	returnValues.exclude = ints.Flag("exclude", "apps to exclude").Short('e').Strings()
+	returnValues.clustered = ints.Flag("clustered",
+		"group integration components into clusters").Short('c').Default("false").Bool()
+	returnValues.epa = ints.Flag("epa", "produce and EPA integration view").Default("false").Bool()
+	returnValues.loglevel = ints.Flag("log", "log level[debug,info,warn,off]").Default("warn").String()
+	returnValues.verbose = ints.Flag("verbose", "show output").Short('v').Default("false").Bool()
 
-	_, err := ints.Parse(args[1:])
-	if err != nil {
-		log.Errorf("arguments parse error: %v", err)
-	}
-	if level, has := defaultLevel[*loglevel]; has {
-		log.SetLevel(level)
-	}
-	if *plantuml == "" {
-		*plantuml = os.Getenv("SYSL_PLANTUML")
-		if *plantuml == "" {
-			*plantuml = "http://localhost:8080/plantuml"
-		}
-	}
-	log.Infof("root: %s\n", *root)
-	log.Infof("project: %v\n", *project)
-	log.Infof("clustered: %t\n", *clustered)
-	log.Infof("exclude: %s\n", *exclude)
-	log.Infof("epa: %t\n", *epa)
-	log.Infof("title: %s\n", *title)
-	log.Infof("plantuml: %s\n", *plantuml)
-	log.Infof("filter: %s\n", *filter)
-	log.Infof("modules: %s\n", *modules)
-	log.Infof("output: %s\n", *output)
-	log.Infof("loglevel: %s\n", *loglevel)
-
-	r, err := GenerateIntegrations(*root, *title, *output, *project, *filter, *modules, *exclude, *clustered, *epa)
-	if err != nil {
-		return err
-	}
-	for k, v := range r {
-		if *verbose {
-			fmt.Println(k)
-		}
-		err := OutputPlantuml(k, *plantuml, v)
-		if err != nil {
-			return fmt.Errorf("plantuml drawing error for %#v: %v", k, err)
-		}
-	}
-	return nil
+	return returnValues
 }

--- a/sysl2/sysl/ints_test.go
+++ b/sysl2/sysl/ints_test.go
@@ -447,3 +447,25 @@ func TestAllStmts(t *testing.T) {
 	// Then
 	comparePUML(t, expected, result)
 }
+
+func GenerateIntegrationsWithParams(rootModel, title, output, project, filter, modules string,
+	exclude []string,
+	clustered, epa bool,
+	loglevel string,
+	isVerbose bool,
+) (map[string]string, error) {
+	cmdContextParamIntgen := &CmdContextParamIntgen{
+		root:      &rootModel,
+		title:     &title,
+		output:    &output,
+		project:   &project,
+		filter:    &filter,
+		modules:   &modules,
+		exclude:   &exclude,
+		clustered: &clustered,
+		epa:       &epa,
+		loglevel:  &loglevel,
+		isVerbose: &isVerbose,
+	}
+	return GenerateIntegrations(cmdContextParamIntgen)
+}

--- a/sysl2/sysl/ints_test.go
+++ b/sysl2/sysl/ints_test.go
@@ -1,8 +1,6 @@
 package main
 
 import (
-	"bytes"
-	"flag"
 	"io/ioutil"
 	"testing"
 
@@ -10,6 +8,7 @@ import (
 	"github.com/anz-bank/sysl/sysl2/sysl/parse"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"gopkg.in/alecthomas/kingpin.v2"
 )
 
 const plantumlHeader = `''''''''''''''''''''''''''''''''''''''''''
@@ -109,8 +108,9 @@ func TestGenerateIntegrationsWithTestFile(t *testing.T) {
 	}
 
 	// When
-	result, err := GenerateIntegrations(args.rootModel, args.title, args.output,
-		args.project, args.filter, args.modules, args.exclude, args.clustered, args.epa)
+	result, err := GenerateIntegrationsWithParams(args.rootModel, args.title, args.output,
+		args.project, args.filter, args.modules, args.exclude, args.clustered,
+		args.epa, "warn", false)
 	require.NoError(t, err)
 
 	// Then
@@ -129,8 +129,9 @@ func TestGenerateIntegrationsWithTestFileAndFilters(t *testing.T) {
 	expected := map[string]string{}
 
 	// When
-	result, err := GenerateIntegrations(args.rootModel, args.title, args.output,
-		args.project, args.filter, args.modules, args.exclude, args.clustered, args.epa)
+	result, err := GenerateIntegrationsWithParams(args.rootModel, args.title, args.output,
+		args.project, args.filter, args.modules, args.exclude, args.clustered,
+		args.epa, "warn", false)
 	require.NoError(t, err)
 
 	// Then
@@ -150,8 +151,9 @@ func TestGenerateIntegrationsWithImmediatePredecessors(t *testing.T) {
 	}
 
 	// When
-	result, err := GenerateIntegrations(args.rootModel, args.title, args.output,
-		args.project, args.filter, args.modules, args.exclude, args.clustered, args.epa)
+	result, err := GenerateIntegrationsWithParams(args.rootModel, args.title, args.output,
+		args.project, args.filter, args.modules, args.exclude, args.clustered,
+		args.epa, "warn", false)
 	require.NoError(t, err)
 
 	// Then
@@ -172,8 +174,9 @@ func TestGenerateIntegrationsWithExclude(t *testing.T) {
 	}
 
 	// When
-	result, err := GenerateIntegrations(args.rootModel, args.title, args.output,
-		args.project, args.filter, args.modules, args.exclude, args.clustered, args.epa)
+	result, err := GenerateIntegrationsWithParams(args.rootModel, args.title, args.output,
+		args.project, args.filter, args.modules, args.exclude, args.clustered,
+		args.epa, "warn", false)
 	require.NoError(t, err)
 
 	// Then
@@ -194,8 +197,9 @@ func TestGenerateIntegrationsWithPassthrough(t *testing.T) {
 	}
 
 	// When
-	result, err := GenerateIntegrations(args.rootModel, args.title, args.output,
-		args.project, args.filter, args.modules, args.exclude, args.clustered, args.epa)
+	result, err := GenerateIntegrationsWithParams(args.rootModel, args.title, args.output,
+		args.project, args.filter, args.modules, args.exclude, args.clustered,
+		args.epa, "warn", false)
 	require.NoError(t, err)
 
 	// Then
@@ -203,32 +207,18 @@ func TestGenerateIntegrationsWithPassthrough(t *testing.T) {
 }
 
 func TestDoGenerateIntegrations(t *testing.T) {
-	type args struct {
-		flags *flag.FlagSet
-		args  []string
+	args := &intsArg{
+		rootModel: "./tests/",
+		modules:   "indirect_1.sysl",
+		output:    "%(epname).png",
+		project:   "Project",
 	}
-	argsData := []string{"ints"}
-	test := struct {
-		name       string
-		args       args
-		wantStdout string
-		wantStderr string
-	}{
-		"Case-Do generate integrations",
-		args{
-			flag.NewFlagSet(argsData[0], flag.PanicOnError),
-			argsData,
-		},
-		"",
-		"",
-	}
-	t.Run(test.name, func(t *testing.T) {
-		stdout := &bytes.Buffer{}
-		stderr := &bytes.Buffer{}
-		require.Error(t, DoGenerateIntegrations(test.args.args))
-		assert.Equal(t, test.wantStdout, stdout.String())
-		assert.Equal(t, test.wantStderr, stderr.String())
-	})
+	argsData := []string{"sysl", "ints", "--root", args.rootModel, "-o", args.output, "-j", args.project, args.modules}
+	sysl := kingpin.New("sysl", "System Modelling Language Toolkit")
+	configureCmdlineForIntgen(sysl)
+	selectedCommand, err := sysl.Parse(argsData[1:])
+	assert.Nil(t, err, "Cmd line parse failed for sysl ints")
+	assert.Equal(t, selectedCommand, "ints")
 }
 
 func TestGenerateIntegrationsWithCluster(t *testing.T) {
@@ -242,8 +232,9 @@ func TestGenerateIntegrationsWithCluster(t *testing.T) {
 	}
 
 	// When
-	result, err := GenerateIntegrations(args.rootModel, args.title, args.output,
-		args.project, args.filter, args.modules, args.exclude, args.clustered, args.epa)
+	result, err := GenerateIntegrationsWithParams(args.rootModel, args.title, args.output,
+		args.project, args.filter, args.modules, args.exclude, args.clustered,
+		args.epa, "warn", false)
 	require.NoError(t, err)
 
 	expected := map[string]string{
@@ -265,8 +256,9 @@ func TestGenerateIntegrationsWithEpa(t *testing.T) {
 	}
 
 	// When
-	result, err := GenerateIntegrations(args.rootModel, args.title, args.output,
-		args.project, args.filter, args.modules, args.exclude, args.clustered, args.epa)
+	result, err := GenerateIntegrationsWithParams(args.rootModel, args.title, args.output,
+		args.project, args.filter, args.modules, args.exclude, args.clustered,
+		args.epa, "warn", false)
 	require.NoError(t, err)
 
 	expected := map[string]string{
@@ -287,8 +279,9 @@ func TestGenerateIntegrationsWithIndirectArrow(t *testing.T) {
 	}
 
 	// When
-	result, err := GenerateIntegrations(args.rootModel, args.title, args.output,
-		args.project, args.filter, args.modules, args.exclude, args.clustered, args.epa)
+	result, err := GenerateIntegrationsWithParams(args.rootModel, args.title, args.output,
+		args.project, args.filter, args.modules, args.exclude, args.clustered,
+		args.epa, "warn", false)
 	require.NoError(t, err)
 
 	expected := map[string]string{
@@ -315,8 +308,9 @@ func TestGenerateIntegrationsWithRestrictBy(t *testing.T) {
 	}
 
 	// When
-	result, err := GenerateIntegrations(args.rootModel, args.title, args.output,
-		args.project, args.filter, args.modules, args.exclude, args.clustered, args.epa)
+	result, err := GenerateIntegrationsWithParams(args.rootModel, args.title, args.output,
+		args.project, args.filter, args.modules, args.exclude, args.clustered,
+		args.epa, "warn", false)
 	require.NoError(t, err)
 
 	expected := map[string]string{
@@ -343,8 +337,9 @@ func TestGenerateIntegrationsWithFilter(t *testing.T) {
 	}
 
 	// When
-	result, err := GenerateIntegrations(args.rootModel, args.title, args.output,
-		args.project, args.filter, args.modules, args.exclude, args.clustered, args.epa)
+	result, err := GenerateIntegrationsWithParams(args.rootModel, args.title, args.output,
+		args.project, args.filter, args.modules, args.exclude, args.clustered,
+		args.epa, "warn", false)
 	require.NoError(t, err)
 
 	// Then
@@ -361,8 +356,9 @@ func TestGenerateIntegrationWithOrWithoutPassThrough(t *testing.T) {
 	}
 
 	// When
-	result, err := GenerateIntegrations(args.rootModel, args.title, args.output,
-		args.project, args.filter, args.modules, args.exclude, args.clustered, args.epa)
+	result, err := GenerateIntegrationsWithParams(args.rootModel, args.title, args.output,
+		args.project, args.filter, args.modules, args.exclude, args.clustered,
+		args.epa, "warn", false)
 	require.NoError(t, err)
 
 	expected := map[string]string{
@@ -386,8 +382,9 @@ func TestPassthrough2(t *testing.T) {
 	}
 
 	// When
-	result, err := GenerateIntegrations(args.rootModel, args.title, args.output,
-		args.project, args.filter, args.modules, args.exclude, args.clustered, args.epa)
+	result, err := GenerateIntegrationsWithParams(args.rootModel, args.title, args.output,
+		args.project, args.filter, args.modules, args.exclude, args.clustered,
+		args.epa, "warn", false)
 	require.NoError(t, err)
 
 	expected := map[string]string{
@@ -415,8 +412,9 @@ func TestGenerateIntegrationsWithPubSub(t *testing.T) {
 	}
 
 	// When
-	result, err := GenerateIntegrations(args.rootModel, args.title, args.output,
-		args.project, args.filter, args.modules, args.exclude, args.clustered, args.epa)
+	result, err := GenerateIntegrationsWithParams(args.rootModel, args.title, args.output,
+		args.project, args.filter, args.modules, args.exclude, args.clustered,
+		args.epa, "warn", false)
 	require.NoError(t, err)
 
 	expected := map[string]string{
@@ -437,8 +435,9 @@ func TestAllStmts(t *testing.T) {
 	}
 
 	// When
-	result, err := GenerateIntegrations(args.rootModel, args.title, args.output,
-		args.project, args.filter, args.modules, args.exclude, args.clustered, args.epa)
+	result, err := GenerateIntegrationsWithParams(args.rootModel, args.title, args.output,
+		args.project, args.filter, args.modules, args.exclude, args.clustered,
+		args.epa, "warn", false)
 	require.NoError(t, err)
 
 	expected := map[string]string{

--- a/sysl2/sysl/seqs_test.go
+++ b/sysl2/sysl/seqs_test.go
@@ -400,7 +400,7 @@ func TestDoGenerateSequenceDiagrams(t *testing.T) {
 	}
 	argsData := []string{"sysl", "sd", "--root", args.rootModel, "-o", args.output, "-a", args.apps[0], args.modules}
 	sysl := kingpin.New("sysl", "System Modelling Language Toolkit")
-	configureCmdlineForSeqdiaggen(sysl)
+	configureCmdlineForSeqgen(sysl)
 	selectedCommand, err := sysl.Parse(argsData[1:])
 	assert.Nil(t, err, "Cmd line parse failed for sysl sd")
 	assert.Equal(t, selectedCommand, "sd")
@@ -508,4 +508,29 @@ end box`
 	boxPresent, err = regexp.MatchString(boxCloud, result["SEQ-Two.png"])
 	assert.Nil(t, err, "Error compiling regular expression")
 	assert.True(t, boxPresent)
+}
+
+func DoConstructSequenceDiagramsWithParams(
+	rootModel, endpointFormat, appFormat, title, output, modules string,
+	endpoints, apps []string,
+	blackboxes [][]string,
+	group string,
+	loglevel string,
+	isVerbose bool,
+) (map[string]string, error) {
+	cmdContextParamSeqgen := &CmdContextParamSeqgen{
+		root:           &rootModel,
+		endpointFormat: &endpointFormat,
+		appFormat:      &appFormat,
+		title:          &title,
+		output:         &output,
+		modulesFlag:    &modules,
+		endpointsFlag:  &endpoints,
+		appsFlag:       &apps,
+		blackboxes:     &blackboxes,
+		loglevel:       &loglevel,
+		group:          &group,
+		isVerbose:      &isVerbose,
+	}
+	return DoConstructSequenceDiagrams(cmdContextParamSeqgen)
 }

--- a/sysl2/sysl/seqs_test.go
+++ b/sysl2/sysl/seqs_test.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"flag"
 	"regexp"
 	"strings"
 	"testing"
@@ -9,6 +8,7 @@ import (
 	"github.com/anz-bank/sysl/sysl2/sysl/parse"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"gopkg.in/alecthomas/kingpin.v2"
 )
 
 func TestGenerateSequenceDiag(t *testing.T) {
@@ -215,8 +215,9 @@ func TestDoConstructSequenceDiagramsNoSyslSdFiltersWithoutEndpoints(t *testing.T
 	expected := make(map[string]string)
 
 	// When
-	result, err := DoConstructSequenceDiagrams(args.rootModel, args.endpointFormat, args.appFormat,
-		args.title, args.output, args.modules, args.endpoints, args.apps, args.blackboxes, args.groupbox)
+	result, err := DoConstructSequenceDiagramsWithParams(args.rootModel, args.endpointFormat, args.appFormat,
+		args.title, args.output, args.modules, args.endpoints, args.apps, args.blackboxes,
+		args.groupbox, "warn", false)
 	require.NoError(t, err)
 
 	// Then
@@ -231,8 +232,9 @@ func TestDoConstructSequenceDiagramsMissingFile(t *testing.T) {
 	}
 
 	// When
-	_, err := DoConstructSequenceDiagrams(args.rootModel, args.endpointFormat, args.appFormat,
-		args.title, args.output, args.modules, args.endpoints, args.apps, args.blackboxes, args.groupbox)
+	_, err := DoConstructSequenceDiagramsWithParams(args.rootModel, args.endpointFormat, args.appFormat,
+		args.title, args.output, args.modules, args.endpoints, args.apps, args.blackboxes,
+		args.groupbox, "warn", false)
 	assert.Error(t, err)
 }
 
@@ -247,8 +249,9 @@ func TestDoConstructSequenceDiagramsNoSyslSdFilters(t *testing.T) {
 
 	// When
 	assert.Panics(t, func() {
-		_, err := DoConstructSequenceDiagrams(args.rootModel, args.endpointFormat, args.appFormat,
-			args.title, args.output, args.modules, args.endpoints, args.apps, args.blackboxes, args.groupbox)
+		_, err := DoConstructSequenceDiagramsWithParams(args.rootModel, args.endpointFormat, args.appFormat,
+			args.title, args.output, args.modules, args.endpoints, args.apps, args.blackboxes,
+			args.groupbox, "warn", false)
 		assert.NoError(t, err)
 	})
 }
@@ -293,8 +296,9 @@ deactivate _0
 	}
 
 	// When
-	result, err := DoConstructSequenceDiagrams(args.rootModel, args.endpointFormat, args.appFormat,
-		args.title, args.output, args.modules, args.endpoints, args.apps, args.blackboxes, args.groupbox)
+	result, err := DoConstructSequenceDiagramsWithParams(args.rootModel, args.endpointFormat, args.appFormat,
+		args.title, args.output, args.modules, args.endpoints, args.apps, args.blackboxes,
+		args.groupbox, "warn", false)
 	require.NoError(t, err)
 
 	// Then
@@ -338,8 +342,9 @@ activate _0
 deactivate _0
 @enduml
 `
-	result, err := DoConstructSequenceDiagrams(args.rootModel, args.endpointFormat, args.appFormat,
-		args.title, args.output, args.modules, args.endpoints, args.apps, args.blackboxes, args.groupbox)
+	result, err := DoConstructSequenceDiagramsWithParams(args.rootModel, args.endpointFormat, args.appFormat,
+		args.title, args.output, args.modules, args.endpoints, args.apps, args.blackboxes,
+		args.groupbox, "warn", false)
 	require.NoError(t, err)
 	expected := map[string]string{"tests/call.png": expectContent}
 	// Then
@@ -377,8 +382,9 @@ activate _0
 	}
 
 	// When
-	result, err := DoConstructSequenceDiagrams(args.rootModel, args.endpointFormat, args.appFormat,
-		args.title, args.output, args.modules, args.endpoints, args.apps, args.blackboxes, args.groupbox)
+	result, err := DoConstructSequenceDiagramsWithParams(args.rootModel, args.endpointFormat, args.appFormat,
+		args.title, args.output, args.modules, args.endpoints, args.apps, args.blackboxes,
+		args.groupbox, "warn", false)
 	require.NoError(t, err)
 
 	// Then
@@ -386,30 +392,22 @@ activate _0
 }
 
 func TestDoGenerateSequenceDiagrams(t *testing.T) {
-	type args struct {
-		flags *flag.FlagSet
-		args  []string
+	args := &sdArgs{
+		rootModel: "./tests/",
+		modules:   "sequence_diagram_complex_format.sysl",
+		output:    "%(epname).png",
+		apps:      []string{"Project"},
 	}
-	argsData := []string{"sd"}
-	tests := []struct {
-		name string
-		args args
-	}{
-		{
-			"Case-Do generate sequence diagrams",
-			args{
-				flag.NewFlagSet(argsData[0], flag.PanicOnError),
-				argsData,
-			},
-		},
-	}
-	for _, tt := range tests {
-		tt := tt
-		t.Run(tt.name, func(t *testing.T) {
-			// TODO: Figure out why this is broken.
-			// require.NoError(t, DoGenerateSequenceDiagrams(tt.args.args))
-		})
-	}
+	argsData := []string{"sysl", "sd", "--root", args.rootModel, "-o", args.output, "-a", args.apps[0], args.modules}
+	sysl := kingpin.New("sysl", "System Modelling Language Toolkit")
+	configureCmdlineForSeqdiaggen(sysl)
+	selectedCommand, err := sysl.Parse(argsData[1:])
+	assert.Nil(t, err, "Cmd line parse failed for sysl sd")
+	assert.Equal(t, selectedCommand, "sd")
+}
+
+func TestDoConstructSequenceDiagramsWithParams(t *testing.T) {
+
 }
 
 func TestDoConstructSequenceDiagramWithGroupingCommandline(t *testing.T) {
@@ -433,8 +431,9 @@ end box`
 	participant _\d
 	participant _\d
 end box`
-	result, err := DoConstructSequenceDiagrams(args.rootModel, args.endpointFormat, args.appFormat,
-		args.title, args.output, args.modules, args.endpoints, args.apps, args.blackboxes, args.groupbox)
+	result, err := DoConstructSequenceDiagramsWithParams(args.rootModel, args.endpointFormat, args.appFormat,
+		args.title, args.output, args.modules, args.endpoints, args.apps, args.blackboxes,
+		args.groupbox, "warn", false)
 	require.NoError(t, err)
 
 	// Then
@@ -468,8 +467,9 @@ end box`
 	participant _\d
 	participant _\d
 end box`
-	result, err := DoConstructSequenceDiagrams(args.rootModel, args.endpointFormat, args.appFormat,
-		args.title, args.output, args.modules, args.endpoints, args.apps, args.blackboxes, args.groupbox)
+	result, err := DoConstructSequenceDiagramsWithParams(args.rootModel, args.endpointFormat, args.appFormat,
+		args.title, args.output, args.modules, args.endpoints, args.apps, args.blackboxes,
+		args.groupbox, "warn", false)
 	require.NoError(t, err)
 
 	// Then
@@ -499,8 +499,9 @@ func TestDoConstructSequenceDiagramWithOneEntityBox(t *testing.T) {
 	boxCloud := `box "cloud" #LightBlue
 	participant _\d
 end box`
-	result, err := DoConstructSequenceDiagrams(args.rootModel, args.endpointFormat, args.appFormat,
-		args.title, args.output, args.modules, args.endpoints, args.apps, args.blackboxes, args.groupbox)
+	result, err := DoConstructSequenceDiagramsWithParams(args.rootModel, args.endpointFormat, args.appFormat,
+		args.title, args.output, args.modules, args.endpoints, args.apps, args.blackboxes,
+		args.groupbox, "warn", false)
 	require.NoError(t, err)
 
 	// Then

--- a/sysl2/sysl/sysl_test.go
+++ b/sysl2/sysl/sysl_test.go
@@ -152,8 +152,8 @@ func TestMain2WithGroupingParamsCommandline(t *testing.T) {
 
 func TestMain2WithGroupingParamsSysl(t *testing.T) {
 	testHook := test.NewGlobal()
-	main2([]string{"sysl", "sd", "-g", "location", "-o", "%(epname).png", "tests/groupby.sysl", "-a", "Project :: Sequences"},
-		main3)
+	main2([]string{"sysl", "sd", "-g", "location", "-o", "%(epname).png", "tests/groupby.sysl", "-a",
+		"Project :: Sequences"}, main3)
 	for _, filename := range []string{"SEQ-One.png", "SEQ-Two.png"} {
 		_, err := os.Stat(filename)
 		assert.NoError(t, err)

--- a/sysl2/sysl/sysl_test.go
+++ b/sysl2/sysl/sysl_test.go
@@ -37,14 +37,14 @@ func TestMain2JSON(t *testing.T) {
 }
 
 func testMain2Stdout(t *testing.T, args []string, golden string) {
-	rc := main2(append([]string{"sysl", "pb", "-o", "test"}, args...), main3)
+	rc := main2(append([]string{"sysl", "pb", "-o", " - "}, args...), main3)
 	assert.Zero(t, rc)
 
 	_, err := ioutil.ReadFile(golden)
 	require.NoError(t, err)
 
 	_, err = os.Stat("-")
-	assert.True(t, os.IsNotExist(err), "Should not have created file 'test'")
+	assert.True(t, os.IsNotExist(err), "Should not have created file '-'")
 }
 
 func TestMain2TextPBStdout(t *testing.T) {
@@ -56,7 +56,7 @@ func TestMain2JSONStdout(t *testing.T) {
 }
 
 func TestMain2BadMode(t *testing.T) {
-	rc := main2([]string{"sysl", "pb", "-o", "-", "-mode", "BAD", "tests/args.sysl"}, main3)
+	rc := main2([]string{"sysl", "pb", "-o", " - ", "--mode", "BAD", "tests/args.sysl"}, main3)
 	assert.NotZero(t, rc)
 
 	_, err := os.Stat("-")
@@ -64,7 +64,7 @@ func TestMain2BadMode(t *testing.T) {
 }
 
 func TestMain2BadLog(t *testing.T) {
-	rc := main2([]string{"sysl", "pb", "-o", "-", "-log", "BAD", "tests/args.sysl"}, main3)
+	rc := main2([]string{"sysl", "pb", "-o", "-", "--log", "BAD", "tests/args.sysl"}, main3)
 	assert.NotZero(t, rc)
 
 	_, err := os.Stat("-")
@@ -184,5 +184,15 @@ func TestMain2WithTestPbJsonMode(t *testing.T) {
 
 func TestMain2WithTestPbMode(t *testing.T) {
 	ret := main2([]string{"sysl", "pb", "--mode", "json", "-o", "tests/callout", "tests/call.sysl"}, main3)
+	assert.True(t, ret == 0)
+}
+
+func TestMain2WithTestPbJsonConsole(t *testing.T) {
+	ret := main2([]string{"sysl", "pb", "--mode", "textpb", "-o", " - ", "tests/call.sysl", "-v"}, main3)
+	assert.True(t, ret == 0)
+}
+
+func TestMain2WithTestPbConsole(t *testing.T) {
+	ret := main2([]string{"sysl", "pb", "--mode", "json", "-o", " - ", "tests/call.sysl", "-v"}, main3)
 	assert.True(t, ret == 0)
 }

--- a/sysl2/sysl/sysl_test.go
+++ b/sysl2/sysl/sysl_test.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/anz-bank/sysl/sysl2/sysl/parse"
 	"github.com/anz-bank/sysl/sysl2/sysl/testutil"
-	log "github.com/sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"github.com/sirupsen/logrus/hooks/test"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -15,8 +15,8 @@ import (
 
 func testMain2(t *testing.T, args []string, golden string) {
 	if output := testutil.TempFilename(t, "", "sysl-TestTextPBNilModule-*.textpb"); output != "" {
-		rc := main2(append([]string{"sysl", "-o", output}, args...), main3)
-		require.Zero(t, rc)
+		rc := main2(append([]string{"sysl", "pb", "-o", output}, args...), main3)
+		assert.Zero(t, rc)
 
 		actual, err := ioutil.ReadFile(output)
 		assert.NoError(t, err)
@@ -33,18 +33,18 @@ func TestMain2TextPB(t *testing.T) {
 }
 
 func TestMain2JSON(t *testing.T) {
-	testMain2(t, []string{"-mode", "json", "tests/args.sysl"}, "tests/args.sysl.golden.json")
+	testMain2(t, []string{"--mode", "json", "tests/args.sysl"}, "tests/args.sysl.golden.json")
 }
 
 func testMain2Stdout(t *testing.T, args []string, golden string) {
-	rc := main2(append([]string{"sysl", "-o", "-"}, args...), main3)
+	rc := main2(append([]string{"sysl", "pb", "-o", "test"}, args...), main3)
 	assert.Zero(t, rc)
 
 	_, err := ioutil.ReadFile(golden)
 	require.NoError(t, err)
 
 	_, err = os.Stat("-")
-	assert.True(t, os.IsNotExist(err), "Should not have created file '-'")
+	assert.True(t, os.IsNotExist(err), "Should not have created file 'test'")
 }
 
 func TestMain2TextPBStdout(t *testing.T) {
@@ -52,11 +52,11 @@ func TestMain2TextPBStdout(t *testing.T) {
 }
 
 func TestMain2JSONStdout(t *testing.T) {
-	testMain2Stdout(t, []string{"-mode", "json", "tests/args.sysl"}, "tests/args.sysl.golden.json")
+	testMain2Stdout(t, []string{"--mode", "json", "tests/args.sysl"}, "tests/args.sysl.golden.json")
 }
 
 func TestMain2BadMode(t *testing.T) {
-	rc := main2([]string{"sysl", "-o", "-", "-mode", "BAD", "tests/args.sysl"}, main3)
+	rc := main2([]string{"sysl", "pb", "-o", "-", "-mode", "BAD", "tests/args.sysl"}, main3)
 	assert.NotZero(t, rc)
 
 	_, err := os.Stat("-")
@@ -64,7 +64,7 @@ func TestMain2BadMode(t *testing.T) {
 }
 
 func TestMain2BadLog(t *testing.T) {
-	rc := main2([]string{"sysl", "-o", "-", "-log", "BAD", "tests/args.sysl"}, main3)
+	rc := main2([]string{"sysl", "pb", "-o", "-", "-log", "BAD", "tests/args.sysl"}, main3)
 	assert.NotZero(t, rc)
 
 	_, err := os.Stat("-")
@@ -88,26 +88,26 @@ func TestMain2SeqdiagWithImpossibleOutput(t *testing.T) {
 
 func TestMain2WithBlackboxParams(t *testing.T) {
 	testHook := test.NewGlobal()
-	main2([]string{"sd", "-s", "MobileApp <- Login", "-o", "tests/call.png", "-b", "Server <- DB=call to database",
+	main2([]string{"sysl", "sd", "-s", "MobileApp <- Login", "-o", "tests/call.png", "-b", "Server <- DB=call to database",
 		"-b", "Server <- Login=call to database", "tests/call.sysl"}, main3)
-	assert.Equal(t, log.WarnLevel, testHook.LastEntry().Level)
+	assert.Equal(t, logrus.WarnLevel, testHook.LastEntry().Level)
 	assert.Equal(t, "blackbox 'Server <- DB' passed on commandline not hit\n", testHook.LastEntry().Message)
 	testHook.Reset()
 }
 
 func TestMain2WithBlackboxParamsFaultyArguments(t *testing.T) {
 	testHook := test.NewGlobal()
-	main2([]string{"sd", "-s", "MobileApp <- Login", "-o", "tests/call.png", "-b", "Server <- DB",
+	main2([]string{"sysl", "sd", "-s", "MobileApp <- Login", "-o", "tests/call.png", "-b", "Server <- DB",
 		"-b", "Server <- Login", "tests/call.sysl"}, main3)
-	assert.Equal(t, log.ErrorLevel, testHook.LastEntry().Level)
+	assert.Equal(t, logrus.ErrorLevel, testHook.LastEntry().Level)
 	assert.Equal(t, "expected KEY=VALUE got 'Server <- DB'", testHook.LastEntry().Message)
 	testHook.Reset()
 }
 
 func TestMain2WithBlackboxSysl(t *testing.T) {
 	testHook := test.NewGlobal()
-	main2([]string{"sd", "-o", "%(epname).png", "tests/blackbox.sysl", "-a", "Project :: Sequences"}, main3)
-	assert.Equal(t, log.WarnLevel, testHook.LastEntry().Level)
+	main2([]string{"sysl", "sd", "-o", "%(epname).png", "tests/blackbox.sysl", "-a", "Project :: Sequences"}, main3)
+	assert.Equal(t, logrus.WarnLevel, testHook.LastEntry().Level)
 	assert.Equal(t, "blackbox 'SomeApp <- AppEndpoint' not hit in app 'Project :: Sequences'\n",
 		testHook.Entries[len(testHook.Entries)-1].Message)
 	assert.Equal(t, "blackbox 'SomeApp <- BarEndpoint1' not hit in app 'Project :: Sequences :: SEQ-Two'\n",
@@ -119,8 +119,8 @@ func TestMain2WithBlackboxSysl(t *testing.T) {
 
 func TestMain2WithBlackboxSyslEmptyEndpoints(t *testing.T) {
 	testHook := test.NewGlobal()
-	main2([]string{"sd", "-o", "%(epname).png", "tests/blackbox.sysl", "-a", "Project :: Integrations"}, main3)
-	assert.Equal(t, log.ErrorLevel, testHook.LastEntry().Level)
+	main2([]string{"sysl", "sd", "-o", "%(epname).png", "tests/blackbox.sysl", "-a", "Project :: Integrations"}, main3)
+	assert.Equal(t, logrus.ErrorLevel, testHook.LastEntry().Level)
 	assert.Equal(t, "No call statements to build sequence diagram for endpoint PROJECT-E2E", testHook.LastEntry().Message)
 	testHook.Reset()
 }
@@ -130,20 +130,21 @@ func TestMain2Fatal(t *testing.T) {
 	assert.Equal(t, 42, main2(nil, func(_ []string) error {
 		return parse.Exitf(42, "Exit error")
 	}))
-	assert.Equal(t, log.ErrorLevel, testHook.LastEntry().Level)
+	assert.Equal(t, logrus.ErrorLevel, testHook.LastEntry().Level)
 	testHook.Reset()
 }
 
 func TestMain2WithGroupingParamsGroupParamAbsent(t *testing.T) {
 	testHook := test.NewGlobal()
-	main2([]string{"sd", "-s", "MobileApp <- Login", "-g", "-o", "tests/call.png", "tests/call.sysl"}, main3)
-	assert.Equal(t, log.ErrorLevel, testHook.LastEntry().Level)
+	main2([]string{"sysl", "sd", "-s", "MobileApp <- Login", "-g", "-o", "tests/call.png", "tests/call.sysl"}, main3)
+	assert.Equal(t, logrus.ErrorLevel, testHook.LastEntry().Level)
 	assert.Equal(t, "expected argument for flag '-g'", testHook.LastEntry().Message)
 	testHook.Reset()
 }
 
 func TestMain2WithGroupingParamsCommandline(t *testing.T) {
-	main2([]string{"sd", "-s", "MobileApp <- Login", "-g", "owner", "-o", "tests/call.png", "tests/call.sysl"}, main3)
+	main2([]string{"sysl", "sd", "-s", "MobileApp <- Login", "-g", "owner", "-o", "tests/call.png",
+		"tests/call.sysl"}, main3)
 	_, err := os.Stat("tests/call.png")
 	assert.NoError(t, err)
 	os.Remove("tests/call.png")
@@ -151,13 +152,37 @@ func TestMain2WithGroupingParamsCommandline(t *testing.T) {
 
 func TestMain2WithGroupingParamsSysl(t *testing.T) {
 	testHook := test.NewGlobal()
-	main2([]string{"sd", "-g", "location", "-o", "%(epname).png", "tests/groupby.sysl", "-a", "Project :: Sequences"},
+	main2([]string{"sysl", "sd", "-g", "location", "-o", "%(epname).png", "tests/groupby.sysl", "-a", "Project :: Sequences"},
 		main3)
 	for _, filename := range []string{"SEQ-One.png", "SEQ-Two.png"} {
 		_, err := os.Stat(filename)
 		assert.NoError(t, err)
 		os.Remove(filename)
 	}
-	assert.Equal(t, log.WarnLevel, testHook.LastEntry().Level)
+	assert.Equal(t, logrus.WarnLevel, testHook.LastEntry().Level)
 	assert.Equal(t, "Ignoring groupby passed from command line", testHook.LastEntry().Message)
+}
+
+func TestMain2WithGenerateIntegrations(t *testing.T) {
+	main2([]string{"sysl", "ints", "--root", "./tests/", "-o", "indirect_1.png", "-j", "Project",
+		"indirect_1.sysl"}, main3)
+	_, err2 := os.Stat("indirect_1.png")
+	assert.True(t, err2 == nil)
+}
+
+func TestMain2WithGenerateCode(t *testing.T) {
+	ret := main2([]string{"sysl", "gen", "--root-model", ".", "--model", "tests/model.sysl",
+		"--root-transform", ".", "--transform", "tests/test.gen_multiple_annotations.sysl",
+		"--grammar", "tests/test.gen.g", "--start", "javaFile"}, main3)
+	assert.True(t, ret == 0)
+}
+
+func TestMain2WithTestPbJsonMode(t *testing.T) {
+	ret := main2([]string{"sysl", "pb", "--mode", "textpb", "-o", "tests/callout", "tests/call.sysl"}, main3)
+	assert.True(t, ret == 0)
+}
+
+func TestMain2WithTestPbMode(t *testing.T) {
+	ret := main2([]string{"sysl", "pb", "--mode", "json", "-o", "tests/callout", "tests/call.sysl"}, main3)
+	assert.True(t, ret == 0)
 }

--- a/sysl2/sysl/types.go
+++ b/sysl2/sysl/types.go
@@ -32,3 +32,56 @@ type AppLabeler interface {
 type VarManager interface {
 	UniqueVarForAppName(appName string) string
 }
+
+type CmdContextParamCodegen struct {
+	rootModel     *string
+	model         *string
+	rootTransform *string
+	transform     *string
+	grammar       *string
+	start         *string
+	outDir        *string
+	verbose       *bool
+	loglevel      *string
+}
+
+type CmdContextParamPbgen struct {
+	root     *string
+	output   *string
+	mode     *string
+	modules  *string
+	verbose  *bool
+	loglevel *string
+}
+
+type CmdContextParamSeqgen struct {
+	root           *string
+	endpointFormat *string
+	appFormat      *string
+	title          *string
+	output         *string
+	modulesFlag    *string
+	endpointsFlag  *[]string
+	appsFlag       *[]string
+	blackboxesFlag *map[string]string
+	blackboxes     *[][]string
+	plantuml       *string
+	loglevel       *string
+	verbose        *bool
+	group          *string
+}
+
+type CmdContextParamIntgen struct {
+	root      *string
+	title     *string
+	output    *string
+	project   *string
+	filter    *string
+	modules   *string
+	exclude   *[]string
+	clustered *bool
+	epa       *bool
+	plantuml  *string
+	verbose   *bool
+	loglevel  *string
+}

--- a/sysl2/sysl/types.go
+++ b/sysl2/sysl/types.go
@@ -41,17 +41,17 @@ type CmdContextParamCodegen struct {
 	grammar       *string
 	start         *string
 	outDir        *string
-	verbose       *bool
+	isVerbose     *bool
 	loglevel      *string
 }
 
 type CmdContextParamPbgen struct {
-	root     *string
-	output   *string
-	mode     *string
-	modules  *string
-	verbose  *bool
-	loglevel *string
+	root      *string
+	output    *string
+	mode      *string
+	modules   *string
+	isVerbose *bool
+	loglevel  *string
 }
 
 type CmdContextParamSeqgen struct {
@@ -67,7 +67,7 @@ type CmdContextParamSeqgen struct {
 	blackboxes     *[][]string
 	plantuml       *string
 	loglevel       *string
-	verbose        *bool
+	isVerbose      *bool
 	group          *string
 }
 
@@ -82,6 +82,6 @@ type CmdContextParamIntgen struct {
 	clustered *bool
 	epa       *bool
 	plantuml  *string
-	verbose   *bool
+	isVerbose *bool
 	loglevel  *string
 }

--- a/test-gosysl.bat
+++ b/test-gosysl.bat
@@ -3,7 +3,7 @@ SETLOCAL EnableDelayedExpansion
 
 set ROOT=sysl2\sysl\tests
 for /R %ROOT% %%f in (*.sysl) do (
-	dist\gosysl.exe -mode textpb -root %ROOT% -o %ROOT%\%%~nf.win.txt -log debug /%%~nf.sysl || exit /b !errorlevel!
+	dist\gosysl.exe pb --mode textpb --root %ROOT% -o %ROOT%\%%~nf.win.txt --log debug /%%~nf.sysl || exit /b !errorlevel!
 )
 
 del sysl2\sysl\tests\*.win.txt

--- a/test-gosysl.sh
+++ b/test-gosysl.sh
@@ -4,7 +4,7 @@ set -e
 ROOT="sysl2/sysl/tests"
 for f in $ROOT/*.sysl; do
  f=`basename $f`
- $GOPATH/bin/sysl -mode textpb -root $ROOT -o $ROOT/$f.out.txt /$f
+ $GOPATH/bin/sysl pb --mode textpb --root $ROOT -o $ROOT/$f.out.txt /$f
 done;
 
 rm $ROOT/*.out.txt

--- a/test-gosysl.sh
+++ b/test-gosysl.sh
@@ -4,16 +4,16 @@ set -e
 ROOT="sysl2/sysl/tests"
 for f in $ROOT/*.sysl; do
  f=`basename $f`
- $GOPATH/bin/sysl pb --mode textpb --root $ROOT -o $ROOT/$f.out.txt /$f
+ $GOPATH/bin/sysl pb --mode textpb --root $ROOT -o $ROOT/$f.out.txt /$f -v
 done;
 
 rm $ROOT/*.out.txt
 
-$GOPATH/bin/sysl sd -a 'Project' $ROOT/sequence_diagram_project.sysl
+$GOPATH/bin/sysl sd -a 'Project' $ROOT/sequence_diagram_project.sysl -v
 rm _.png
 
-$GOPATH/bin/sysl sd -s 'WebFrontend <- RequestProfile' -o sd.png $ROOT/sequence_diagram_project.sysl
+$GOPATH/bin/sysl sd -s 'WebFrontend <- RequestProfile' -o sd.png $ROOT/sequence_diagram_project.sysl -v
 rm sd.png
 
-$GOPATH/bin/sysl ints -j 'Project' $ROOT/integration_test.sysl
+$GOPATH/bin/sysl ints -j 'Project' $ROOT/integration_test.sysl -v
 rm _.png

--- a/test-gosysl.sh
+++ b/test-gosysl.sh
@@ -9,14 +9,11 @@ done;
 
 rm $ROOT/*.out.txt
 
-ln -s $GOPATH/bin/sysl $GOPATH/bin/sd
-$GOPATH/bin/sd -a 'Project' $ROOT/sequence_diagram_project.sysl
+$GOPATH/bin/sysl sd -a 'Project' $ROOT/sequence_diagram_project.sysl
 rm _.png
-$GOPATH/bin/sd -s 'WebFrontend <- RequestProfile' -o sd.png $ROOT/sequence_diagram_project.sysl
-rm sd.png
-rm $GOPATH/bin/sd
 
-ln -s $GOPATH/bin/sysl $GOPATH/bin/ints
-$GOPATH/bin/ints -j 'Project' $ROOT/integration_test.sysl
+$GOPATH/bin/sysl sd -s 'WebFrontend <- RequestProfile' -o sd.png $ROOT/sequence_diagram_project.sysl
+rm sd.png
+
+$GOPATH/bin/sysl ints -j 'Project' $ROOT/integration_test.sysl
 rm _.png
-rm $GOPATH/bin/ints


### PR DESCRIPTION
Fixes # .

Changes proposed in this pull request:
- Refactor sysl cmd line support, each of the sub-commands such as sd, ints, gen now become a child of the parent Sysl application.
- Merge sysl binary, we have only one sysl binary and one sysl command line application from now on.

@anz-bank/sysl-developers
