### PR TITLE
Update README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -41,7 +41,7 @@ Now you can execute Sysl on the command line with ::
 See ``sysl --help`` and ``reljam --help`` for more options.
 
 Docker
-~~~~~
+~~~~~~
 Install `Docker <https://docs.docker.com/install/>`_ and pull the Docker Image with ::
 
   > docker pull anzbank/sysl


### PR DESCRIPTION
PyPI upload fails with rst rendering error. Following issue was found and README is updated accordingly to fix it.

```
The project's long_description has invalid markup which will not be rendered on PyPI. The following syntax errors were detected:
line 44: Warning: Title underline too short.

Docker
~~~~~
Checking distribution dist/sysl-0.2.9-py2-none-any.whl: warning: `long_description_content_type` missing.  defaulting to `text/x-rst`.
Failed
The project's long_description has invalid markup which will not be rendered on PyPI. The following syntax errors were detected:
line 44: Warning: Title underline too short.
```