### PR TITLE
Add version info into gosysl binary

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -57,9 +57,9 @@ script:
 - if [[ ( "$TRAVIS_OS_NAME" == "linux" ) ]]; then gradle test -b test/java/build.gradle; fi
 - go test -coverprofile=coverage.txt -covermode=atomic github.com/anz-bank/sysl/...
 - npm test --prefix sysl2/sysl/sysl_js
-- GOOS=darwin GOARCH=amd64 go build -o gosysl/gosysl-darwin github.com/anz-bank/sysl/sysl2/sysl
-- GOOS=linux GOARCH=amd64 go build -o gosysl/gosysl-linux github.com/anz-bank/sysl/sysl2/sysl
-- go install github.com/anz-bank/sysl/sysl2/sysl
+- GOOS=darwin GOARCH=amd64 go build -o gosysl/gosysl-darwin -ldflags "-X main.Version=${TRAVIS_TAG:1}" github.com/anz-bank/sysl/sysl2/sysl
+- GOOS=linux GOARCH=amd64 go build -o gosysl/gosysl-linux -ldflags "-X main.Version=${TRAVIS_TAG:1}" github.com/anz-bank/sysl/sysl2/sysl
+- go install -ldflags "-X main.Version=${TRAVIS_TAG:1}" github.com/anz-bank/sysl/sysl2/sysl
 - bash test-gosysl.sh
 
 addons:

--- a/sysl2/sysl/sysl.go
+++ b/sysl2/sysl/sysl.go
@@ -15,12 +15,17 @@ import (
 	"gopkg.in/alecthomas/kingpin.v2"
 )
 
+// Version contains the sysl binary version
+//nolint:gochecknoglobals
+var Version = "unspecified"
+
 const debug string = "debug"
 
 // main3 is the real main function. It takes its output streams and command-line
 // arguments as parameters to support testability.
 func main3(args []string, fs afero.Fs, logger *logrus.Logger) error {
 	sysl := kingpin.New("sysl", "System Modelling Language Toolkit")
+	sysl.Version(Version)
 	flagmap := map[string][]string{}
 	textpbParams := configureCmdlineForPb(sysl, flagmap)
 	codegenParams := configureCmdlineForCodegen(sysl, flagmap)

--- a/test-gosysl.sh
+++ b/test-gosysl.sh
@@ -17,3 +17,10 @@ rm sd.png
 
 $GOPATH/bin/sysl ints -j 'Project' $ROOT/integration_test.sysl -v
 rm _.png
+
+version=`$GOPATH/bin/sysl --version 2>&1 >/dev/null`
+if [[ ${version} = "unspecified" ]]; then
+    echo "version is unspecified"
+    exit 1
+fi
+echo "gosysl version is ${version}"


### PR DESCRIPTION
Fixes #286 .

Changes proposed in this pull request:
- Add version info into sysl binary so that `sysl --version` will show the binary version

@anz-bank/sysl-developers
