### PR TITLE
go get entire tree in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -49,7 +49,7 @@ env:
 install:
 - pip install flake8==3.5.0
 - pip install . pytest
-- go get -t -v github.com/anz-bank/sysl/sysl2/sysl
+- go get -t -v github.com/anz-bank/sysl/...
 - npm install --prefix sysl2/sysl/sysl_js
 script:
 - flake8


### PR DESCRIPTION
Travis currently does:
```bash
go get -t -v github.com/anz-bank/sysl/sysl2/sysl
```
but then does:
```bash
go test … github.com/anz-bank/sysl/...
```
If any packages used for testing aren't a direct dependency of `…/sysl2/sysl`, some tests will fail.