### PR TITLE
Reduce global state

### DIFF
--- a/sysl2/codegen/golang/ast_helpers.go
+++ b/sysl2/codegen/golang/ast_helpers.go
@@ -5,8 +5,7 @@ import (
 	"regexp"
 )
 
-//nolint:gochecknoglobals
-var idRE = regexp.MustCompile(`^[\pL_][\pL_\pN]*$`)
+var idRE = regexp.MustCompile(`^[\pL_][\pL_\pN]*$`) //nolint:gochecknoglobals
 
 // ArrayN creates a `[n]elt` ArrayType.
 func ArrayN(n int, elt Expr) *ArrayType {

--- a/sysl2/sysl/grammar/sysl_lexer.go
+++ b/sysl2/sysl/grammar/sysl_lexer.go
@@ -1049,18 +1049,8 @@ const (
 	SyslLexerVIEW_TRANSFORM
 )
 
-var spaces int
-var linenum int
-var in_sq_brackets int
-var parens int
-
-var gotNewLine bool
-var gotHttpVerb bool
-var gotView bool
-var prevTokenIndex = -1
-
 func (l *SyslLexer) NextToken() antlr.Token {
-	return GetNextToken(l)
+	return getNextToken(l)
 }
 
 func (l *SyslLexer) Action(localctx antlr.RuleContext, ruleIndex, actionIndex int) {
@@ -1139,7 +1129,7 @@ func (l *SyslLexer) Action(localctx antlr.RuleContext, ruleIndex, actionIndex in
 func (l *SyslLexer) HTTP_VERBS_Action(localctx antlr.RuleContext, actionIndex int) {
 	switch actionIndex {
 	case 0:
-		gotHttpVerb = true
+		ls(l).gotHTTPVerb = true
 
 	default:
 		panic("No registered action for: " + fmt.Sprint(actionIndex))
@@ -1148,7 +1138,7 @@ func (l *SyslLexer) HTTP_VERBS_Action(localctx antlr.RuleContext, actionIndex in
 func (l *SyslLexer) VIEW_Action(localctx antlr.RuleContext, actionIndex int) {
 	switch actionIndex {
 	case 1:
-		gotView = true
+		ls(l).gotView = true
 
 	default:
 		panic("No registered action for: " + fmt.Sprint(actionIndex))
@@ -1157,10 +1147,12 @@ func (l *SyslLexer) VIEW_Action(localctx antlr.RuleContext, actionIndex int) {
 func (l *SyslLexer) IMPORT_Action(localctx antlr.RuleContext, actionIndex int) {
 	switch actionIndex {
 	case 2:
-		gotNewLine = true
-		spaces = 0
-		gotHttpVerb = false
-		linenum++
+
+		ls := ls(l)
+		ls.gotNewLine = true
+		ls.spaces = 0
+		ls.gotHTTPVerb = false
+		ls.linenum++
 
 	default:
 		panic("No registered action for: " + fmt.Sprint(actionIndex))
@@ -1169,7 +1161,7 @@ func (l *SyslLexer) IMPORT_Action(localctx antlr.RuleContext, actionIndex int) {
 func (l *SyslLexer) ABSTRACT_Action(localctx antlr.RuleContext, actionIndex int) {
 	switch actionIndex {
 	case 3:
-		gotView = false
+		ls(l).gotView = false
 
 	default:
 		panic("No registered action for: " + fmt.Sprint(actionIndex))
@@ -1178,7 +1170,7 @@ func (l *SyslLexer) ABSTRACT_Action(localctx antlr.RuleContext, actionIndex int)
 func (l *SyslLexer) FORWARD_SLASH_Action(localctx antlr.RuleContext, actionIndex int) {
 	switch actionIndex {
 	case 4:
-		gotHttpVerb = true
+		ls(l).gotHTTPVerb = true
 
 	default:
 		panic("No registered action for: " + fmt.Sprint(actionIndex))
@@ -1187,7 +1179,7 @@ func (l *SyslLexer) FORWARD_SLASH_Action(localctx antlr.RuleContext, actionIndex
 func (l *SyslLexer) SQ_OPEN_Action(localctx antlr.RuleContext, actionIndex int) {
 	switch actionIndex {
 	case 5:
-		in_sq_brackets++
+		ls(l).inSqBrackets++
 
 	default:
 		panic("No registered action for: " + fmt.Sprint(actionIndex))
@@ -1196,7 +1188,7 @@ func (l *SyslLexer) SQ_OPEN_Action(localctx antlr.RuleContext, actionIndex int) 
 func (l *SyslLexer) SQ_CLOSE_Action(localctx antlr.RuleContext, actionIndex int) {
 	switch actionIndex {
 	case 6:
-		in_sq_brackets--
+		ls(l).inSqBrackets--
 
 	default:
 		panic("No registered action for: " + fmt.Sprint(actionIndex))
@@ -1205,10 +1197,12 @@ func (l *SyslLexer) SQ_CLOSE_Action(localctx antlr.RuleContext, actionIndex int)
 func (l *SyslLexer) EMPTY_COMMENT_Action(localctx antlr.RuleContext, actionIndex int) {
 	switch actionIndex {
 	case 7:
-		gotNewLine = true
-		spaces = 0
-		gotHttpVerb = false
-		linenum++
+
+		ls := ls(l)
+		ls.gotNewLine = true
+		ls.spaces = 0
+		ls.gotHTTPVerb = false
+		ls.linenum++
 
 	default:
 		panic("No registered action for: " + fmt.Sprint(actionIndex))
@@ -1217,10 +1211,12 @@ func (l *SyslLexer) EMPTY_COMMENT_Action(localctx antlr.RuleContext, actionIndex
 func (l *SyslLexer) EMPTY_LINE_Action(localctx antlr.RuleContext, actionIndex int) {
 	switch actionIndex {
 	case 8:
-		gotNewLine = true
-		spaces = 0
-		gotHttpVerb = false
-		linenum++
+
+		ls := ls(l)
+		ls.gotNewLine = true
+		ls.spaces = 0
+		ls.gotHTTPVerb = false
+		ls.linenum++
 
 	default:
 		panic("No registered action for: " + fmt.Sprint(actionIndex))
@@ -1229,10 +1225,12 @@ func (l *SyslLexer) EMPTY_LINE_Action(localctx antlr.RuleContext, actionIndex in
 func (l *SyslLexer) INDENTED_COMMENT_Action(localctx antlr.RuleContext, actionIndex int) {
 	switch actionIndex {
 	case 9:
-		gotNewLine = true
-		spaces = 0
-		gotHttpVerb = false
-		linenum++
+
+		ls := ls(l)
+		ls.gotNewLine = true
+		ls.spaces = 0
+		ls.gotHTTPVerb = false
+		ls.linenum++
 
 	default:
 		panic("No registered action for: " + fmt.Sprint(actionIndex))
@@ -1241,13 +1239,15 @@ func (l *SyslLexer) INDENTED_COMMENT_Action(localctx antlr.RuleContext, actionIn
 func (l *SyslLexer) NEWLINE_Action(localctx antlr.RuleContext, actionIndex int) {
 	switch actionIndex {
 	case 10:
-		gotNewLine = true
-		gotHttpVerb = false
-		spaces = 0
-		linenum++
+
+		ls := ls(l)
+		ls.gotNewLine = true
+		ls.gotHTTPVerb = false
+		ls.spaces = 0
+		ls.linenum++
 
 	case 11:
-		if gotView {
+		if ls(l).gotView {
 			l.PushMode(SyslLexerVIEW_TRANSFORM)
 		}
 
@@ -1258,7 +1258,7 @@ func (l *SyslLexer) NEWLINE_Action(localctx antlr.RuleContext, actionIndex int) 
 func (l *SyslLexer) WS_Action(localctx antlr.RuleContext, actionIndex int) {
 	switch actionIndex {
 	case 12:
-		spaces = calcSpaces(l.GetText())
+		ls(l).spaces = calcSpaces(l.GetText())
 
 	default:
 		panic("No registered action for: " + fmt.Sprint(actionIndex))
@@ -1270,7 +1270,7 @@ func (l *SyslLexer) TEXT_VALUE_Action(localctx antlr.RuleContext, actionIndex in
 		l.SetType(SyslLexerName)
 
 	case 14:
-		l.SetText(TrimText(l))
+		l.SetText(trimText(l))
 
 	default:
 		panic("No registered action for: " + fmt.Sprint(actionIndex))
@@ -1279,10 +1279,12 @@ func (l *SyslLexer) TEXT_VALUE_Action(localctx antlr.RuleContext, actionIndex in
 func (l *SyslLexer) NEWLINE_2_Action(localctx antlr.RuleContext, actionIndex int) {
 	switch actionIndex {
 	case 15:
-		gotNewLine = true
-		gotHttpVerb = false
-		spaces = 0
-		linenum++
+
+		ls := ls(l)
+		ls.gotNewLine = true
+		ls.gotHTTPVerb = false
+		ls.spaces = 0
+		ls.linenum++
 
 	default:
 		panic("No registered action for: " + fmt.Sprint(actionIndex))
@@ -1300,10 +1302,12 @@ func (l *SyslLexer) E_NativeDataTypes_Action(localctx antlr.RuleContext, actionI
 func (l *SyslLexer) E_INDENTED_COMMENT_Action(localctx antlr.RuleContext, actionIndex int) {
 	switch actionIndex {
 	case 17:
-		gotNewLine = true
-		spaces = 0
-		gotHttpVerb = false
-		linenum++
+
+		ls := ls(l)
+		ls.gotNewLine = true
+		ls.spaces = 0
+		ls.gotHTTPVerb = false
+		ls.linenum++
 
 	default:
 		panic("No registered action for: " + fmt.Sprint(actionIndex))
@@ -1312,7 +1316,7 @@ func (l *SyslLexer) E_INDENTED_COMMENT_Action(localctx antlr.RuleContext, action
 func (l *SyslLexer) E_OPEN_PAREN_Action(localctx antlr.RuleContext, actionIndex int) {
 	switch actionIndex {
 	case 18:
-		parens++
+		ls(l).parens++
 
 	default:
 		panic("No registered action for: " + fmt.Sprint(actionIndex))
@@ -1321,7 +1325,7 @@ func (l *SyslLexer) E_OPEN_PAREN_Action(localctx antlr.RuleContext, actionIndex 
 func (l *SyslLexer) E_CLOSE_PAREN_Action(localctx antlr.RuleContext, actionIndex int) {
 	switch actionIndex {
 	case 19:
-		parens--
+		ls(l).parens--
 
 	default:
 		panic("No registered action for: " + fmt.Sprint(actionIndex))
@@ -1330,9 +1334,11 @@ func (l *SyslLexer) E_CLOSE_PAREN_Action(localctx antlr.RuleContext, actionIndex
 func (l *SyslLexer) E_DOT_NAME_NL_Action(localctx antlr.RuleContext, actionIndex int) {
 	switch actionIndex {
 	case 20:
-		gotNewLine = true
-		gotHttpVerb = false
-		linenum++
+
+		ls := ls(l)
+		ls.gotNewLine = true
+		ls.gotHTTPVerb = false
+		ls.linenum++
 
 	default:
 		panic("No registered action for: " + fmt.Sprint(actionIndex))
@@ -1341,7 +1347,7 @@ func (l *SyslLexer) E_DOT_NAME_NL_Action(localctx antlr.RuleContext, actionIndex
 func (l *SyslLexer) E_WS_Action(localctx antlr.RuleContext, actionIndex int) {
 	switch actionIndex {
 	case 21:
-		spaces = calcSpaces(l.GetText())
+		ls(l).spaces = calcSpaces(l.GetText())
 
 	default:
 		panic("No registered action for: " + fmt.Sprint(actionIndex))
@@ -1350,10 +1356,12 @@ func (l *SyslLexer) E_WS_Action(localctx antlr.RuleContext, actionIndex int) {
 func (l *SyslLexer) E_EMPTY_LINE_Action(localctx antlr.RuleContext, actionIndex int) {
 	switch actionIndex {
 	case 22:
-		gotNewLine = true
-		spaces = 0
-		gotHttpVerb = false
-		linenum++
+
+		ls := ls(l)
+		ls.gotNewLine = true
+		ls.spaces = 0
+		ls.gotHTTPVerb = false
+		ls.linenum++
 
 	default:
 		panic("No registered action for: " + fmt.Sprint(actionIndex))
@@ -1362,14 +1370,18 @@ func (l *SyslLexer) E_EMPTY_LINE_Action(localctx antlr.RuleContext, actionIndex 
 func (l *SyslLexer) E_NL_Action(localctx antlr.RuleContext, actionIndex int) {
 	switch actionIndex {
 	case 23:
-		gotNewLine = true
-		gotHttpVerb = false
-		spaces = 0
-		linenum++
+
+		ls := ls(l)
+		ls.gotNewLine = true
+		ls.gotHTTPVerb = false
+		ls.spaces = 0
+		ls.linenum++
 
 	case 24:
-		if parens == 0 {
-			gotView = false
+
+		ls := ls(l)
+		if ls.parens == 0 {
+			ls.gotView = false
 			l.PopMode()
 		}
 
@@ -1406,7 +1418,7 @@ func (l *SyslLexer) Sempred(localctx antlr.RuleContext, ruleIndex, predIndex int
 func (p *SyslLexer) NativeDataTypes_Sempred(localctx antlr.RuleContext, predIndex int) bool {
 	switch predIndex {
 	case 0:
-		return in_sq_brackets == 0
+		return ls(p).inSqBrackets == 0
 
 	default:
 		panic("No predicate with index: " + fmt.Sprint(predIndex))
@@ -1416,7 +1428,7 @@ func (p *SyslLexer) NativeDataTypes_Sempred(localctx antlr.RuleContext, predInde
 func (p *SyslLexer) ABSTRACT_Sempred(localctx antlr.RuleContext, predIndex int) bool {
 	switch predIndex {
 	case 1:
-		return gotView
+		return ls(p).gotView
 
 	default:
 		panic("No predicate with index: " + fmt.Sprint(predIndex))
@@ -1426,7 +1438,7 @@ func (p *SyslLexer) ABSTRACT_Sempred(localctx antlr.RuleContext, predIndex int) 
 func (p *SyslLexer) AMP_Sempred(localctx antlr.RuleContext, predIndex int) bool {
 	switch predIndex {
 	case 2:
-		return gotHttpVerb
+		return ls(p).gotHTTPVerb
 
 	default:
 		panic("No predicate with index: " + fmt.Sprint(predIndex))
@@ -1436,10 +1448,10 @@ func (p *SyslLexer) AMP_Sempred(localctx antlr.RuleContext, predIndex int) bool 
 func (p *SyslLexer) TEXT_LINE_Sempred(localctx antlr.RuleContext, predIndex int) bool {
 	switch predIndex {
 	case 3:
-		return in_sq_brackets == 0
+		return ls(p).inSqBrackets == 0
 
 	case 4:
-		return startsWithKeyword(p.GetText()) == false
+		return !startsWithKeyword(p.GetText())
 
 	default:
 		panic("No predicate with index: " + fmt.Sprint(predIndex))
@@ -1449,7 +1461,7 @@ func (p *SyslLexer) TEXT_LINE_Sempred(localctx antlr.RuleContext, predIndex int)
 func (p *SyslLexer) E_DOT_NAME_NL_Sempred(localctx antlr.RuleContext, predIndex int) bool {
 	switch predIndex {
 	case 5:
-		return spaces > 1
+		return ls(p).spaces > 1
 
 	default:
 		panic("No predicate with index: " + fmt.Sprint(predIndex))
@@ -1459,7 +1471,7 @@ func (p *SyslLexer) E_DOT_NAME_NL_Sempred(localctx antlr.RuleContext, predIndex 
 func (p *SyslLexer) E_EMPTY_LINE_Sempred(localctx antlr.RuleContext, predIndex int) bool {
 	switch predIndex {
 	case 6:
-		return gotNewLine
+		return ls(p).gotNewLine
 
 	default:
 		panic("No predicate with index: " + fmt.Sprint(predIndex))

--- a/sysl2/sysl/parse/Parser_test.go
+++ b/sysl2/sysl/parse/Parser_test.go
@@ -212,16 +212,22 @@ func testParseAgainstGoldenWithSourceContext(t *testing.T, filename string) {
 }
 
 func TestParseBadRoot(t *testing.T) {
+	t.Parallel()
+
 	_, err := parseComparable("dontcare.sysl", "NON-EXISTENT-ROOT", false)
 	assert.Error(t, err)
 }
 
 func TestParseMissingFile(t *testing.T) {
+	t.Parallel()
+
 	_, err := parseComparable("doesn't.exist.sysl", "tests", false)
 	assert.Error(t, err)
 }
 
 func TestParseDirectoryAsFile(t *testing.T) {
+	t.Parallel()
+
 	dirname := "not-a-file.sysl"
 	tmproot := os.TempDir()
 	tmpdir := path.Join(tmproot, dirname)
@@ -232,178 +238,266 @@ func TestParseDirectoryAsFile(t *testing.T) {
 }
 
 func TestParseBadFile(t *testing.T) {
+	t.Parallel()
+
 	_, err := parseAndCompareWithGolden("sysl.go", "", false)
 	assert.Error(t, err)
 }
 
 func TestSimpleEP(t *testing.T) {
+	t.Parallel()
+
 	testParseAgainstGolden(t, "tests/test1.sysl", "")
 }
 
 func TestSimpleEPNoSuffix(t *testing.T) {
+	t.Parallel()
+
 	testParseAgainstGolden(t, "tests/test1", "")
 }
 
 func TestAttribs(t *testing.T) {
+	t.Parallel()
+
 	testParseAgainstGolden(t, "tests/attribs.sysl", "")
 }
 
 func TestIfElse(t *testing.T) {
+	t.Parallel()
+
 	testParseAgainstGolden(t, "tests/if_else.sysl", "")
 }
 
 func TestArgs(t *testing.T) {
+	t.Parallel()
+
 	testParseAgainstGoldenWithSourceContext(t, "tests/args.sysl")
 }
 
 func TestSimpleEPWithSpaces(t *testing.T) {
+	t.Parallel()
+
 	testParseAgainstGolden(t, "tests/with_spaces.sysl", "")
 }
 
 func TestSimpleEP2(t *testing.T) {
+	t.Parallel()
+
 	testParseAgainstGolden(t, "tests/test4.sysl", "")
 }
 
 func TestUnion(t *testing.T) {
+	t.Parallel()
+
 	testParseAgainstGolden(t, "tests/union.sysl", "")
 }
 
 func TestSimpleEndpointParams(t *testing.T) {
+	t.Parallel()
+
 	testParseAgainstGolden(t, "tests/ep_params.sysl", "")
 }
 
 func TestOneOfStatements(t *testing.T) {
+	t.Parallel()
+
 	testParseAgainstGolden(t, "tests/oneof.sysl", "")
 }
 
 func TestDuplicateEndpoints(t *testing.T) {
+	t.Parallel()
+
 	testParseAgainstGolden(t, "tests/duplicate.sysl", "")
 }
 
 func TestEventing(t *testing.T) {
+	t.Parallel()
+
 	testParseAgainstGolden(t, "tests/eventing.sysl", "")
 }
 
 func TestCollector(t *testing.T) {
+	t.Parallel()
+
 	testParseAgainstGolden(t, "tests/collector.sysl", "")
 }
 
 func TestPubSubCollector(t *testing.T) {
+	t.Parallel()
+
 	testParseAgainstGolden(t, "tests/pubsub_collector.sysl", "")
 }
 
 func TestDocstrings(t *testing.T) {
+	t.Parallel()
+
 	testParseAgainstGolden(t, "tests/docstrings.sysl", "")
 }
 
 func TestMixins(t *testing.T) {
+	t.Parallel()
+
 	testParseAgainstGolden(t, "tests/mixin.sysl", "")
 }
 func TestForLoops(t *testing.T) {
+	t.Parallel()
+
 	testParseAgainstGolden(t, "tests/for_loop.sysl", "")
 }
 
 func TestGroupStmt(t *testing.T) {
+	t.Parallel()
+
 	testParseAgainstGolden(t, "tests/group_stmt.sysl", "")
 }
 
 func TestUntilLoop(t *testing.T) {
+	t.Parallel()
+
 	testParseAgainstGolden(t, "tests/until_loop.sysl", "")
 }
 
 func TestTuple(t *testing.T) {
+	t.Parallel()
+
 	testParseAgainstGolden(t, "tests/test2.sysl", "")
 }
 
 func TestInplaceTuple(t *testing.T) {
+	t.Parallel()
+
 	testParseAgainstGolden(t, "tests/inplace_tuple.sysl", "")
 }
 
 func TestRelational(t *testing.T) {
+	t.Parallel()
+
 	testParseAgainstGolden(t, "tests/school.sysl", "")
 }
 
 func TestImports(t *testing.T) {
+	t.Parallel()
+
 	testParseAgainstGolden(t, "tests/library.sysl", "")
 }
 
 func TestRootArg(t *testing.T) {
+	t.Parallel()
+
 	testParseAgainstGolden(t, "school.sysl", "tests")
 }
 
 func TestSequenceType(t *testing.T) {
+	t.Parallel()
+
 	testParseAgainstGoldenWithSourceContext(t, "tests/sequence_type.sysl")
 }
 
 func TestRestApi(t *testing.T) {
+	t.Parallel()
+
 	testParseAgainstGoldenWithSourceContext(t, "tests/test_rest_api.sysl")
 }
 
 func TestRestApiQueryParams(t *testing.T) {
+	t.Parallel()
+
 	testParseAgainstGoldenWithSourceContext(t, "tests/rest_api_query_params.sysl")
 }
 
 func TestSimpleProject(t *testing.T) {
+	t.Parallel()
+
 	testParseAgainstGolden(t, "tests/project.sysl", "")
 }
 
 func TestUrlParamOrder(t *testing.T) {
+	t.Parallel()
+
 	testParseAgainstGoldenWithSourceContext(t, "tests/rest_url_params.sysl")
 }
 
 func TestRestApi_WrongOrder(t *testing.T) {
+	t.Parallel()
+
 	testParseAgainstGoldenWithSourceContext(t, "tests/bad_order.sysl")
 }
 
 func TestTransform(t *testing.T) {
+	t.Parallel()
+
 	testParseAgainstGolden(t, "tests/transform.sysl", "")
 }
 
 func TestImpliedDot(t *testing.T) {
+	t.Parallel()
+
 	testParseAgainstGolden(t, "tests/implied.sysl", "")
 }
 
 func TestStmts(t *testing.T) {
+	t.Parallel()
+
 	testParseAgainstGolden(t, "tests/stmts.sysl", "")
 }
 
 func TestMath(t *testing.T) {
+	t.Parallel()
+
 	testParseAgainstGolden(t, "tests/math.sysl", "")
 }
 
 func TestTableof(t *testing.T) {
+	t.Parallel()
+
 	testParseAgainstGolden(t, "tests/tableof.sysl", "")
 }
 
 func TestRank(t *testing.T) {
+	t.Parallel()
+
 	testParseAgainstGolden(t, "tests/rank.sysl", "")
 }
 
 func TestMatching(t *testing.T) {
+	t.Parallel()
+
 	testParseAgainstGolden(t, "tests/matching.sysl", "")
 }
 
 func TestNavigate(t *testing.T) {
+	t.Parallel()
+
 	testParseAgainstGolden(t, "tests/navigate.sysl", "")
 }
 
 func TestFuncs(t *testing.T) {
+	t.Parallel()
+
 	testParseAgainstGolden(t, "tests/funcs.sysl", "")
 }
 
 func TestPetshop(t *testing.T) {
+	t.Parallel()
+
 	testParseAgainstGolden(t, "tests/petshop.sysl", "")
 }
 
 func TestCrash(t *testing.T) {
+	t.Parallel()
+
 	testParseAgainstGolden(t, "tests/crash.sysl", "")
 }
 
 func TestStrings(t *testing.T) {
+	t.Parallel()
+
 	testParseAgainstGoldenWithSourceContext(t, "tests/strings_expr.sysl")
 }
 
 func TestTypeAlias(t *testing.T) {
+	t.Parallel()
+
 	testParseAgainstGoldenWithSourceContext(t, "tests/alias.sysl")
 }
 

--- a/sysl2/sysl/parse/parse.go
+++ b/sysl2/sysl/parse/parse.go
@@ -73,6 +73,7 @@ func (p *Parser) FSParse(filename string, fs http.FileSystem) (*sysl.Module, err
 		listener.filename = filename
 		listener.base = filepath.Dir(filename)
 		lexer := parser.NewSyslLexer(input)
+		defer parser.DeleteLexerState(lexer)
 		stream := antlr.NewCommonTokenStream(lexer, 0)
 		p := parser.NewSyslParser(stream)
 		p.GetInterpreter().SetPredictionMode(antlr.PredictionModeSLL)

--- a/sysl2/sysl/pbutil/output_test.go
+++ b/sysl2/sysl/pbutil/output_test.go
@@ -12,9 +12,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-//nolint:gochecknoglobals
-var (
-	testModule = &sysl.Module{
+func testModule() *sysl.Module {
+	return &sysl.Module{
 		Apps: map[string]*sysl.Application{
 			"Test": {
 				Name: &sysl.AppName{
@@ -37,8 +36,10 @@ var (
 			},
 		},
 	}
+}
 
-	testModuleJSONPB = `{
+func testModuleJSONPB() string {
+	return `{
  "apps": {
   "Test": {
    "name": {
@@ -61,8 +62,10 @@ var (
   }
  }
 }`
+}
 
-	testModuleTextPB = `apps: <
+func testModuleTextPB() string {
+	return `apps: <
   key: "Test"
   value: <
     name: <
@@ -82,14 +85,14 @@ var (
   >
 >
 `
-)
+}
 
 func TestJSONPB(t *testing.T) {
 	if filename := testutil.TempFilename(t, "", "sysl-TestJSONPB-*.json"); filename != "" {
-		require.NoError(t, JSONPB(testModule, filename))
+		require.NoError(t, JSONPB(testModule(), filename))
 		output, err := ioutil.ReadFile(filename)
 		require.NoError(t, err)
-		assert.Equal(t, testModuleJSONPB, string(output))
+		assert.Equal(t, testModuleJSONPB(), string(output))
 	}
 }
 
@@ -105,8 +108,8 @@ func TestJSONPBNilModule(t *testing.T) {
 
 func TestFJSONPB(t *testing.T) {
 	var output bytes.Buffer
-	require.NoError(t, FJSONPB(&output, testModule))
-	assert.Equal(t, testModuleJSONPB, output.String())
+	require.NoError(t, FJSONPB(&output, testModule()))
+	assert.Equal(t, testModuleJSONPB(), output.String())
 }
 
 func TestFJSONPBNilModule(t *testing.T) {
@@ -117,10 +120,10 @@ func TestFJSONPBNilModule(t *testing.T) {
 
 func TestTextPB(t *testing.T) {
 	if filename := testutil.TempFilename(t, "", "sysl-TestJSONPB-*.json"); filename != "" {
-		require.NoError(t, TextPB(testModule, filename))
+		require.NoError(t, TextPB(testModule(), filename))
 		output, err := ioutil.ReadFile(filename)
 		require.NoError(t, err)
-		assert.Equal(t, testModuleTextPB, string(output))
+		assert.Equal(t, testModuleTextPB(), string(output))
 	}
 }
 
@@ -136,8 +139,8 @@ func TestTextPBNilModule(t *testing.T) {
 
 func TestFTextPB(t *testing.T) {
 	var output bytes.Buffer
-	require.NoError(t, FTextPB(&output, testModule))
-	assert.Equal(t, testModuleTextPB, output.String())
+	require.NoError(t, FTextPB(&output, testModule()))
+	assert.Equal(t, testModuleTextPB(), output.String())
 }
 
 func TestFTextPBNilModule(t *testing.T) {


### PR DESCRIPTION
- Turn some global variables into functions.
- Move the lexer state into a global concurrent map. There seemed no other way to de-globalise the state based on the antlr-generated lexer.
- Mark tests with `t.Parallel()`.