### PR TITLE
Add coverage > 80% check to travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -55,7 +55,7 @@ script:
 - pytest
 - pytest test/e2e --syslexe=${SYSL_PYTHON_DIR}sysl --reljamexe=${SYSL_PYTHON_DIR}reljam
 - if [[ ( "$TRAVIS_OS_NAME" == "linux" ) ]]; then gradle test -b test/java/build.gradle; fi
-- go test -coverprofile=coverage.txt -covermode=atomic github.com/anz-bank/sysl/...
+- ./check-coverage.sh 80
 - npm test --prefix sysl2/sysl/sysl_js
 - GOOS=darwin GOARCH=amd64 go build -o gosysl/gosysl-darwin github.com/anz-bank/sysl/sysl2/sysl
 - GOOS=linux GOARCH=amd64 go build -o gosysl/gosysl-linux github.com/anz-bank/sysl/sysl2/sysl

--- a/check-coverage.sh
+++ b/check-coverage.sh
@@ -1,0 +1,25 @@
+#!/bin/sh
+
+MIN_COVERAGE="$1"
+
+if [ -z "$MIN_COVERAGE" ]; then
+    echo "Usage: $0 <min_coverage%> (e.g., $0 80)"
+    exit 1
+fi
+
+COVERAGE_FILE=coverage.txt
+
+coverage_level() {
+    go tool cover -func=$COVERAGE_FILE | \
+        grep '^total:' | \
+        tee | \
+        awk '//{sub(/(\.[0-9]+)?%$/,"",$3);print$3}'
+}
+
+go test -coverprofile=$COVERAGE_FILE -covermode=atomic ./...
+
+COVERAGE_LEVEL="$(coverage_level)"
+if [ "$COVERAGE_LEVEL" -lt "$MIN_COVERAGE" ]; then
+    echo "Coverage ${COVERAGE_LEVEL}% < ${MIN_COVERAGE}% required"
+    exit 1
+fi


### PR DESCRIPTION
Codecov has been un-required as a check in GitHub because its forced nonnegative delta was slowing us down unduly. This provides an alternative measure to ensure coverage doesn't regress significantly.

This is mostly a delta on #304. Only the final commit is significant.