### PR TITLE
Start cleaning up the command line args, start with verbose handling

### DIFF
--- a/sysl2/sysl/Codegen_test.go
+++ b/sysl2/sysl/Codegen_test.go
@@ -16,7 +16,7 @@ func TestGenerateCode(t *testing.T) {
 	t.Parallel()
 
 	output, err := GenerateCodeWithParams(".", "tests/model.sysl", ".", "tests/test.gen.sysl",
-		"tests/test.gen.g", "javaFile", "warn", false)
+		"tests/test.gen.g", "javaFile")
 	require.NoError(t, err)
 	root := output[0].output
 	assert.Len(t, output, 1)
@@ -56,7 +56,7 @@ func TestGenerateCodeNoComment(t *testing.T) {
 	t.Parallel()
 
 	output, err := GenerateCodeWithParams(".", "tests/model.sysl", ".", "tests/test.gen_no_comment.sysl",
-		"tests/test.gen.g", "javaFile", "warn", false)
+		"tests/test.gen.g", "javaFile")
 	require.NoError(t, err)
 	assert.Len(t, output, 1)
 	root := output[0].output
@@ -87,7 +87,7 @@ func TestGenerateCodeNoPackage(t *testing.T) {
 	t.Parallel()
 
 	output, err := GenerateCodeWithParams(".", "tests/model.sysl", ".", "tests/test.gen_no_package.sysl",
-		"tests/test.gen.g", "javaFile", "warn", false)
+		"tests/test.gen.g", "javaFile")
 	require.NoError(t, err)
 	root := output[0].output
 	assert.Nil(t, root)
@@ -97,7 +97,7 @@ func TestGenerateCodeMultipleAnnotations(t *testing.T) {
 	t.Parallel()
 
 	output, err := GenerateCodeWithParams(".", "tests/model.sysl", ".", "tests/test.gen_multiple_annotations.sysl",
-		"tests/test.gen.g", "javaFile", "warn", false)
+		"tests/test.gen.g", "javaFile")
 	require.NoError(t, err)
 	root := output[0].output
 	assert.Nil(t, root)
@@ -107,7 +107,7 @@ func TestGenerateCodePerType(t *testing.T) {
 	t.Parallel()
 
 	output, err := GenerateCodeWithParams(".", "tests/model.sysl", ".", "tests/multiple_file.gen.sysl",
-		"tests/test.gen.g", "javaFile", "warn", false)
+		"tests/test.gen.g", "javaFile")
 	require.NoError(t, err)
 	assert.Len(t, output, 1)
 	assert.Equal(t, "Request.java", output[0].filename)
@@ -132,7 +132,7 @@ func TestSerialize(t *testing.T) {
 	t.Parallel()
 
 	output, err := GenerateCodeWithParams(".", "tests/model.sysl", ".", "tests/test.gen.sysl",
-		"tests/test.gen.g", "javaFile", "warn", false)
+		"tests/test.gen.g", "javaFile")
 	require.NoError(t, err)
 	out := new(bytes.Buffer)
 	require.NoError(t, Serialize(out, " ", output[0].output))
@@ -173,19 +173,15 @@ func TestOutputForPureTokenOnlyRule(t *testing.T) {
 }
 
 func GenerateCodeWithParams(
-	rootModel, model, rootTransform, transform, grammar, start, loglevel string,
-	isVerbose bool,
-) ([]*CodeGenOutput, error) {
+	rootModel, model, rootTransform, transform, grammar, start string) ([]*CodeGenOutput, error) {
 	_, fs := testutil.WriteToMemOverlayFs(rootModel)
 	return GenerateCodeWithParamsFs(
-		rootModel, model, rootTransform, transform, grammar, start, loglevel,
-		isVerbose, fs,
+		rootModel, model, rootTransform, transform, grammar, start, fs,
 	)
 }
 
 func GenerateCodeWithParamsFs(
-	rootModel, model, rootTransform, transform, grammar, start, loglevel string,
-	isVerbose bool, fs afero.Fs,
+	rootModel, model, rootTransform, transform, grammar, start string, fs afero.Fs,
 ) ([]*CodeGenOutput, error) {
 	cmdContextParamCodegen := &CmdContextParamCodegen{
 		rootModel:     &rootModel,
@@ -194,8 +190,6 @@ func GenerateCodeWithParamsFs(
 		transform:     &transform,
 		grammar:       &grammar,
 		start:         &start,
-		loglevel:      &loglevel,
-		isVerbose:     &isVerbose,
 	}
 	logger, _ := test.NewNullLogger()
 	return GenerateCode(cmdContextParamCodegen, fs, logger)

--- a/sysl2/sysl/codegen.go
+++ b/sysl2/sysl/codegen.go
@@ -16,7 +16,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/afero"
-	kingpin "gopkg.in/alecthomas/kingpin.v2"
+	"gopkg.in/alecthomas/kingpin.v2"
 )
 
 // Node can be string or node
@@ -307,8 +307,6 @@ func configureCmdlineForCodegen(sysl *kingpin.Application, flagmap map[string][]
 	gen := sysl.Command("gen", "Generate code")
 	returnValues := &CmdContextParamCodegen{}
 
-	returnValues.rootModel = gen.Flag("root-model",
-		"sysl root directory for input model file (default: .)").Default(".").String()
 	returnValues.rootTransform = gen.Flag("root-transform",
 		"sysl root directory for input transform file (default: .)").Default(".").String()
 	returnValues.model = gen.Flag("model", "model.sysl").Default(".").String()

--- a/sysl2/sysl/codegen.go
+++ b/sysl2/sysl/codegen.go
@@ -16,7 +16,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/afero"
-	"gopkg.in/alecthomas/kingpin.v2"
+	kingpin "gopkg.in/alecthomas/kingpin.v2"
 )
 
 // Node can be string or node
@@ -232,15 +232,6 @@ func GenerateCode(codegenParams *CmdContextParamCodegen, fs afero.Fs, logger *lo
 	logger.Debugf("transform: %s\n", *codegenParams.transform)
 	logger.Debugf("grammar: %s\n", *codegenParams.grammar)
 	logger.Debugf("start: %s\n", *codegenParams.start)
-	logger.Debugf("loglevel: %s\n", *codegenParams.loglevel)
-
-	if *codegenParams.isVerbose {
-		*codegenParams.loglevel = debug
-	}
-	// Default info
-	if level, has := syslutil.LogLevels[*codegenParams.loglevel]; has {
-		logger.SetLevel(level)
-	}
 
 	modelFs := syslutil.NewChrootFs(fs, *codegenParams.rootModel)
 	modelParser := parse.NewParser()
@@ -325,8 +316,6 @@ func configureCmdlineForCodegen(sysl *kingpin.Application, flagmap map[string][]
 	returnValues.grammar = gen.Flag("grammar", "grammar.g").Default(".").String()
 	returnValues.start = gen.Flag("start", "start rule for the grammar").Default(".").String()
 	returnValues.outDir = gen.Flag("outdir", "output directory").Default(".").String()
-	returnValues.loglevel = gen.Flag("log", "log level[debug,info,warn,off]").Default("info").String()
-	returnValues.isVerbose = gen.Flag("verbose", "show output").Short('v').Default("false").Bool()
 
 	return returnValues
 }

--- a/sysl2/sysl/commands/protobuf.go
+++ b/sysl2/sysl/commands/protobuf.go
@@ -1,0 +1,50 @@
+package commands
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/anz-bank/sysl/sysl2/sysl/pbutil"
+	"github.com/sirupsen/logrus"
+	"gopkg.in/alecthomas/kingpin.v2"
+)
+
+type protobuf struct {
+	output string
+	mode   string
+}
+
+func (p *protobuf) Name() string            { return "protobuf" }
+func (p *protobuf) RequireSyslModule() bool { return true }
+
+func (p *protobuf) Init(app *kingpin.Application) *kingpin.CmdClause {
+
+	cmd := app.Command(p.Name(), "Generate textpb/json").Alias("pb")
+	cmd.Flag("output", "output file name").Short('o').Default("-").StringVar(&p.output)
+	opts := []string{"textpb", "json"}
+	cmd.Flag("mode", fmt.Sprintf("output mode: [%s]", strings.Join(opts, ","))).
+		Default(opts[0]).
+		EnumVar(&p.mode, opts...)
+	return cmd
+}
+
+func (p *protobuf) Execute(args ExecuteArgs) error {
+
+	args.Logger.Infof("Protobuf: %+v", *p)
+
+	p.output = strings.TrimSpace(p.output)
+	p.mode = strings.TrimSpace(p.mode)
+
+	toJSON := p.mode == "json" || p.mode == "" && strings.HasSuffix(p.output, ".json")
+
+	if toJSON {
+		if p.output == "-" {
+			return pbutil.FJSONPB(args.Logger.Out, args.Module)
+		}
+		return pbutil.JSONPB(args.Module, p.output, args.Filesystem)
+	}
+	if p.output == "-" {
+		return pbutil.FTextPB(logrus.StandardLogger().Out, args.Module)
+	}
+	return pbutil.TextPB(args.Module, p.output, args.Filesystem)
+}

--- a/sysl2/sysl/commands/protobuf.go
+++ b/sysl2/sysl/commands/protobuf.go
@@ -17,7 +17,7 @@ type protobuf struct {
 func (p *protobuf) Name() string            { return "protobuf" }
 func (p *protobuf) RequireSyslModule() bool { return true }
 
-func (p *protobuf) Init(app *kingpin.Application) *kingpin.CmdClause {
+func (p *protobuf) Configure(app *kingpin.Application) *kingpin.CmdClause {
 
 	cmd := app.Command(p.Name(), "Generate textpb/json").Alias("pb")
 	cmd.Flag("output", "output file name").Short('o').Default("-").StringVar(&p.output)

--- a/sysl2/sysl/commands/runner.go
+++ b/sysl2/sysl/commands/runner.go
@@ -1,0 +1,69 @@
+package commands
+
+import (
+	"strings"
+
+	sysl "github.com/anz-bank/sysl/src/proto"
+	"github.com/anz-bank/sysl/sysl2/sysl/parse"
+	"github.com/anz-bank/sysl/sysl2/sysl/syslutil"
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/afero"
+	kingpin "gopkg.in/alecthomas/kingpin.v2"
+)
+
+type Runner struct {
+	commands []Command
+
+	Root   string
+	module string
+}
+
+func (r *Runner) Run(which string, fs afero.Fs, logger *logrus.Logger) error {
+	for _, cmd := range r.commands {
+		if cmd.Name() == which {
+			var mod *sysl.Module
+			var modelAppName string
+			var err error
+			if cmd.RequireSyslModule() {
+				logger.Infof("Attempting to load module:%s (root:%s)", r.module, r.Root)
+				modelParser := parse.NewParser()
+				mod, modelAppName, err = parse.LoadAndGetDefaultApp(r.module, syslutil.NewChrootFs(fs, r.Root), modelParser)
+				if err != nil {
+					return err
+				}
+			}
+
+			return cmd.Execute(ExecuteArgs{mod, modelAppName, fs, logger})
+		}
+	}
+	return nil
+}
+
+func (r *Runner) Init(app *kingpin.Application) error {
+	r.commands = []Command{}
+
+	app.Flag("root",
+		"sysl root directory for input model file (default: .)").
+		Default(".").StringVar(&r.Root)
+
+	for _, cmd := range r.commands {
+		c := cmd.Init(app)
+		if cmd.RequireSyslModule() {
+			c.Arg("MODULE", "input files without .sysl extension and with leading /, eg: "+
+				"/project_dir/my_models combine with --root if needed").
+				Required().StringVar(&r.module)
+		}
+	}
+
+	return nil
+}
+
+// Temp until all the commands move in here
+func (r *Runner) HasCommand(which string) bool {
+	for _, cmd := range r.commands {
+		if strings.EqualFold(cmd.Name(), which) {
+			return true
+		}
+	}
+	return false
+}

--- a/sysl2/sysl/commands/runner.go
+++ b/sysl2/sysl/commands/runner.go
@@ -1,25 +1,23 @@
 package commands
 
 import (
-	"strings"
-
 	sysl "github.com/anz-bank/sysl/src/proto"
 	"github.com/anz-bank/sysl/sysl2/sysl/parse"
 	"github.com/anz-bank/sysl/sysl2/sysl/syslutil"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/afero"
-	kingpin "gopkg.in/alecthomas/kingpin.v2"
+	"gopkg.in/alecthomas/kingpin.v2"
 )
 
 type Runner struct {
-	commands []Command
+	commands map[string]Command
 
 	Root   string
 	module string
 }
 
 func (r *Runner) Run(which string, fs afero.Fs, logger *logrus.Logger) error {
-	for _, cmd := range r.commands {
+	if cmd, ok := r.commands[which]; ok {
 		if cmd.Name() == which {
 			var mod *sysl.Module
 			var modelAppName string
@@ -39,22 +37,26 @@ func (r *Runner) Run(which string, fs afero.Fs, logger *logrus.Logger) error {
 	return nil
 }
 
-func (r *Runner) Init(app *kingpin.Application) error {
-	r.commands = []Command{
+func (r *Runner) Configure(app *kingpin.Application) error {
+	commands := []Command{
 		&protobuf{},
+
+		&validateCmd{},
 	}
+	r.commands = map[string]Command{}
 
 	app.Flag("root",
 		"sysl root directory for input model file (default: .)").
 		Default(".").StringVar(&r.Root)
 
-	for _, cmd := range r.commands {
-		c := cmd.Init(app)
+	for _, cmd := range commands {
+		c := cmd.Configure(app)
 		if cmd.RequireSyslModule() {
 			c.Arg("MODULE", "input files without .sysl extension and with leading /, eg: "+
 				"/project_dir/my_models combine with --root if needed").
 				Required().StringVar(&r.module)
 		}
+		r.commands[cmd.Name()] = cmd
 	}
 
 	return nil
@@ -62,10 +64,7 @@ func (r *Runner) Init(app *kingpin.Application) error {
 
 // Temp until all the commands move in here
 func (r *Runner) HasCommand(which string) bool {
-	for _, cmd := range r.commands {
-		if strings.EqualFold(cmd.Name(), which) {
-			return true
-		}
-	}
-	return false
+
+	_, ok := r.commands[which]
+	return ok
 }

--- a/sysl2/sysl/commands/runner.go
+++ b/sysl2/sysl/commands/runner.go
@@ -40,7 +40,9 @@ func (r *Runner) Run(which string, fs afero.Fs, logger *logrus.Logger) error {
 }
 
 func (r *Runner) Init(app *kingpin.Application) error {
-	r.commands = []Command{}
+	r.commands = []Command{
+		&protobuf{},
+	}
 
 	app.Flag("root",
 		"sysl root directory for input model file (default: .)").

--- a/sysl2/sysl/commands/types.go
+++ b/sysl2/sysl/commands/types.go
@@ -1,0 +1,22 @@
+package commands
+
+import (
+	sysl "github.com/anz-bank/sysl/src/proto"
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/afero"
+	"gopkg.in/alecthomas/kingpin.v2"
+)
+
+type ExecuteArgs struct {
+	Module        *sysl.Module
+	ModuleAppName string
+	Filesystem    afero.Fs
+	Logger        *logrus.Logger
+}
+
+type Command interface {
+	Init(*kingpin.Application) *kingpin.CmdClause
+	Execute(ExecuteArgs) error
+	Name() string
+	RequireSyslModule() bool
+}

--- a/sysl2/sysl/commands/types.go
+++ b/sysl2/sysl/commands/types.go
@@ -15,7 +15,7 @@ type ExecuteArgs struct {
 }
 
 type Command interface {
-	Init(*kingpin.Application) *kingpin.CmdClause
+	Configure(*kingpin.Application) *kingpin.CmdClause
 	Execute(ExecuteArgs) error
 	Name() string
 	RequireSyslModule() bool

--- a/sysl2/sysl/commands/validate.go
+++ b/sysl2/sysl/commands/validate.go
@@ -1,0 +1,40 @@
+package commands
+
+import (
+	"github.com/anz-bank/sysl/sysl2/sysl/validate"
+	"gopkg.in/alecthomas/kingpin.v2"
+)
+
+type validateCmd struct {
+	rootTransform string
+	transform     string
+	grammar       string
+	start         string
+}
+
+func (p *validateCmd) Name() string            { return "validate" }
+func (p *validateCmd) RequireSyslModule() bool { return false }
+
+func (p *validateCmd) Configure(app *kingpin.Application) *kingpin.CmdClause {
+
+	cmd := app.Command(p.Name(), "Validate transform")
+	cmd.Flag("root-transform", "sysl root directory for input transform file (default: .)").
+		Default(".").StringVar(&p.rootTransform)
+	cmd.Flag("transform", "grammar.g").Required().StringVar(&p.transform)
+	cmd.Flag("grammar", "grammar.sysl").Required().StringVar(&p.grammar)
+	cmd.Flag("start", "start rule for the grammar").Default(".").StringVar(&p.start)
+
+	return cmd
+}
+
+func (p *validateCmd) Execute(args ExecuteArgs) error {
+
+	return validate.DoValidate(validate.Params{
+		RootTransform: p.rootTransform,
+		Transform:     p.transform,
+		Grammar:       p.grammar,
+		Start:         p.start,
+		Filesystem:    args.Filesystem,
+		Logger:        args.Logger,
+	})
+}

--- a/sysl2/sysl/commands/validate_test.go
+++ b/sysl2/sysl/commands/validate_test.go
@@ -1,0 +1,68 @@
+package commands
+
+import (
+	"testing"
+
+	"github.com/sirupsen/logrus/hooks/test"
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/alecthomas/kingpin.v2"
+)
+
+func TestValidatorDoValidate(t *testing.T) {
+	t.Parallel()
+
+	cases := map[string]struct {
+		args     []string
+		isErrNil bool
+	}{
+		"Success": {
+			args: []string{
+				"sysl2", "validate", "--root-transform", "../tests", "--transform", "transform2.sysl", "--grammar",
+				"../tests/grammar.sysl", "--start", "goFile"}, isErrNil: true},
+		"Grammar loading fail": {
+			args: []string{
+				"sysl2", "validate", "--root-transform", "../tests", "--transform", "transform2.sysl", "--grammar",
+				"../tests/go.sysl", "--start", "goFile"}, isErrNil: false},
+		"Transform loading fail": {
+			args: []string{
+				"sysl2", "validate", "--root-transform", "../tests", "--transform", "tfm.sysl", "--grammar",
+				"../tests/grammar.sysl", "--start", "goFile"}, isErrNil: false},
+		"Has validation messages": {
+			args: []string{
+				"sysl2", "validate", "--root-transform", "../tests", "--transform", "transform1.sysl", "--grammar",
+				"../tests/grammar.sysl", "--start", "goFile"}, isErrNil: false},
+	}
+
+	for name, tt := range cases {
+		args := tt.args
+		isErrNil := tt.isErrNil
+		t.Run(name, func(t *testing.T) {
+			sysl := kingpin.New("sysl", "System Modelling Language Toolkit")
+
+			cmd := &validateCmd{}
+			require.NotNil(t, cmd.Configure(sysl))
+
+			var selectedCmd string
+			var err error
+			if selectedCmd, err = sysl.Parse(args[1:]); err != nil {
+				assert.FailNow(t, "Failed to parse args")
+			}
+			require.Equal(t, cmd.Name(), selectedCmd)
+			l, _ := test.NewNullLogger()
+			execArgs := ExecuteArgs{
+				Module:        nil,
+				ModuleAppName: "",
+				Filesystem:    afero.NewOsFs(),
+				Logger:        l,
+			}
+			err = cmd.Execute(execArgs)
+			if isErrNil {
+				assert.Nil(t, err, "Unexpected result")
+			} else {
+				assert.NotNil(t, err, "Unexpected result")
+			}
+		})
+	}
+}

--- a/sysl2/sysl/datamodel.go
+++ b/sysl2/sysl/datamodel.go
@@ -10,7 +10,7 @@ import (
 	"github.com/anz-bank/sysl/sysl2/sysl/syslutil"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/afero"
-	kingpin "gopkg.in/alecthomas/kingpin.v2"
+	"gopkg.in/alecthomas/kingpin.v2"
 )
 
 const localPlantuml = "http://localhost:8080/plantuml"
@@ -70,7 +70,6 @@ func configureCmdlineForDatagen(sysl *kingpin.Application) *CmdContextParamDatag
 	data := sysl.Command("data", "Generate data models")
 	returnValues := &CmdContextParamDatagen{}
 
-	returnValues.root = data.Flag("root", "sysl root directory for input model file (default: .)").Default(".").String()
 	returnValues.classFormat = data.Flag("class_format",
 		"Specify the format string for data diagram participants. "+
 			"May include %%(appname) and %%(@foo) for attribute foo (default: %(classname))",

--- a/sysl2/sysl/datamodel.go
+++ b/sysl2/sysl/datamodel.go
@@ -10,7 +10,7 @@ import (
 	"github.com/anz-bank/sysl/sysl2/sysl/syslutil"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/afero"
-	"gopkg.in/alecthomas/kingpin.v2"
+	kingpin "gopkg.in/alecthomas/kingpin.v2"
 )
 
 const localPlantuml = "http://localhost:8080/plantuml"
@@ -24,7 +24,6 @@ func GenerateDataModels(datagenParams *CmdContextParamDatagen) (map[string]strin
 	log.Debugf("filter: %s\n", *datagenParams.filter)
 	log.Debugf("modules: %s\n", *datagenParams.modules)
 	log.Debugf("output: %s\n", *datagenParams.output)
-	log.Debugf("loglevel: %s\n", *datagenParams.loglevel)
 
 	if *datagenParams.plantuml == "" {
 		plantuml := os.Getenv("SYSL_PLANTUML")
@@ -35,13 +34,6 @@ func GenerateDataModels(datagenParams *CmdContextParamDatagen) (map[string]strin
 	}
 	log.Debugf("plantuml: %s\n", *datagenParams.plantuml)
 
-	if *datagenParams.isVerbose {
-		*datagenParams.loglevel = debug
-	}
-	// Default info
-	if level, has := syslutil.LogLevels[*datagenParams.loglevel]; has {
-		log.SetLevel(level)
-	}
 	spclass := constructFormatParser("", *datagenParams.classFormat)
 	mod, err := loadApp(*datagenParams.modules, syslutil.NewChrootFs(afero.NewOsFs(), *datagenParams.root))
 
@@ -95,8 +87,6 @@ func configureCmdlineForDatagen(sysl *kingpin.Application) *CmdContextParamDatag
 		strings.Join([]string{"input files without .sysl extension and with leading /",
 			"eg: /project_dir/my_models",
 			"combine with --root if needed"}, "\n")).String()
-	returnValues.loglevel = data.Flag("log", "log level[debug,info,warn,off]").Default("info").String()
-	returnValues.isVerbose = data.Flag("verbose", "show output").Short('v').Default("false").Bool()
 
 	return returnValues
 }

--- a/sysl2/sysl/datamodel_test.go
+++ b/sysl2/sysl/datamodel_test.go
@@ -53,15 +53,14 @@ func TestDoConstructDataDiagrams(t *testing.T) {
 			"Object-Model.png":     "tests/object-model-golden.puml",
 		},
 	}
-	result, err := DoConstructDataDiagramsWithParams(args.root, "", args.title, args.output, "warn", args.project,
-		args.modules, false)
+	result, err := DoConstructDataDiagramsWithParams(args.root, "", args.title, args.output, args.project,
+		args.modules)
 	assert.Nil(t, err, "Generating the data diagrams failed")
 	comparePUML(t, args.expected, result)
 }
 
 func DoConstructDataDiagramsWithParams(
-	rootModel, filter, title, output, loglevel, project, modules string,
-	isVerbose bool,
+	rootModel, filter, title, output, project, modules string,
 ) (map[string]string, error) {
 	plantuml := ""
 	classFormat := "%(classname)"
@@ -70,9 +69,7 @@ func DoConstructDataDiagramsWithParams(
 		filter:      &filter,
 		title:       &title,
 		output:      &output,
-		loglevel:    &loglevel,
 		project:     &project,
-		isVerbose:   &isVerbose,
 		plantuml:    &plantuml,
 		modules:     &modules,
 		classFormat: &classFormat,

--- a/sysl2/sysl/datamodel_test.go
+++ b/sysl2/sysl/datamodel_test.go
@@ -28,12 +28,11 @@ func TestGenerateDataDiagFail(t *testing.T) {
 
 func TestDoGenerateDataDiagrams(t *testing.T) {
 	args := &dataArgs{
-		root:    "./tests/",
 		modules: "data.sysl",
 		output:  "%(epname).png",
 		project: "Project",
 	}
-	argsData := []string{"sysl", "data", "--root", args.root, "-o", args.output, "-j", args.project, args.modules}
+	argsData := []string{"sysl", "data", "-o", args.output, "-j", args.project, args.modules}
 	syslCmd := kingpin.New("sysl", "System Modelling Language Toolkit")
 	configureCmdlineForDatagen(syslCmd)
 	selectedCommand, err := syslCmd.Parse(argsData[1:])

--- a/sysl2/sysl/ints.go
+++ b/sysl2/sysl/ints.go
@@ -78,7 +78,6 @@ func configureCmdlineForIntgen(sysl *kingpin.Application, flagmap map[string][]s
 	ints := sysl.Command("ints", "Generate integrations")
 	returnValues := &CmdContextParamIntgen{}
 
-	returnValues.root = ints.Flag("root", "sysl root directory for input model file (default: .)").Default(".").String()
 	returnValues.title = ints.Flag("title", "diagram title").Short('t').String()
 	returnValues.plantuml = ints.Flag("plantuml", strings.Join([]string{"base url of plantuml server",
 		"(default: $SYSL_PLANTUML or http://localhost:8080/plantuml",

--- a/sysl2/sysl/ints.go
+++ b/sysl2/sysl/ints.go
@@ -8,7 +8,7 @@ import (
 	"github.com/anz-bank/sysl/sysl2/sysl/syslutil"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/afero"
-	"gopkg.in/alecthomas/kingpin.v2"
+	kingpin "gopkg.in/alecthomas/kingpin.v2"
 )
 
 const endpointWildcard = ".. * <- *"
@@ -25,7 +25,6 @@ func GenerateIntegrations(intgenParams *CmdContextParamIntgen) (map[string]strin
 	log.Debugf("filter: %s\n", *intgenParams.filter)
 	log.Debugf("modules: %s\n", *intgenParams.modules)
 	log.Debugf("output: %s\n", *intgenParams.output)
-	log.Debugf("loglevel: %s\n", *intgenParams.loglevel)
 
 	if *intgenParams.plantuml == "" {
 		plantuml := os.Getenv("SYSL_PLANTUML")
@@ -35,14 +34,6 @@ func GenerateIntegrations(intgenParams *CmdContextParamIntgen) (map[string]strin
 		}
 	}
 	log.Debugf("plantuml: %s\n", *intgenParams.plantuml)
-
-	if *intgenParams.isVerbose {
-		*intgenParams.loglevel = debug
-	}
-	// Default info
-	if level, has := syslutil.LogLevels[*intgenParams.loglevel]; has {
-		log.SetLevel(level)
-	}
 
 	mod, err := loadApp(*intgenParams.modules, syslutil.NewChrootFs(afero.NewOsFs(), *intgenParams.root))
 	if err != nil {
@@ -104,8 +95,6 @@ func configureCmdlineForIntgen(sysl *kingpin.Application, flagmap map[string][]s
 	returnValues.clustered = ints.Flag("clustered",
 		"group integration components into clusters").Short('c').Default("false").Bool()
 	returnValues.epa = ints.Flag("epa", "produce and EPA integration view").Default("false").Bool()
-	returnValues.loglevel = ints.Flag("log", "log level[debug,info,warn,off]").Default("info").String()
-	returnValues.isVerbose = ints.Flag("verbose", "show output").Short('v').Default("false").Bool()
 
 	return returnValues
 }

--- a/sysl2/sysl/ints_test.go
+++ b/sysl2/sysl/ints_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	kingpin "gopkg.in/alecthomas/kingpin.v2"
+	"gopkg.in/alecthomas/kingpin.v2"
 )
 
 const plantumlHeader = `''''''''''''''''''''''''''''''''''''''''''
@@ -225,12 +225,11 @@ func TestDoGenerateIntegrations(t *testing.T) {
 	t.Parallel()
 
 	args := &intsArg{
-		rootModel: "./tests/",
-		modules:   "indirect_1.sysl",
-		output:    "%(epname).png",
-		project:   "Project",
+		modules: "indirect_1.sysl",
+		output:  "%(epname).png",
+		project: "Project",
 	}
-	argsData := []string{"sysl", "ints", "--root", args.rootModel, "-o", args.output, "-j", args.project, args.modules}
+	argsData := []string{"sysl", "ints", "-o", args.output, "-j", args.project, args.modules}
 	sysl := kingpin.New("sysl", "System Modelling Language Toolkit")
 	configureCmdlineForIntgen(sysl, map[string][]string{})
 	selectedCommand, err := sysl.Parse(argsData[1:])

--- a/sysl2/sysl/ints_test.go
+++ b/sysl2/sysl/ints_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"gopkg.in/alecthomas/kingpin.v2"
+	kingpin "gopkg.in/alecthomas/kingpin.v2"
 )
 
 const plantumlHeader = `''''''''''''''''''''''''''''''''''''''''''
@@ -117,7 +117,7 @@ func TestGenerateIntegrationsWithTestFile(t *testing.T) {
 	// When
 	result, err := GenerateIntegrationsWithParams(args.rootModel, args.title, args.output,
 		args.project, args.filter, args.modules, args.exclude, args.clustered,
-		args.epa, "warn", false)
+		args.epa)
 	require.NoError(t, err)
 
 	// Then
@@ -140,7 +140,7 @@ func TestGenerateIntegrationsWithTestFileAndFilters(t *testing.T) {
 	// When
 	result, err := GenerateIntegrationsWithParams(args.rootModel, args.title, args.output,
 		args.project, args.filter, args.modules, args.exclude, args.clustered,
-		args.epa, "warn", false)
+		args.epa)
 	require.NoError(t, err)
 
 	// Then
@@ -164,7 +164,7 @@ func TestGenerateIntegrationsWithImmediatePredecessors(t *testing.T) {
 	// When
 	result, err := GenerateIntegrationsWithParams(args.rootModel, args.title, args.output,
 		args.project, args.filter, args.modules, args.exclude, args.clustered,
-		args.epa, "warn", false)
+		args.epa)
 	require.NoError(t, err)
 
 	// Then
@@ -189,7 +189,7 @@ func TestGenerateIntegrationsWithExclude(t *testing.T) {
 	// When
 	result, err := GenerateIntegrationsWithParams(args.rootModel, args.title, args.output,
 		args.project, args.filter, args.modules, args.exclude, args.clustered,
-		args.epa, "warn", false)
+		args.epa)
 	require.NoError(t, err)
 
 	// Then
@@ -214,7 +214,7 @@ func TestGenerateIntegrationsWithPassthrough(t *testing.T) {
 	// When
 	result, err := GenerateIntegrationsWithParams(args.rootModel, args.title, args.output,
 		args.project, args.filter, args.modules, args.exclude, args.clustered,
-		args.epa, "warn", false)
+		args.epa)
 	require.NoError(t, err)
 
 	// Then
@@ -253,7 +253,7 @@ func TestGenerateIntegrationsWithCluster(t *testing.T) {
 	// When
 	result, err := GenerateIntegrationsWithParams(args.rootModel, args.title, args.output,
 		args.project, args.filter, args.modules, args.exclude, args.clustered,
-		args.epa, "warn", false)
+		args.epa)
 	require.NoError(t, err)
 
 	expected := map[string]string{
@@ -279,7 +279,7 @@ func TestGenerateIntegrationsWithEpa(t *testing.T) {
 	// When
 	result, err := GenerateIntegrationsWithParams(args.rootModel, args.title, args.output,
 		args.project, args.filter, args.modules, args.exclude, args.clustered,
-		args.epa, "warn", false)
+		args.epa)
 	require.NoError(t, err)
 
 	expected := map[string]string{
@@ -304,7 +304,7 @@ func TestGenerateIntegrationsWithIndirectArrow(t *testing.T) {
 	// When
 	result, err := GenerateIntegrationsWithParams(args.rootModel, args.title, args.output,
 		args.project, args.filter, args.modules, args.exclude, args.clustered,
-		args.epa, "warn", false)
+		args.epa)
 	require.NoError(t, err)
 
 	expected := map[string]string{
@@ -335,7 +335,7 @@ func TestGenerateIntegrationsWithRestrictBy(t *testing.T) {
 	// When
 	result, err := GenerateIntegrationsWithParams(args.rootModel, args.title, args.output,
 		args.project, args.filter, args.modules, args.exclude, args.clustered,
-		args.epa, "warn", false)
+		args.epa)
 	require.NoError(t, err)
 
 	expected := map[string]string{
@@ -366,7 +366,7 @@ func TestGenerateIntegrationsWithFilter(t *testing.T) {
 	// When
 	result, err := GenerateIntegrationsWithParams(args.rootModel, args.title, args.output,
 		args.project, args.filter, args.modules, args.exclude, args.clustered,
-		args.epa, "warn", false)
+		args.epa)
 	require.NoError(t, err)
 
 	// Then
@@ -387,7 +387,7 @@ func TestGenerateIntegrationWithOrWithoutPassThrough(t *testing.T) {
 	// When
 	result, err := GenerateIntegrationsWithParams(args.rootModel, args.title, args.output,
 		args.project, args.filter, args.modules, args.exclude, args.clustered,
-		args.epa, "warn", false)
+		args.epa)
 	require.NoError(t, err)
 
 	expected := map[string]string{
@@ -415,7 +415,7 @@ func TestPassthrough2(t *testing.T) {
 	// When
 	result, err := GenerateIntegrationsWithParams(args.rootModel, args.title, args.output,
 		args.project, args.filter, args.modules, args.exclude, args.clustered,
-		args.epa, "warn", false)
+		args.epa)
 	require.NoError(t, err)
 
 	expected := map[string]string{
@@ -447,7 +447,7 @@ func TestGenerateIntegrationsWithPubSub(t *testing.T) {
 	// When
 	result, err := GenerateIntegrationsWithParams(args.rootModel, args.title, args.output,
 		args.project, args.filter, args.modules, args.exclude, args.clustered,
-		args.epa, "warn", false)
+		args.epa)
 	require.NoError(t, err)
 
 	expected := map[string]string{
@@ -472,7 +472,7 @@ func TestAllStmts(t *testing.T) {
 	// When
 	result, err := GenerateIntegrationsWithParams(args.rootModel, args.title, args.output,
 		args.project, args.filter, args.modules, args.exclude, args.clustered,
-		args.epa, "warn", false)
+		args.epa)
 	require.NoError(t, err)
 
 	expected := map[string]string{
@@ -487,8 +487,6 @@ func GenerateIntegrationsWithParams(
 	rootModel, title, output, project, filter, modules string,
 	exclude []string,
 	clustered, epa bool,
-	loglevel string,
-	isVerbose bool,
 ) (map[string]string, error) {
 	plantuml := ""
 	cmdContextParamIntgen := &CmdContextParamIntgen{
@@ -501,8 +499,6 @@ func GenerateIntegrationsWithParams(
 		exclude:   &exclude,
 		clustered: &clustered,
 		epa:       &epa,
-		loglevel:  &loglevel,
-		isVerbose: &isVerbose,
 		plantuml:  &plantuml,
 	}
 	return GenerateIntegrations(cmdContextParamIntgen)

--- a/sysl2/sysl/seqs.go
+++ b/sysl2/sysl/seqs.go
@@ -13,7 +13,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/afero"
-	"gopkg.in/alecthomas/kingpin.v2"
+	kingpin "gopkg.in/alecthomas/kingpin.v2"
 )
 
 type sequenceDiagParam struct {
@@ -93,7 +93,6 @@ func DoConstructSequenceDiagrams(
 	logger.Debugf("title: %s\n", *cmdContextParam.title)
 	logger.Debugf("modules: %s\n", *cmdContextParam.modulesFlag)
 	logger.Debugf("output: %s\n", *cmdContextParam.output)
-	logger.Debugf("loglevel: %s\n", *cmdContextParam.loglevel)
 
 	if *cmdContextParam.plantuml == "" {
 		plantuml := os.Getenv("SYSL_PLANTUML")
@@ -109,14 +108,6 @@ func DoConstructSequenceDiagrams(
 		logger.Debugf("blackbox: %s\n", *cmdContextParam.blackboxesFlag)
 	} else {
 		blackboxes = *cmdContextParam.blackboxes
-	}
-
-	if *cmdContextParam.isVerbose {
-		*cmdContextParam.loglevel = debug
-	}
-	// Default info
-	if level, has := syslutil.LogLevels[*cmdContextParam.loglevel]; has {
-		logger.SetLevel(level)
 	}
 
 	result := make(map[string]string)
@@ -273,9 +264,6 @@ func configureCmdlineForSeqgen(sysl *kingpin.Application, flagmap map[string][]s
 
 	returnValues.group = sd.Flag("groupby", "Enter the groupby attribute (apps having "+
 		"the same attribute value are grouped together in one box").Short('g').String()
-
-	returnValues.loglevel = sd.Flag("log", "log level[debug,info,warn,off]").Default("info").String()
-	returnValues.isVerbose = sd.Flag("verbose", "show output").Short('v').Default("false").Bool()
 
 	returnValues.modulesFlag = sd.Arg("modules",
 		"input files without .sysl extension and with leading /, eg: "+

--- a/sysl2/sysl/seqs.go
+++ b/sysl2/sysl/seqs.go
@@ -13,7 +13,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/afero"
-	kingpin "gopkg.in/alecthomas/kingpin.v2"
+	"gopkg.in/alecthomas/kingpin.v2"
 )
 
 type sequenceDiagParam struct {
@@ -220,10 +220,6 @@ func configureCmdlineForSeqgen(sysl *kingpin.Application, flagmap map[string][]s
 		"groupby", "endpoint", "app"}
 	sd := sysl.Command("sd", "Generate sequence diagram")
 	returnValues := &CmdContextParamSeqgen{}
-
-	returnValues.root = sd.Flag("root",
-		"sysl root directory for input model file (default: .)",
-	).Default(".").String()
 
 	returnValues.endpointFormat = sd.Flag("endpoint_format",
 		"Specify the format string for sequence diagram endpoints. May include "+

--- a/sysl2/sysl/seqs_test.go
+++ b/sysl2/sysl/seqs_test.go
@@ -485,12 +485,11 @@ func TestDoGenerateSequenceDiagrams(t *testing.T) {
 	t.Parallel()
 
 	args := &sdArgs{
-		rootModel: "./tests/",
-		modules:   "sequence_diagram_complex_format.sysl",
-		output:    "%(epname).png",
-		apps:      []string{"Project"},
+		modules: "sequence_diagram_complex_format.sysl",
+		output:  "%(epname).png",
+		apps:    []string{"Project"},
 	}
-	argsData := []string{"sysl", "sd", "--root", args.rootModel, "-o", args.output, "-a", args.apps[0], args.modules}
+	argsData := []string{"sysl", "sd", "-o", args.output, "-a", args.apps[0], args.modules}
 	sysl := kingpin.New("sysl", "System Modelling Language Toolkit")
 	configureCmdlineForSeqgen(sysl, map[string][]string{})
 	selectedCommand, err := sysl.Parse(argsData[1:])

--- a/sysl2/sysl/seqs_test.go
+++ b/sysl2/sysl/seqs_test.go
@@ -301,7 +301,7 @@ func TestDoConstructSequenceDiagramsNoSyslSdFiltersWithoutEndpoints(t *testing.T
 	// When
 	result, err := DoConstructSequenceDiagramsWithParams(args.rootModel, args.endpointFormat, args.appFormat,
 		args.title, args.output, args.modules, args.endpoints, args.apps, args.blackboxes,
-		args.groupbox, "warn", false)
+		args.groupbox)
 	require.NoError(t, err)
 
 	// Then
@@ -320,7 +320,7 @@ func TestDoConstructSequenceDiagramsMissingFile(t *testing.T) {
 	// When
 	_, err := DoConstructSequenceDiagramsWithParams(args.rootModel, args.endpointFormat, args.appFormat,
 		args.title, args.output, args.modules, args.endpoints, args.apps, args.blackboxes,
-		args.groupbox, "warn", false)
+		args.groupbox)
 	assert.Error(t, err)
 }
 
@@ -339,7 +339,7 @@ func TestDoConstructSequenceDiagramsNoSyslSdFilters(t *testing.T) {
 	assert.Panics(t, func() {
 		_, err := DoConstructSequenceDiagramsWithParams(args.rootModel, args.endpointFormat, args.appFormat,
 			args.title, args.output, args.modules, args.endpoints, args.apps, args.blackboxes,
-			args.groupbox, "warn", false)
+			args.groupbox)
 		assert.NoError(t, err)
 	})
 }
@@ -388,7 +388,7 @@ deactivate _0
 	// When
 	result, err := DoConstructSequenceDiagramsWithParams(args.rootModel, args.endpointFormat, args.appFormat,
 		args.title, args.output, args.modules, args.endpoints, args.apps, args.blackboxes,
-		args.groupbox, "warn", false)
+		args.groupbox)
 	require.NoError(t, err)
 
 	// Then
@@ -436,7 +436,7 @@ deactivate _0
 `
 	result, err := DoConstructSequenceDiagramsWithParams(args.rootModel, args.endpointFormat, args.appFormat,
 		args.title, args.output, args.modules, args.endpoints, args.apps, args.blackboxes,
-		args.groupbox, "warn", false)
+		args.groupbox)
 	require.NoError(t, err)
 	expected := map[string]string{"tests/call.png": expectContent}
 	// Then
@@ -474,7 +474,7 @@ activate _0
 	// When
 	result, err := DoConstructSequenceDiagramsWithParams(args.rootModel, args.endpointFormat, args.appFormat,
 		args.title, args.output, args.modules, args.endpoints, args.apps, args.blackboxes,
-		args.groupbox, "warn", false)
+		args.groupbox)
 	require.NoError(t, err)
 
 	// Then
@@ -527,7 +527,7 @@ end box`
 end box`
 	result, err := DoConstructSequenceDiagramsWithParams(args.rootModel, args.endpointFormat, args.appFormat,
 		args.title, args.output, args.modules, args.endpoints, args.apps, args.blackboxes,
-		args.groupbox, "warn", false)
+		args.groupbox)
 	require.NoError(t, err)
 
 	// Then
@@ -565,7 +565,7 @@ end box`
 end box`
 	result, err := DoConstructSequenceDiagramsWithParams(args.rootModel, args.endpointFormat, args.appFormat,
 		args.title, args.output, args.modules, args.endpoints, args.apps, args.blackboxes,
-		args.groupbox, "warn", false)
+		args.groupbox)
 	require.NoError(t, err)
 
 	// Then
@@ -599,7 +599,7 @@ func TestDoConstructSequenceDiagramWithOneEntityBox(t *testing.T) {
 end box`
 	result, err := DoConstructSequenceDiagramsWithParams(args.rootModel, args.endpointFormat, args.appFormat,
 		args.title, args.output, args.modules, args.endpoints, args.apps, args.blackboxes,
-		args.groupbox, "warn", false)
+		args.groupbox)
 	require.NoError(t, err)
 
 	// Then
@@ -613,8 +613,6 @@ func DoConstructSequenceDiagramsWithParams(
 	endpoints, apps []string,
 	blackboxes [][]string,
 	group string,
-	loglevel string,
-	isVerbose bool,
 ) (map[string]string, error) {
 	plantuml := ""
 	cmdContextParamSeqgen := &CmdContextParamSeqgen{
@@ -627,9 +625,7 @@ func DoConstructSequenceDiagramsWithParams(
 		endpointsFlag:  &endpoints,
 		appsFlag:       &apps,
 		blackboxes:     &blackboxes,
-		loglevel:       &loglevel,
 		group:          &group,
-		isVerbose:      &isVerbose,
 		plantuml:       &plantuml,
 	}
 	logger, _ := test.NewNullLogger()

--- a/sysl2/sysl/sysl.go
+++ b/sysl2/sysl/sysl.go
@@ -12,7 +12,7 @@ import (
 	"github.com/anz-bank/sysl/sysl2/sysl/validate"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/afero"
-	"gopkg.in/alecthomas/kingpin.v2"
+	kingpin "gopkg.in/alecthomas/kingpin.v2"
 )
 
 // Version contains the sysl binary version
@@ -26,6 +26,8 @@ const debug string = "debug"
 func main3(args []string, fs afero.Fs, logger *logrus.Logger) error {
 	syslCmd := kingpin.New("sysl", "System Modelling Language Toolkit")
 	syslCmd.Version(Version)
+
+	(&debugTypeData{}).add(syslCmd)
 	flagmap := map[string][]string{}
 	textpbParams := configureCmdlineForPb(syslCmd, flagmap)
 	codegenParams := configureCmdlineForCodegen(syslCmd, flagmap)
@@ -68,9 +70,6 @@ func main3(args []string, fs afero.Fs, logger *logrus.Logger) error {
 			return err
 		}
 		for k, v := range r {
-			if *intgenParams.isVerbose {
-				logrus.Debugf(k)
-			}
 			err := OutputPlantuml(k, *intgenParams.plantuml, v, fs)
 			if err != nil {
 				return fmt.Errorf("plantuml drawing error: %v", err)
@@ -85,9 +84,6 @@ func main3(args []string, fs afero.Fs, logger *logrus.Logger) error {
 			return err
 		}
 		for k, v := range outmap {
-			if *datagenParams.isVerbose {
-				logrus.Debugf(k)
-			}
 			err := OutputPlantuml(k, *datagenParams.plantuml, v, fs)
 			if err != nil {
 				return fmt.Errorf("plantuml drawing error: %v", err)
@@ -96,6 +92,40 @@ func main3(args []string, fs afero.Fs, logger *logrus.Logger) error {
 		return nil
 	}
 	return nil
+}
+
+type debugTypeData struct {
+	loglevel string
+	verbose  bool
+}
+
+//nolint:unparam
+func (d *debugTypeData) do(_ *kingpin.ParseContext) error {
+	if d.verbose {
+		d.loglevel = debug
+	}
+	// Default info
+	if level, has := syslutil.LogLevels[d.loglevel]; has {
+		logrus.SetLevel(level)
+	}
+
+	logrus.Infof("Logging: %+v", *d)
+	return nil
+}
+func (d *debugTypeData) add(app *kingpin.Application) {
+
+	var levels []string
+	for l := range syslutil.LogLevels {
+		if l != "" {
+			levels = append(levels, l)
+		}
+	}
+	app.Flag("log", fmt.Sprintf("log level: [%s]", strings.Join(levels, ","))).
+		HintOptions(levels...).
+		Default(levels[0]).
+		StringVar(&d.loglevel)
+	app.Flag("verbose", "enable verbose logging").Short('v').BoolVar(&d.verbose)
+	app.PreAction(d.do)
 }
 
 // main2 calls main3 and handles any errors it returns. It takes its output
@@ -136,11 +166,6 @@ func configureCmdlineForPb(sysl *kingpin.Application, flagmap map[string][]strin
 	returnValues.output = textpb.Flag("output", "output file name").Short('o').String()
 	returnValues.mode = textpb.Flag("mode", "output mode").Default("textpb").String()
 
-	returnValues.loglevel = textpb.Flag("log",
-		"log level[debug,info,warn,off]").Default("info").String()
-
-	returnValues.isVerbose = textpb.Flag("verbose", "show output").Short('v').Default("false").Bool()
-
 	returnValues.modules = textpb.Arg("modules", "input files without .sysl extension and with leading /, eg: "+
 		"/project_dir/my_models combine with --root if needed",
 	).String()
@@ -152,7 +177,6 @@ func doGeneratePb(textpbParams *CmdContextParamPbgen, fs afero.Fs) error {
 	logrus.Debugf("Root: %s\n", *textpbParams.root)
 	logrus.Debugf("Module: %s\n", *textpbParams.modules)
 	logrus.Debugf("Mode: %s\n", *textpbParams.mode)
-	logrus.Debugf("Log Level: %s\n", *textpbParams.loglevel)
 
 	format := strings.ToLower(*textpbParams.output)
 	toJSON := *textpbParams.mode == "json" || *textpbParams.mode == "" && strings.HasSuffix(format, ".json")
@@ -162,14 +186,6 @@ func doGeneratePb(textpbParams *CmdContextParamPbgen, fs afero.Fs) error {
 		return err
 	}
 	*textpbParams.output = strings.Trim(*textpbParams.output, " ")
-
-	if *textpbParams.isVerbose {
-		*textpbParams.loglevel = debug
-	}
-	// Default info
-	if level, has := syslutil.LogLevels[*textpbParams.loglevel]; has {
-		logrus.SetLevel(level)
-	}
 
 	switch *textpbParams.mode {
 	case "", "textpb", "json":

--- a/sysl2/sysl/sysl.go
+++ b/sysl2/sysl/sysl.go
@@ -9,7 +9,6 @@ import (
 	"github.com/anz-bank/sysl/sysl2/sysl/commands"
 
 	"github.com/anz-bank/sysl/sysl2/sysl/parse"
-	"github.com/anz-bank/sysl/sysl2/sysl/pbutil"
 	"github.com/anz-bank/sysl/sysl2/sysl/syslutil"
 	"github.com/anz-bank/sysl/sysl2/sysl/validate"
 	"github.com/sirupsen/logrus"
@@ -37,7 +36,6 @@ func main3(args []string, fs afero.Fs, logger *logrus.Logger) error {
 	}
 
 	flagmap := map[string][]string{}
-	textpbParams := configureCmdlineForPb(syslCmd, flagmap)
 	codegenParams := configureCmdlineForCodegen(syslCmd, flagmap)
 	sequenceParams := configureCmdlineForSeqgen(syslCmd, flagmap)
 	intgenParams := configureCmdlineForIntgen(syslCmd, flagmap)
@@ -58,9 +56,6 @@ func main3(args []string, fs afero.Fs, logger *logrus.Logger) error {
 	}
 
 	switch selectedCommand {
-	case "pb":
-		textpbParams.root = &runner.Root
-		return doGeneratePb(textpbParams, fs)
 	case "gen":
 		codegenParams.rootModel = &runner.Root
 		output, err := GenerateCode(codegenParams, fs, logger)
@@ -170,56 +165,6 @@ func main() {
 	if rc := main2(os.Args, afero.NewOsFs(), logrus.StandardLogger(), main3); rc != 0 {
 		os.Exit(rc)
 	}
-}
-
-func configureCmdlineForPb(sysl *kingpin.Application, flagmap map[string][]string) *CmdContextParamPbgen {
-	flagmap["pb"] = []string{"root", "output", "mode"}
-	textpb := sysl.Command("pb", "Generate textpb/json")
-	returnValues := &CmdContextParamPbgen{}
-
-	returnValues.output = textpb.Flag("output", "output file name").Short('o').String()
-	returnValues.mode = textpb.Flag("mode", "output mode").Default("textpb").String()
-
-	returnValues.modules = textpb.Arg("modules", "input files without .sysl extension and with leading /, eg: "+
-		"/project_dir/my_models combine with --root if needed",
-	).String()
-
-	return returnValues
-}
-
-func doGeneratePb(textpbParams *CmdContextParamPbgen, fs afero.Fs) error {
-	logrus.Debugf("Root: %s\n", *textpbParams.root)
-	logrus.Debugf("Module: %s\n", *textpbParams.modules)
-	logrus.Debugf("Mode: %s\n", *textpbParams.mode)
-
-	format := strings.ToLower(*textpbParams.output)
-	toJSON := *textpbParams.mode == "json" || *textpbParams.mode == "" && strings.HasSuffix(format, ".json")
-	logrus.Debugf("%s\n", *textpbParams.modules)
-	mod, err := parse.NewParser().Parse(*textpbParams.modules, syslutil.NewChrootFs(fs, *textpbParams.root))
-	if err != nil {
-		return err
-	}
-	*textpbParams.output = strings.Trim(*textpbParams.output, " ")
-
-	switch *textpbParams.mode {
-	case "", "textpb", "json":
-	default:
-		return fmt.Errorf("invalid -mode %#v", *textpbParams.mode)
-	}
-
-	if mod != nil {
-		if toJSON {
-			if *textpbParams.output == "-" {
-				return pbutil.FJSONPB(logrus.StandardLogger().Out, mod)
-			}
-			return pbutil.JSONPB(mod, *textpbParams.output, fs)
-		}
-		if *textpbParams.output == "-" {
-			return pbutil.FTextPB(logrus.StandardLogger().Out, mod)
-		}
-		return pbutil.TextPB(mod, *textpbParams.output, fs)
-	}
-	return nil
 }
 
 func generateAppargValidator(selectedCommand string, flags map[string][]string) func(*kingpin.Application) error {

--- a/sysl2/sysl/sysl.go
+++ b/sysl2/sysl/sysl.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/anz-bank/sysl/sysl2/sysl/parse"
 	"github.com/anz-bank/sysl/sysl2/sysl/syslutil"
-	"github.com/anz-bank/sysl/sysl2/sysl/validate"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/afero"
 	"gopkg.in/alecthomas/kingpin.v2"
@@ -31,7 +30,7 @@ func main3(args []string, fs afero.Fs, logger *logrus.Logger) error {
 	(&debugTypeData{}).add(syslCmd)
 
 	runner := commands.Runner{}
-	if err := runner.Init(syslCmd); err != nil {
+	if err := runner.Configure(syslCmd); err != nil {
 		return err
 	}
 
@@ -39,7 +38,6 @@ func main3(args []string, fs afero.Fs, logger *logrus.Logger) error {
 	codegenParams := configureCmdlineForCodegen(syslCmd, flagmap)
 	sequenceParams := configureCmdlineForSeqgen(syslCmd, flagmap)
 	intgenParams := configureCmdlineForIntgen(syslCmd, flagmap)
-	validateParams := validate.ConfigureCmdlineForValidate(syslCmd)
 	datagenParams := configureCmdlineForDatagen(syslCmd)
 
 	var selectedCommand string
@@ -88,8 +86,6 @@ func main3(args []string, fs afero.Fs, logger *logrus.Logger) error {
 			}
 		}
 		return nil
-	case "validate":
-		return validate.DoValidate(validateParams)
 	case "data":
 		datagenParams.root = &runner.Root
 		outmap, err := GenerateDataModels(datagenParams)

--- a/sysl2/sysl/sysl_test.go
+++ b/sysl2/sysl/sysl_test.go
@@ -387,7 +387,7 @@ func TestMain2WithGenerateCode(t *testing.T) {
 		[]string{
 			"sysl",
 			"gen",
-			"--root-model", ".",
+			"--root", ".",
 			"--model", "tests/model.sysl",
 			"--root-transform", ".",
 			"--transform", "tests/test.gen_multiple_annotations.sysl",
@@ -410,7 +410,7 @@ func TestMain2WithGenerateCodeReadOnlyFs(t *testing.T) {
 		[]string{
 			"sysl",
 			"gen",
-			"--root-model", ".",
+			"--root", ".",
 			"--model", "tests/model.sysl",
 			"--root-transform", ".",
 			"--transform", "tests/test.gen_multiple_annotations.sysl",
@@ -520,11 +520,11 @@ func TestMain2WithEmptyPbParams(t *testing.T) {
 
 	logger, hook := test.NewNullLogger()
 	memFs, fs := testutil.WriteToMemOverlayFs(".")
-	main2([]string{"sysl", "pb", "--root", "", "-o", " ", "--mode", "", "tests/call.sysl"}, fs, logger, main3)
+	main2([]string{"sysl", "pb", "-o", " ", "--mode", "", "tests/call.sysl"}, fs, logger, main3)
 	assert.Equal(t, logrus.ErrorLevel, hook.LastEntry().Level)
-	assert.Equal(t, "'root' value passed is empty\n"+
+	assert.Equal(t,
 		"'output' value passed is empty\n"+
-		"'mode' value passed is empty\n", hook.LastEntry().Message)
+			"'mode' value passed is empty\n", hook.LastEntry().Message)
 	testutil.AssertFsHasExactly(t, memFs)
 }
 
@@ -533,15 +533,15 @@ func TestMain2WithEmptyGenParams(t *testing.T) {
 
 	logger, hook := test.NewNullLogger()
 	memFs, fs := testutil.WriteToMemOverlayFs(".")
-	main2([]string{"sysl", "gen", "--root-model", " ", "--root-transform", "", "--model", " ", "--transform",
+	main2([]string{"sysl", "gen", "--root-transform", "", "--model", " ", "--transform",
 		"tests/test.gen_multiple_annotations.sysl", "--grammar", " ", "--start", "", "--outdir", " "}, fs, logger, main3)
 	assert.Equal(t, logrus.ErrorLevel, hook.LastEntry().Level)
-	assert.Equal(t, "'root-model' value passed is empty\n"+
+	assert.Equal(t,
 		"'root-transform' value passed is empty\n"+
-		"'model' value passed is empty\n"+
-		"'grammar' value passed is empty\n"+
-		"'start' value passed is empty\n"+
-		"'outdir' value passed is empty\n", hook.LastEntry().Message)
+			"'model' value passed is empty\n"+
+			"'grammar' value passed is empty\n"+
+			"'start' value passed is empty\n"+
+			"'outdir' value passed is empty\n", hook.LastEntry().Message)
 	testutil.AssertFsHasExactly(t, memFs)
 }
 
@@ -550,11 +550,11 @@ func TestMain2WithEmptyIntsParams(t *testing.T) {
 
 	logger, hook := test.NewNullLogger()
 	memFs, fs := testutil.WriteToMemOverlayFs(".")
-	main2([]string{"sysl", "ints", "--root", " ", "-o", "", "-j", " ", "indirect_1.sysl"}, fs, logger, main3)
+	main2([]string{"sysl", "ints", "-o", "", "-j", " ", "indirect_1.sysl"}, fs, logger, main3)
 	assert.Equal(t, logrus.ErrorLevel, hook.LastEntry().Level)
-	assert.Equal(t, "'root' value passed is empty\n"+
+	assert.Equal(t,
 		"'output' value passed is empty\n"+
-		"'project' value passed is empty\n", hook.LastEntry().Message)
+			"'project' value passed is empty\n", hook.LastEntry().Message)
 	testutil.AssertFsHasExactly(t, memFs)
 }
 

--- a/sysl2/sysl/sysl_test.go
+++ b/sysl2/sysl/sysl_test.go
@@ -523,8 +523,7 @@ func TestMain2WithEmptyPbParams(t *testing.T) {
 	main2([]string{"sysl", "pb", "-o", " ", "--mode", "", "tests/call.sysl"}, fs, logger, main3)
 	assert.Equal(t, logrus.ErrorLevel, hook.LastEntry().Level)
 	assert.Equal(t,
-		"'output' value passed is empty\n"+
-			"'mode' value passed is empty\n", hook.LastEntry().Message)
+		"enum value must be one of textpb,json, got ''", hook.LastEntry().Message)
 	testutil.AssertFsHasExactly(t, memFs)
 }
 

--- a/sysl2/sysl/sysl_test.go
+++ b/sysl2/sysl/sysl_test.go
@@ -476,7 +476,6 @@ func TestMain2WithTextPbModeStdout(t *testing.T) {
 			"--mode", "textpb",
 			"-o", " - ",
 			"tests/call.sysl",
-			"-v",
 		},
 		fs, logger, main3,
 	)
@@ -496,7 +495,6 @@ func TestMain2WithJSONModeStdout(t *testing.T) {
 			"--mode", "json",
 			"-o", " - ",
 			"tests/call.sysl",
-			"-v",
 		},
 		fs, logger, main3,
 	)

--- a/sysl2/sysl/types.go
+++ b/sysl2/sysl/types.go
@@ -45,17 +45,13 @@ type CmdContextParamCodegen struct {
 	grammar       *string
 	start         *string
 	outDir        *string
-	isVerbose     *bool
-	loglevel      *string
 }
 
 type CmdContextParamPbgen struct {
-	root      *string
-	output    *string
-	mode      *string
-	modules   *string
-	isVerbose *bool
-	loglevel  *string
+	root    *string
+	output  *string
+	mode    *string
+	modules *string
 }
 
 type CmdContextParamSeqgen struct {
@@ -70,8 +66,6 @@ type CmdContextParamSeqgen struct {
 	blackboxesFlag *map[string]string
 	blackboxes     *[][]string
 	plantuml       *string
-	loglevel       *string
-	isVerbose      *bool
 	group          *string
 }
 
@@ -86,8 +80,6 @@ type CmdContextParamIntgen struct {
 	clustered *bool
 	epa       *bool
 	plantuml  *string
-	isVerbose *bool
-	loglevel  *string
 }
 
 type CmdContextParamDatagen struct {
@@ -98,7 +90,5 @@ type CmdContextParamDatagen struct {
 	filter      *string
 	modules     *string
 	plantuml    *string
-	isVerbose   *bool
-	loglevel    *string
 	classFormat *string
 }

--- a/sysl2/sysl/types.go
+++ b/sysl2/sysl/types.go
@@ -47,13 +47,6 @@ type CmdContextParamCodegen struct {
 	outDir        *string
 }
 
-type CmdContextParamPbgen struct {
-	root    *string
-	output  *string
-	mode    *string
-	modules *string
-}
-
 type CmdContextParamSeqgen struct {
 	root           *string
 	endpointFormat *string

--- a/sysl2/sysl/validate/validate.go
+++ b/sysl2/sysl/validate/validate.go
@@ -10,7 +10,6 @@ import (
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/afero"
-	"gopkg.in/alecthomas/kingpin.v2"
 )
 
 type Validator struct {
@@ -21,30 +20,31 @@ type Validator struct {
 	messages    map[string][]msg.Msg
 }
 
-type CmdContextParamValidate struct {
-	rootTransform *string
-	transform     *string
-	grammar       *string
-	start         *string
+type Params struct {
+	RootTransform string
+	Transform     string
+	Grammar       string
+	Start         string
+
+	Filesystem afero.Fs
+	Logger     *logrus.Logger
 }
 
-func DoValidate(validateParams *CmdContextParamValidate) error {
-	logrus.Debugf("root-transform: %s\n", *validateParams.rootTransform)
-	logrus.Debugf("transform: %s\n", *validateParams.transform)
-	logrus.Debugf("grammar: %s\n", *validateParams.grammar)
-	logrus.Debugf("start: %s\n", *validateParams.start)
+func DoValidate(validateParams Params) error {
+	logrus.Debugf("root-transform: %s\n", validateParams.RootTransform)
+	logrus.Debugf("transform: %s\n", validateParams.Transform)
+	logrus.Debugf("grammar: %s\n", validateParams.Grammar)
+	logrus.Debugf("start: %s\n", validateParams.Start)
 
-	fs := afero.NewOsFs()
-
-	grammar, err := LoadGrammar(*validateParams.grammar, fs)
+	grammar, err := LoadGrammar(validateParams.Grammar, validateParams.Filesystem)
 	if err != nil {
 		return err
 	}
 
 	parser := parse.NewParser()
 	transform, err := loadTransform(
-		*validateParams.transform,
-		syslutil.NewChrootFs(fs, *validateParams.rootTransform),
+		validateParams.Transform,
+		syslutil.NewChrootFs(validateParams.Filesystem, validateParams.RootTransform),
 		parser,
 	)
 	if err != nil {
@@ -52,7 +52,7 @@ func DoValidate(validateParams *CmdContextParamValidate) error {
 	}
 
 	validator := NewValidator(grammar, transform, parser)
-	validator.Validate(*validateParams.start)
+	validator.Validate(validateParams.Start)
 	validator.LogMessages()
 
 	if len(validator.GetMessages()) > 0 {
@@ -313,16 +313,4 @@ func LoadGrammar(grammarFile string, fs afero.Fs) (*sysl.Application, error) {
 		return nil, err
 	}
 	return grammar.GetApps()[name], nil
-}
-
-// ConfigureCmdlineForValidate configures commandline params related to validate
-func ConfigureCmdlineForValidate(sysl *kingpin.Application) *CmdContextParamValidate {
-	validate := sysl.Command("validate", "Validate transform")
-	return &CmdContextParamValidate{
-		rootTransform: validate.Flag("root-transform",
-			"sysl root directory for input transform file (default: .)").Default(".").String(),
-		transform: validate.Flag("transform", "grammar.g").Default(".").String(),
-		grammar:   validate.Flag("grammar", "grammar.sysl").Default(".").String(),
-		start:     validate.Flag("start", "start rule for the grammar").Default(".").String(),
-	}
 }

--- a/sysl2/sysl/validate/validate.go
+++ b/sysl2/sysl/validate/validate.go
@@ -26,8 +26,6 @@ type CmdContextParamValidate struct {
 	transform     *string
 	grammar       *string
 	start         *string
-	isVerbose     *bool
-	loglevel      *string
 }
 
 func DoValidate(validateParams *CmdContextParamValidate) error {
@@ -35,16 +33,6 @@ func DoValidate(validateParams *CmdContextParamValidate) error {
 	logrus.Debugf("transform: %s\n", *validateParams.transform)
 	logrus.Debugf("grammar: %s\n", *validateParams.grammar)
 	logrus.Debugf("start: %s\n", *validateParams.start)
-	logrus.Debugf("loglevel: %s\n", *validateParams.loglevel)
-	logrus.Debugf("isVerbose: %v\n", *validateParams.isVerbose)
-
-	// Default info
-	if level, has := syslutil.LogLevels[*validateParams.loglevel]; has {
-		logrus.SetLevel(level)
-	}
-	if *validateParams.isVerbose {
-		*validateParams.loglevel = "debug"
-	}
 
 	fs := afero.NewOsFs()
 
@@ -336,7 +324,5 @@ func ConfigureCmdlineForValidate(sysl *kingpin.Application) *CmdContextParamVali
 		transform: validate.Flag("transform", "grammar.g").Default(".").String(),
 		grammar:   validate.Flag("grammar", "grammar.sysl").Default(".").String(),
 		start:     validate.Flag("start", "start rule for the grammar").Default(".").String(),
-		loglevel:  validate.Flag("log", "log level[debug,info,warn,off]").Default("info").String(),
-		isVerbose: validate.Flag("verbose", "show output").Short('v').Default("false").Bool(),
 	}
 }

--- a/sysl2/sysl/validate/validate_test.go
+++ b/sysl2/sysl/validate/validate_test.go
@@ -492,7 +492,7 @@ func TestValidatorDoValidate(t *testing.T) {
 		"Success": {
 			args: []string{
 				"sysl2", "validate", "--root-transform", "../tests", "--transform", "transform2.sysl", "--grammar",
-				"../tests/grammar.sysl", "--start", "goFile", "--verbose"}, isErrNil: true},
+				"../tests/grammar.sysl", "--start", "goFile"}, isErrNil: true},
 		"Grammar loading fail": {
 			args: []string{
 				"sysl2", "validate", "--root-transform", "../tests", "--transform", "transform2.sysl", "--grammar",

--- a/sysl2/sysl/validate/validate_test.go
+++ b/sysl2/sysl/validate/validate_test.go
@@ -6,8 +6,6 @@ import (
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/require"
 
-	"gopkg.in/alecthomas/kingpin.v2"
-
 	"github.com/anz-bank/sysl/sysl2/sysl/msg"
 	"github.com/anz-bank/sysl/sysl2/sysl/parse"
 	"github.com/anz-bank/sysl/sysl2/sysl/syslutil"
@@ -480,48 +478,4 @@ func TestValidatorLoadGrammarError(t *testing.T) {
 	grammar, err := LoadGrammar("foo/bar.g", afero.NewOsFs())
 	assert.Nil(t, grammar, "Unexpected result")
 	assert.NotNil(t, err, "Unexpected result")
-}
-
-func TestValidatorDoValidate(t *testing.T) {
-	t.Parallel()
-
-	cases := map[string]struct {
-		args     []string
-		isErrNil bool
-	}{
-		"Success": {
-			args: []string{
-				"sysl2", "validate", "--root-transform", "../tests", "--transform", "transform2.sysl", "--grammar",
-				"../tests/grammar.sysl", "--start", "goFile"}, isErrNil: true},
-		"Grammar loading fail": {
-			args: []string{
-				"sysl2", "validate", "--root-transform", "../tests", "--transform", "transform2.sysl", "--grammar",
-				"../tests/go.sysl", "--start", "goFile"}, isErrNil: false},
-		"Transform loading fail": {
-			args: []string{
-				"sysl2", "validate", "--root-transform", "../tests", "--transform", "tfm.sysl", "--grammar",
-				"../tests/grammar.sysl", "--start", "goFile"}, isErrNil: false},
-		"Has validation messages": {
-			args: []string{
-				"sysl2", "validate", "--root-transform", "../tests", "--transform", "transform1.sysl", "--grammar",
-				"../tests/grammar.sysl", "--start", "goFile"}, isErrNil: false},
-	}
-
-	for name, test := range cases {
-		args := test.args
-		isErrNil := test.isErrNil
-		t.Run(name, func(t *testing.T) {
-			sysl := kingpin.New("sysl", "System Modelling Language Toolkit")
-			validateParams := ConfigureCmdlineForValidate(sysl)
-			if _, err := sysl.Parse(args[1:]); err != nil {
-				assert.FailNow(t, "Failed to parse args")
-			}
-			err := DoValidate(validateParams)
-			if isErrNil {
-				assert.Nil(t, err, "Unexpected result")
-			} else {
-				assert.NotNil(t, err, "Unexpected result")
-			}
-		})
-	}
 }

--- a/test-gosysl.bat
+++ b/test-gosysl.bat
@@ -3,7 +3,7 @@ SETLOCAL EnableDelayedExpansion
 
 set ROOT=sysl2\sysl\tests
 for /R %ROOT% %%f in (*.sysl) do (
-	dist\gosysl.exe pb --mode textpb --root %ROOT% -o %ROOT%\%%~nf.win.txt --log debug /%%~nf.sysl || exit /b !errorlevel!
+	dist\gosysl.exe --log debug pb --mode textpb --root %ROOT% -o %ROOT%\%%~nf.win.txt  /%%~nf.sysl || exit /b !errorlevel!
 )
 
 del sysl2\sysl\tests\*.win.txt

--- a/test-gosysl.sh
+++ b/test-gosysl.sh
@@ -4,18 +4,18 @@ set -e
 ROOT="sysl2/sysl/tests"
 for f in $ROOT/*.sysl; do
  f=`basename $f`
- $GOPATH/bin/sysl pb --mode textpb --root $ROOT -o $ROOT/$f.out.txt /$f -v
+ $GOPATH/bin/sysl -v pb --mode textpb --root $ROOT -o $ROOT/$f.out.txt /$f
 done;
 
 rm $ROOT/*.out.txt
 
-$GOPATH/bin/sysl sd -a 'Project' $ROOT/sequence_diagram_project.sysl -v
+$GOPATH/bin/sysl -v sd -a 'Project' $ROOT/sequence_diagram_project.sysl
 rm _.png
 
-$GOPATH/bin/sysl sd -s 'WebFrontend <- RequestProfile' -o sd.png $ROOT/sequence_diagram_project.sysl -v
+$GOPATH/bin/sysl -v sd -s 'WebFrontend <- RequestProfile' -o sd.png $ROOT/sequence_diagram_project.sysl
 rm sd.png
 
-$GOPATH/bin/sysl ints -j 'Project' $ROOT/integration_test.sysl -v
+$GOPATH/bin/sysl -v ints -j 'Project' $ROOT/integration_test.sysl
 rm _.png
 
 version=`$GOPATH/bin/sysl --version 2>&1 >/dev/null`


### PR DESCRIPTION

Changes proposed in this pull request:
- Moves verbose/log level args to top level sysl flags (can be anywhere on the command line now)
- Add the top level --root arg used for the model root for all sub commands
- Automatically add the MODULE arg at the end of each command which requires it
- framwork to move the module loading to a single spot
- give the pb command a better name (aliased to pb so old scripts and muscle-memory work)

@anz-bank/sysl-developers
