### PR TITLE
Introduce a very basic object model for swagger imports to allow futu…

### DIFF
--- a/sysl2/sysl/swagger/endpoints.go
+++ b/sysl2/sysl/swagger/endpoints.go
@@ -45,31 +45,26 @@ func initEndpoint(path string,
 func buildResponses(path string, responses *spec.Responses, types TypeList, logger *logrus.Logger) []Response {
 	var outs []Response
 
-	fn := func(n string) Response {
-		return Response{Text: n}
-	}
-
 	for statusCode, response := range responses.StatusCodeResponses {
 		if schema := response.Schema; schema != nil {
-
 			t, found := types.FindFromSchema(*schema, &typeData{logger: logger})
 			if !found {
 				logger.Panicf("Responses type for code %d not found, endpoint: %s", statusCode, path)
 			}
 			outs = append(outs, Response{Type: t})
 		} else {
-			outs = append(outs, fn(fmt.Sprintf("%d", statusCode)))
+			outs = append(outs, Response{Text: fmt.Sprintf("%d", statusCode)})
 		}
 	}
 	if responses.Extensions != nil {
 		logger.Warnf("x-* responses not implemented, endpoint: %s", path)
 		for key := range responses.Extensions {
-			outs = append(outs, fn(key))
+			outs = append(outs, Response{Text: key})
 		}
 	}
 	if responses.Default != nil {
 		logger.Warnf("default responses not implemented, endpoint: %s", path)
-		outs = append(outs, fn("default"))
+		outs = append(outs, Response{Text: "default"})
 	}
 
 	return outs

--- a/sysl2/sysl/swagger/endpoints.go
+++ b/sysl2/sysl/swagger/endpoints.go
@@ -1,6 +1,7 @@
 package swagger
 
 import (
+	"fmt"
 	"sort"
 	"strings"
 
@@ -8,13 +9,19 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
+// Response is either going to be freetext or a type
+type Response struct {
+	Text string
+	Type Type
+}
+
 type Endpoint struct {
 	Path        string
 	Description string
 
 	Params Parameters
 
-	Responses *spec.Responses
+	Responses []Response
 }
 
 // nolint:gochecknoglobals
@@ -29,10 +36,43 @@ func initEndpoint(path string,
 	res := Endpoint{
 		Path:        path,
 		Description: op.Description,
-		Responses:   op.Responses,
+		Responses:   buildResponses(path, op.Responses, types, logger),
 		Params:      buildParameters(op.Parameters, types, globals, apiParams, logger),
 	}
 	return res
+}
+
+func buildResponses(path string, responses *spec.Responses, types TypeList, logger *logrus.Logger) []Response {
+	var outs []Response
+
+	fn := func(n string) Response {
+		return Response{Text: n}
+	}
+
+	for statusCode, response := range responses.StatusCodeResponses {
+		if schema := response.Schema; schema != nil {
+
+			t, found := types.FindFromSchema(*schema, &typeData{logger: logger})
+			if !found {
+				logger.Panicf("Responses type for code %d not found, endpoint: %s", statusCode, path)
+			}
+			outs = append(outs, Response{Type: t})
+		} else {
+			outs = append(outs, fn(fmt.Sprintf("%d", statusCode)))
+		}
+	}
+	if responses.Extensions != nil {
+		logger.Warnf("x-* responses not implemented, endpoint: %s", path)
+		for key := range responses.Extensions {
+			outs = append(outs, fn(key))
+		}
+	}
+	if responses.Default != nil {
+		logger.Warnf("default responses not implemented, endpoint: %s", path)
+		outs = append(outs, fn("default"))
+	}
+
+	return outs
 }
 
 func InitEndpoints(doc *spec.Swagger, types TypeList, globals Parameters, logger *logrus.Logger) map[string][]Endpoint {

--- a/sysl2/sysl/swagger/endpoints.go
+++ b/sysl2/sysl/swagger/endpoints.go
@@ -49,7 +49,8 @@ func buildResponses(path string, responses *spec.Responses, types TypeList, logg
 		if schema := response.Schema; schema != nil {
 			t, found := types.FindFromSchema(*schema, &typeData{logger: logger})
 			if !found {
-				logger.Panicf("Responses type for code %d not found, endpoint: %s", statusCode, path)
+				logger.Errorf("Responses type for code %d not found, endpoint: %s, skipping", statusCode, path)
+				continue
 			}
 			outs = append(outs, Response{Type: t})
 		} else {

--- a/sysl2/sysl/swagger/import.go
+++ b/sysl2/sysl/swagger/import.go
@@ -311,11 +311,7 @@ func (si *swaggerImporter) writeDefinition(t *StandardType) {
 
 func isExternalAlias(item Type) bool {
 	switch item.(type) {
-	case *Alias:
-		return true
-	case *Array:
-		return true
-	case *Enum:
+	case *Alias, *Array, *Enum:
 		return true
 	}
 	return false
@@ -330,7 +326,7 @@ func (si *swaggerImporter) writeExternalAlias(item Type) {
 			aliasType = getSyslTypeName(t.Properties[0].Type)
 		}
 	case *Alias:
-		aliasType = getSyslTypeName(t.Alias)
+		aliasType = getSyslTypeName(t.Target)
 	case *Array:
 		aliasType = getSyslTypeName(item)
 		aliasName = t.name


### PR DESCRIPTION
The sysl writing part of the swagger importing could easily be extended to be able to import other document formats with a bit of rework on the types that it uses. This PR addresses that.

The import.go file (which should now be renamed) is responsible for writing the sysl file from a import-file-agnostic data model (i.e using no swagger types).
