### PR TITLE
Update transform validator

### DIFF
--- a/sysl2/sysl/msg/Message.go
+++ b/sysl2/sysl/msg/Message.go
@@ -52,7 +52,7 @@ var (
 		ErrEntryPointUndefined:     "Entry point view: (%s) is undefined",
 		ErrInvalidEntryPointReturn: "Return type of entry point view: (%s) should be (%s)",
 		ErrUndefinedView:           "View (%s) is undefined",
-		ErrInvalidReturn:           "In view (%s), return type should be (%s)",
+		ErrInvalidReturn:           "In view (%s), return type is invalid. (%s)",
 		ErrMissingReqField:         "Missing required field (%s) in View (%s) with return Type (%s)",
 		ErrExcessAttr:              "Excess Attribute (%s), defined in View (%s), having return Type (%s)",
 		ErrInvalidOption:           "In View %s, (%s) does not match any of the options for return Type (%s)",

--- a/sysl2/sysl/tests/transform1.sysl
+++ b/sysl2/sysl/tests/transform1.sysl
@@ -262,3 +262,66 @@ CodeGenTransform:
       TopLevelDecl = ""
     )
 
+  !view validViewReturnSingleObj(input <: string) -> VarDecl:
+    input -> (:
+      identifier = input
+      TypeName = "typeName"
+    )
+
+  !view validViewReturnSequence(inputs <: sequence of string) -> sequence of VarDecl:
+    inputs -> (input:
+      identifier = input
+      TypeName = "typeName"
+    )
+
+  !view validViewReturnSet(inputs <: set of string) -> set of VarDecl:
+    inputs -> (input:
+      identifier = input
+      TypeName = "typeName"
+    )
+
+  !view invalidViewReturnSingleObj(inputs <: sequence of string) -> VarDecl:
+    inputs -> (input:
+      identifier = input
+      TypeName = "typeName"
+    )
+
+  !view invalidViewReturnSequence(inputs <: sequence of string) -> sequence of VarDecl:
+    inputs -> (:
+      identifier = input
+      TypeName = "typeName"
+    )
+
+  !view invalidViewReturnSet(inputs <: set of string) -> set of VarDecl:
+    inputs -> (:
+      identifier = input
+      TypeName = "typeName"
+    )
+
+  !view validInnerTfmReturnSingleObj(input <: string) -> StatementList:
+    input -> (:
+      Statement = input -> <Statement>(:
+        identifier = input
+      )
+    )
+
+  !view validInnerTfmReturnCollection(inputs <: sequence of string) -> StatementList:
+    inputs -> (:
+      Statement = inputs -> <sequence of Statement>(input:
+        identifier = input
+      )
+    )
+
+  !view InvalidInnerTfmReturnSingleObj(inputs <: sequence of string) -> StatementList:
+    inputs -> (:
+      Statement = inputs -> <Statement>(input:
+        identifier = input
+      )
+    )
+
+  !view InvalidInnerTfmReturnCollection(input <: string) -> StatementList:
+    input -> (:
+      Statement = input -> <sequence of Statement>(:
+        identifier = input
+      )
+    )


### PR DESCRIPTION
Changes proposed in this pull request:

Update validator so that it returns errors when return type (single object vs collection) of a transform does not match with expected return type.