### PR TITLE
Changes to the binary arg transform code:

### DIFF
--- a/sysl2/sysl/eval/exprOp.go
+++ b/sysl2/sysl/eval/exprOp.go
@@ -29,12 +29,6 @@ func leInt64(lhs, rhs *sysl.Value) *sysl.Value {
 	return MakeValueBool(lhs.GetI() <= rhs.GetI())
 }
 
-func not(f func(lhs, rhs *sysl.Value) *sysl.Value) func(lhs, rhs *sysl.Value) *sysl.Value {
-	return func(lhs, rhs *sysl.Value) *sysl.Value {
-		return MakeValueBool(!f(lhs, rhs).GetB())
-	}
-}
-
 func subInt64(lhs, rhs *sysl.Value) *sysl.Value {
 	return MakeValueI64(lhs.GetI() - rhs.GetI())
 }
@@ -222,6 +216,12 @@ func stringInSet(lhs, rhs *sysl.Value) *sysl.Value {
 		}
 	}
 	return MakeValueBool(false)
+}
+
+func stringInMapKey(lhs, rhs *sysl.Value) *sysl.Value {
+	str := lhs.GetS()
+	_, has := rhs.GetMap().Items[str]
+	return MakeValueBool(has)
 }
 
 func intSet(list []*sysl.Value) map[int64]struct{} {

--- a/sysl2/sysl/eval/unaryEval.go
+++ b/sysl2/sysl/eval/unaryEval.go
@@ -20,8 +20,11 @@ func evalUnaryFunc(op sysl.Expr_UnExpr_Op, arg *sysl.Value) *sysl.Value {
 }
 
 func unaryNeg(arg *sysl.Value) *sysl.Value {
-	if x, ok := arg.Value.(*sysl.Value_I); ok {
+	switch x := arg.Value.(type) {
+	case *sysl.Value_I:
 		return MakeValueI64(-x.I)
+	case *sysl.Value_B:
+		return MakeValueBool(!x.B)
 	}
 	panic(errors.Errorf("unaryNeg for %v not supported", arg.Value))
 }


### PR DESCRIPTION
* Remove the need to manually define callbacks for the NEQ op, simply check for a EQ and negate the result
* Add "in" support for maps (i.e '"foo" in foo.keys)
* Add unary negate support for binary values


@anz-bank/sysl-developers
