### PR TITLE
Enforce set logic for transforms that return "set of"

### DIFF
--- a/sysl2/proto/grammar.pb.go
+++ b/sysl2/proto/grammar.pb.go
@@ -5,11 +5,10 @@ package sysl
 
 import (
 	fmt "fmt"
-	math "math"
-
 	proto "github.com/golang/protobuf/proto"
 	descriptor "github.com/golang/protobuf/protoc-gen-go/descriptor"
 	empty "github.com/golang/protobuf/ptypes/empty"
+	math "math"
 )
 
 // Reference imports to suppress errors if they are not otherwise used.

--- a/sysl2/sysl/Codegen_test.go
+++ b/sysl2/sysl/Codegen_test.go
@@ -132,7 +132,6 @@ func TestGenerateCodePerType(t *testing.T) {
 
 func TestGenerateCodePutDepPackageAndParamTypeInComment(t *testing.T) {
 	t.Parallel()
-
 	output, err := GenerateCodeWithParams(".", "tests/model_with_deps.sysl", ".", "tests/xform_with_deps.sysl",
 		"tests/test.gen.g", "javaFile")
 	require.NoError(t, err)
@@ -144,7 +143,53 @@ func TestGenerateCodePutDepPackageAndParamTypeInComment(t *testing.T) {
 	comment1 := n1[1].(Node)
 	assert.Len(t, comment1, 1)
 
-	for i, comment := range []string{"dep.GET /dep/{id}"} {
+	for i, comment := range []string{"dep.GET /dep/{id},dep.GET /moredep/{id}"} {
+		comment0 := comment1[i].(Node)
+		assert.Len(t, comment0, 1)
+		comment0_0 := comment0[0].(string)
+		assert.Equal(t, comment, comment0_0)
+	}
+}
+
+func TestGenerateCodePutDepPackageInCommentUsingSets(t *testing.T) {
+	t.Parallel()
+	output, err := GenerateCodeWithParams(".",
+		"tests/model_with_deps.sysl", ".",
+		"tests/xform_with_deps_pkg_set.sysl",
+		"tests/test.gen.g", "javaFile")
+	require.NoError(t, err)
+	root := output[0].output
+	assert.Len(t, output, 1)
+	assert.Len(t, root, 1)
+	n1 := root[0].(Node)
+	assert.Len(t, n1, 4)
+	comment1 := n1[1].(Node)
+	assert.Len(t, comment1, 1)
+
+	for i, comment := range []string{"dep"} {
+		comment0 := comment1[i].(Node)
+		assert.Len(t, comment0, 1)
+		comment0_0 := comment0[0].(string)
+		assert.Equal(t, comment, comment0_0)
+	}
+}
+
+func TestGenerateCodePutDepPackageInCommentUsingLists(t *testing.T) {
+	t.Parallel()
+	output, err := GenerateCodeWithParams(".",
+		"tests/model_with_deps.sysl", ".",
+		"tests/xform_with_deps_pkg_list.sysl",
+		"tests/test.gen.g", "javaFile")
+	require.NoError(t, err)
+	root := output[0].output
+	assert.Len(t, output, 1)
+	assert.Len(t, root, 1)
+	n1 := root[0].(Node)
+	assert.Len(t, n1, 4)
+	comment1 := n1[1].(Node)
+	assert.Len(t, comment1, 1)
+
+	for i, comment := range []string{"dep,dep"} {
 		comment0 := comment1[i].(Node)
 		assert.Len(t, comment0, 1)
 		comment0_0 := comment0[0].(string)

--- a/sysl2/sysl/eval/ValueUtil.go
+++ b/sysl2/sysl/eval/ValueUtil.go
@@ -74,6 +74,18 @@ func MakeValueSet() *sysl.Value {
 	}
 }
 
+// GetValueSlice returns the slice from either a set or a list
+func GetValueSlice(obj *sysl.Value) []*sysl.Value {
+	switch obj.Value.(type) {
+	case *sysl.Value_List_:
+		return obj.GetList().Value
+	case *sysl.Value_Set:
+		return obj.GetSet().Value
+	default:
+		panic("GetValueSlice expecting a collection type")
+	}
+}
+
 // IsCollectionType does obj holds multiple instances of the same thing?
 func IsCollectionType(obj *sysl.Value) bool {
 	switch obj.Value.(type) {

--- a/sysl2/sysl/eval/ValueUtil_test.go
+++ b/sysl2/sysl/eval/ValueUtil_test.go
@@ -445,3 +445,40 @@ func TestAddModule(t *testing.T) {
 	_, hasKey := module["types"]
 	assert.Equal(t, true, hasKey)
 }
+
+func TestGetValueSlice_NullPanic(t *testing.T) {
+	defer func() {
+		r := recover()
+		require.NotNil(t, r)
+	}()
+	_ = GetValueSlice(MakeValueBool(true))
+}
+
+func TestGetValueSlice_ListNoPanic(t *testing.T) {
+	defer func() {
+		r := recover()
+		require.Nil(t, r)
+	}()
+	_ = GetValueSlice(MakeValueList(MakeValueBool(true)))
+}
+
+func TestGetValueSlice_SetNoPanic(t *testing.T) {
+	defer func() {
+		r := recover()
+		require.Nil(t, r)
+	}()
+	_ = GetValueSlice(MakeValueSet())
+}
+
+func TestGetValueSlice_SameList(t *testing.T) {
+	boolList := MakeValueList(MakeValueBool(true))
+	result := GetValueSlice(boolList)
+	assert.Equal(t, &result[0], &boolList.GetList().Value[0])
+}
+
+func TestGetValueSlice_SameSet(t *testing.T) {
+	boolSet := MakeValueSet()
+	boolSet.GetSet().Value = append(boolSet.GetSet().Value, MakeValueBool(true))
+	result := GetValueSlice(boolSet)
+	assert.Equal(t, &result[0], &boolSet.GetSet().Value[0])
+}

--- a/sysl2/sysl/eval/binexprEval.go
+++ b/sysl2/sysl/eval/binexprEval.go
@@ -57,8 +57,9 @@ var (
 		makeKey(sysl.Expr_BinExpr_ADD, ValueInt, ValueInt):       addInt64,
 		makeKey(sysl.Expr_BinExpr_ADD, ValueString, ValueString): addString,
 		makeKey(sysl.Expr_BinExpr_AND, ValueBool, ValueBool):     andBool,
-		makeKey(sysl.Expr_BinExpr_BITOR, ValueList, ValueList):   concatList,
+		makeKey(sysl.Expr_BinExpr_BITOR, ValueList, ValueList):   concatListList,
 		makeKey(sysl.Expr_BinExpr_BITOR, ValueSet, ValueSet):     setUnion,
+		makeKey(sysl.Expr_BinExpr_BITOR, ValueList, ValueSet):    concatListSet,
 		makeKey(sysl.Expr_BinExpr_DIV, ValueInt, ValueInt):       divInt64,
 		makeKey(sysl.Expr_BinExpr_EQ, ValueBool, ValueBool):      cmpBool,
 		makeKey(sysl.Expr_BinExpr_EQ, ValueInt, ValueInt):        cmpInt,
@@ -87,8 +88,10 @@ var (
 		makeKey(sysl.Expr_BinExpr_FLATTEN, ValueList, ValueNoArg): flattenListList, // empty list
 		makeKey(sysl.Expr_BinExpr_FLATTEN, ValueList, ValueList):  flattenListList,
 		makeKey(sysl.Expr_BinExpr_FLATTEN, ValueList, ValueSet):   flattenListSet,
+		makeKey(sysl.Expr_BinExpr_FLATTEN, ValueSet, ValueList):   flattenSetList,
 		makeKey(sysl.Expr_BinExpr_FLATTEN, ValueList, ValueMap):   flattenListMap,
 		makeKey(sysl.Expr_BinExpr_FLATTEN, ValueSet, ValueMap):    flattenSetMap,
+		makeKey(sysl.Expr_BinExpr_FLATTEN, ValueSet, ValueNoArg):  flattenSetSet, // empty list
 		makeKey(sysl.Expr_BinExpr_FLATTEN, ValueSet, ValueSet):    flattenSetSet,
 		makeKey(sysl.Expr_BinExpr_WHERE, ValueList, ValueNoArg):   whereList,
 		makeKey(sysl.Expr_BinExpr_WHERE, ValueList, ValueList):    whereList,

--- a/sysl2/sysl/eval/exprEval_test.go
+++ b/sysl2/sysl/eval/exprEval_test.go
@@ -515,3 +515,35 @@ func TestListOfTypeNames(t *testing.T) {
 	assert.NotNil(t, l)
 	assert.Len(t, l.Value, 2)
 }
+
+func TestListAppender_Nil(t *testing.T) {
+	result := listAppender(nil, nil)
+	require.Nil(t, result[0])
+}
+
+func TestSetAppender_Nil(t *testing.T) {
+	result := setAppender(nil, nil)
+	require.Nil(t, result[0])
+}
+
+func TestListAppender_AllowDup(t *testing.T) {
+	val := MakeValueString("val")
+	list := MakeValueList(MakeValueString("val"))
+
+	result := listAppender(list.GetList().Value, val)
+
+	require.Len(t, result, 2)
+	assert.Equal(t, "val", result[0].GetS())
+	assert.Equal(t, "val", result[1].GetS())
+}
+
+func TestListAppender_BlockDup(t *testing.T) {
+	val := MakeValueString("val")
+	set := MakeValueSet()
+	set.GetSet().Value = append(set.GetSet().Value, MakeValueString("val"))
+
+	result := setAppender(set.GetSet().Value, val)
+
+	require.Len(t, result, 1)
+	assert.Equal(t, "val", result[0].GetS())
+}

--- a/sysl2/sysl/eval/exprOp.go
+++ b/sysl2/sysl/eval/exprOp.go
@@ -126,6 +126,23 @@ func flattenListSet(
 	return listResult
 }
 
+func flattenSetList(
+	txApp *sysl.Application,
+	assign Scope,
+	list *sysl.Value,
+	scopeVar string,
+	rhs *sysl.Expr,
+) *sysl.Value {
+	setResult := MakeValueSet()
+	for _, l := range list.GetSet().Value {
+		for _, ll := range l.GetList().Value {
+			assign[scopeVar] = ll
+			AppendItemToValueList(setResult.GetSet(), Eval(txApp, assign, rhs))
+		}
+	}
+	return setResult
+}
+
 func flattenSetMap(
 	txApp *sysl.Application,
 	assign Scope,
@@ -168,17 +185,23 @@ func flattenSetSet(txApp *sysl.Application,
 	return setResult
 }
 
-func concatList(lhs, rhs *sysl.Value) *sysl.Value {
+func concat(lhs, rhs *sysl.Value_List) *sysl.Value {
 	result := MakeValueList()
 	{
 		result := result.GetList()
-		lhs := lhs.GetList()
-		rhs := rhs.GetList()
 		result.Value = lhs.Value
 		result.Value = append(result.Value, rhs.Value...)
 		logrus.Tracef("concatList: lhs %d | rhs %d = %d\n", len(lhs.Value), len(rhs.Value), len(result.Value))
 	}
 	return result
+}
+
+func concatListList(lhs, rhs *sysl.Value) *sysl.Value {
+	return concat(lhs.GetList(), rhs.GetList())
+}
+
+func concatListSet(lhs, rhs *sysl.Value) *sysl.Value {
+	return concat(lhs.GetList(), rhs.GetSet())
 }
 
 func setUnion(lhs, rhs *sysl.Value) *sysl.Value {

--- a/sysl2/sysl/eval/exprOp_test.go
+++ b/sysl2/sysl/eval/exprOp_test.go
@@ -3,6 +3,8 @@ package eval
 import (
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	sysl "github.com/anz-bank/sysl/src/proto"
 	"github.com/stretchr/testify/require"
 )
@@ -73,4 +75,86 @@ func TestCmpListNull_RhsValid(t *testing.T) {
 	rhs := makeNonNullValueList()
 
 	require.Equal(t, false, cmpListNull(lhs, rhs).GetB())
+}
+
+func TestConcat_NilNilPanic(t *testing.T) {
+	defer func() {
+		r := recover()
+		require.NotNil(t, r)
+	}()
+	_ = concat(nil, nil)
+}
+
+func TestConcat_NilListPanic(t *testing.T) {
+	defer func() {
+		r := recover()
+		require.NotNil(t, r)
+	}()
+	_ = concat(makeNullValueList().GetList(), makeNullValueList().GetList())
+}
+
+func TestConcat_EmptyList(t *testing.T) {
+	result := concatListList(MakeValueList(), MakeValueList())
+	assert.Equal(t, []*sysl.Value{}, result.GetList().Value)
+}
+
+func TestConcat_OneItemList(t *testing.T) {
+	lhs := MakeValueList(MakeValueBool(true))
+	rhs := MakeValueList(MakeValueBool(false))
+	result := concatListList(lhs, rhs)
+	assert.Equal(t, true, result.GetList().Value[0].GetB())
+	assert.Equal(t, false, result.GetList().Value[1].GetB())
+}
+
+func TestConcat_OneItemSet(t *testing.T) {
+	lhs := MakeValueList(MakeValueBool(true))
+	rhs := MakeValueSet()
+	rhs.GetSet().Value = append(rhs.GetSet().Value, MakeValueBool(false))
+
+	result := concatListSet(lhs, rhs)
+	assert.Equal(t, true, result.GetList().Value[0].GetB())
+	assert.Equal(t, false, result.GetList().Value[1].GetB())
+}
+
+func TestFlattenSetList_AllNilPanic(t *testing.T) {
+	defer func() {
+		r := recover()
+		require.NotNil(t, r)
+	}()
+	_ = flattenSetList(nil, Scope{}, nil, "", nil)
+}
+
+func TestFlattenSetList_NameExpr(t *testing.T) {
+	nameExpr := &sysl.Expr{
+		Expr: &sysl.Expr_Name{
+			Name: "var",
+		},
+	}
+
+	s := Scope{}
+	s.AddString("var", "name1")
+
+	setOfList := MakeValueSet()
+	setOfList.GetSet().Value = append(setOfList.GetSet().Value,
+		MakeValueList(MakeValueString("name2")))
+	result := flattenSetList(nil, s, setOfList, "var", nameExpr)
+	require.Equal(t, "name2", result.GetSet().Value[0].GetS())
+}
+
+func TestFlattenListSet_NameExpr(t *testing.T) {
+	nameExpr := &sysl.Expr{
+		Expr: &sysl.Expr_Name{
+			Name: "var",
+		},
+	}
+
+	s := Scope{}
+	s.AddString("var", "name1")
+
+	listOfSet := MakeValueList(MakeValueSet())
+	listOfSet.GetList().Value[0].GetSet().Value = append(
+		listOfSet.GetList().Value[0].GetSet().Value,
+		MakeValueString("name2"))
+	result := flattenListSet(nil, s, listOfSet, "var", nameExpr)
+	require.Equal(t, "name2", result.GetList().Value[0].GetS())
 }

--- a/sysl2/sysl/tests/deps.sysl
+++ b/sysl2/sysl/tests/deps.sysl
@@ -7,3 +7,8 @@ Dep [package="dep"]:
     /{id<:int}:
       GET:
         return Dep
+
+  /moredep:
+    /{id<:int}:
+      GET:
+        return Dep

--- a/sysl2/sysl/tests/model_with_deps.sysl
+++ b/sysl2/sysl/tests/model_with_deps.sysl
@@ -10,4 +10,5 @@ ModelWithDeps [package="model"]:
     /{id<:int}:
       GET:
         Dep <- GET /dep/{id}
+        Dep <- GET /moredep/{id}
         return Response

--- a/sysl2/sysl/tests/xform_with_deps_pkg_list.sysl
+++ b/sysl2/sysl/tests/xform_with_deps_pkg_list.sysl
@@ -14,12 +14,8 @@ TransformDeps:
       let myList = app.endpoints -> <sequence of out> (ep:
         let calls = ep.value.stmts where (.type == "call") -> <sequence of out> (call:
           let pkgList = module.apps where(.value.name == call.target) -> <sequence of out> (dep:
-            let depEpList = dep.value.endpoints where(.value.name == call.endpoint) -> <sequence of out> (depEp:
-                out = depEp.value.name
-            )
-            out = dep.value.attrs.package + "." + Join(depEpList flatten(.out),"")
+            out = dep.value.attrs.package
           )
-
           out = Join(pkgList flatten(.out), "")
         )
         out = Join(calls flatten(.out),",")

--- a/sysl2/sysl/tests/xform_with_deps_pkg_set.sysl
+++ b/sysl2/sysl/tests/xform_with_deps_pkg_set.sysl
@@ -11,15 +11,11 @@ TransformDeps:
         packageName = name1
       )
 
-      let myList = app.endpoints -> <sequence of out> (ep:
-        let calls = ep.value.stmts where (.type == "call") -> <sequence of out> (call:
-          let pkgList = module.apps where(.value.name == call.target) -> <sequence of out> (dep:
-            let depEpList = dep.value.endpoints where(.value.name == call.endpoint) -> <sequence of out> (depEp:
-                out = depEp.value.name
-            )
-            out = dep.value.attrs.package + "." + Join(depEpList flatten(.out),"")
+      let myList = app.endpoints -> <set of out> (ep:
+        let calls = ep.value.stmts where (.type == "call") -> <set of out> (call:
+          let pkgList = module.apps where(.value.name == call.target) -> <set of out> (dep:
+            out = dep.value.attrs.package
           )
-
           out = Join(pkgList flatten(.out), "")
         )
         out = Join(calls flatten(.out),",")


### PR DESCRIPTION
Fixes # .

Changes proposed in this pull request:
- Evaluation result appending approach now depends on the output type to allow use of "set of" to remove duplicates from transform results.
- Adds set/list combinations in concatenation and flattening.

@anz-bank/sysl-developers
