### PR TITLE
Add a work-around fix for ANTLR4 go datarace

### DIFF
--- a/local_ci.sh
+++ b/local_ci.sh
@@ -1,14 +1,15 @@
 #!/usr/bin/env bash
-
+set -x
 
 export SYSL_PLANTUML=http://www.plantuml.com/plantuml
 
+GOTEST_FLAGS='-race'
 
 run_tests() {
 if [[ -n `which gotestsum` ]]; then
-    go test -json ./... | gotestsum
+    go test -json ./... ${GOTEST_FLAGS} | gotestsum
 else
-    go test ./...
+    go test ./... ${GOTEST_FLAGS}
 fi
 }
 

--- a/sysl2/sysl/Makefile
+++ b/sysl2/sysl/Makefile
@@ -36,6 +36,7 @@ $(EXE): $(CODE_FILES)
 
 grammar/sysl_parser.go grammar/sysl_lexer.go: grammar/SyslParser.g4 grammar/SyslLexer.g4
 	$(ANTLR) -Dlanguage=Go -lib grammar $^
+	git apply grammar/antlr4-datarace-fix.diff
 
 $(JS): sysl_js/SyslParser.g4 sysl_js/SyslLexer.g4
 	$(ANTLR) -Dlanguage=JavaScript -lib sysl_js $^

--- a/sysl2/sysl/grammar/antlr4-datarace-fix.diff
+++ b/sysl2/sysl/grammar/antlr4-datarace-fix.diff
@@ -1,0 +1,86 @@
+diff --git a/sysl2/sysl/grammar/sysl_lexer.go b/sysl2/sysl/grammar/sysl_lexer.go
+
+This patch is needed to remove some mutable global variables from the generated go code!
+Without this, the lexer and parser are not safe to run in multiple threads
+
+
+
+
+index 11ab4f7..d98f55f 100644
+--- a/sysl2/sysl/grammar/sysl_lexer.go
++++ b/sysl2/sysl/grammar/sysl_lexer.go
+@@ -782,9 +782,6 @@ var serializedLexerAtn = []uint16{
+ 	3, 176, 26, 3, 177, 27, 3, 177, 28,
+ }
+ 
+-var lexerDeserializer = antlr.NewATNDeserializer(nil)
+-var lexerAtn = lexerDeserializer.DeserializeFromUInt16(serializedLexerAtn)
+-
+ var lexerChannelNames = []string{
+ 	"DEFAULT_TOKEN_CHANNEL", "HIDDEN",
+ }
+@@ -870,17 +867,16 @@ type SyslLexer struct {
+ 	// TODO: EOF string
+ }
+ 
+-var lexerDecisionToDFA = make([]*antlr.DFA, len(lexerAtn.DecisionToState))
++func NewSyslLexer(input antlr.CharStream) *SyslLexer {
+ 
+-func init() {
++	l := new(SyslLexer)
++
++	lexerDeserializer := antlr.NewATNDeserializer(nil)
++	lexerAtn := lexerDeserializer.DeserializeFromUInt16(serializedLexerAtn)
++	lexerDecisionToDFA := make([]*antlr.DFA, len(lexerAtn.DecisionToState))
+ 	for index, ds := range lexerAtn.DecisionToState {
+ 		lexerDecisionToDFA[index] = antlr.NewDFA(ds, index)
+ 	}
+-}
+-
+-func NewSyslLexer(input antlr.CharStream) *SyslLexer {
+-
+-	l := new(SyslLexer)
+ 
+ 	l.BaseLexer = antlr.NewBaseLexer(input)
+ 	l.Interpreter = antlr.NewLexerATNSimulator(l, lexerAtn, lexerDecisionToDFA, antlr.NewPredictionContextCache())
+diff --git a/sysl2/sysl/grammar/sysl_parser.go b/sysl2/sysl/grammar/sysl_parser.go
+index 06e6f61..e7e25e0 100644
+--- a/sysl2/sysl/grammar/sysl_parser.go
++++ b/sysl2/sysl/grammar/sysl_parser.go
+@@ -818,8 +818,6 @@ var parserATN = []uint16{
+ 	1580, 1587, 1592, 1599, 1604, 1624, 1626, 1630, 1635, 1653, 1656, 1661,
+ 	1665, 1670, 1674, 1679, 1682, 1687,
+ }
+-var deserializer = antlr.NewATNDeserializer(nil)
+-var deserializedATN = deserializer.DeserializeFromUInt16(parserATN)
+ 
+ var literalNames = []string{
+ 	"", "", "", "", "", "'!wrap'", "'!table'", "'!type'", "'!alias'", "'!union'",
+@@ -898,13 +896,6 @@ var ruleNames = []string{
+ 	"abstract_view", "view", "alias", "app_decl", "application", "import_mode",
+ 	"import_stmt", "imports_decl", "sysl_file",
+ }
+-var decisionToDFA = make([]*antlr.DFA, len(deserializedATN.DecisionToState))
+-
+-func init() {
+-	for index, ds := range deserializedATN.DecisionToState {
+-		decisionToDFA[index] = antlr.NewDFA(ds, index)
+-	}
+-}
+ 
+ type SyslParser struct {
+ 	*antlr.BaseParser
+@@ -913,6 +904,13 @@ type SyslParser struct {
+ func NewSyslParser(input antlr.TokenStream) *SyslParser {
+ 	this := new(SyslParser)
+ 
++	deserializer := antlr.NewATNDeserializer(nil)
++	deserializedATN := deserializer.DeserializeFromUInt16(parserATN)
++	decisionToDFA := make([]*antlr.DFA, len(deserializedATN.DecisionToState))
++	for index, ds := range deserializedATN.DecisionToState {
++		decisionToDFA[index] = antlr.NewDFA(ds, index)
++	}
++
+ 	this.BaseParser = antlr.NewBaseParser(input)
+ 
+ 	this.Interpreter = antlr.NewParserATNSimulator(this, deserializedATN, decisionToDFA, antlr.NewPredictionContextCache())

--- a/sysl2/sysl/grammar/sysl_lexer.go
+++ b/sysl2/sysl/grammar/sysl_lexer.go
@@ -782,9 +782,6 @@ var serializedLexerAtn = []uint16{
 	3, 176, 26, 3, 177, 27, 3, 177, 28,
 }
 
-var lexerDeserializer = antlr.NewATNDeserializer(nil)
-var lexerAtn = lexerDeserializer.DeserializeFromUInt16(serializedLexerAtn)
-
 var lexerChannelNames = []string{
 	"DEFAULT_TOKEN_CHANNEL", "HIDDEN",
 }
@@ -870,17 +867,16 @@ type SyslLexer struct {
 	// TODO: EOF string
 }
 
-var lexerDecisionToDFA = make([]*antlr.DFA, len(lexerAtn.DecisionToState))
-
-func init() {
-	for index, ds := range lexerAtn.DecisionToState {
-		lexerDecisionToDFA[index] = antlr.NewDFA(ds, index)
-	}
-}
-
 func NewSyslLexer(input antlr.CharStream) *SyslLexer {
 
 	l := new(SyslLexer)
+
+	lexerDeserializer := antlr.NewATNDeserializer(nil)
+	lexerAtn := lexerDeserializer.DeserializeFromUInt16(serializedLexerAtn)
+	lexerDecisionToDFA := make([]*antlr.DFA, len(lexerAtn.DecisionToState))
+	for index, ds := range lexerAtn.DecisionToState {
+		lexerDecisionToDFA[index] = antlr.NewDFA(ds, index)
+	}
 
 	l.BaseLexer = antlr.NewBaseLexer(input)
 	l.Interpreter = antlr.NewLexerATNSimulator(l, lexerAtn, lexerDecisionToDFA, antlr.NewPredictionContextCache())

--- a/sysl2/sysl/parse/parse.go
+++ b/sysl2/sysl/parse/parse.go
@@ -119,7 +119,7 @@ func (p *Parser) Parse(filename string, fs afero.Fs) (*sysl.Module, error) {
 			return nil, err
 		}
 
-		antlr.ParseTreeWalkerDefault.Walk(listener, tree)
+		antlr.NewParseTreeWalker().Walk(listener, tree)
 		if len(listener.imports) == 0 {
 			break
 		}


### PR DESCRIPTION
Partial fix for #396 

This patches the generated code to not use mutable global state. There is . still one non-determinisic test to fix as a follow up



@anz-bank/sysl-developers
