### PR TITLE
moved testutil into syslutil

### DIFF
--- a/sysl2/sysl/Codegen_test.go
+++ b/sysl2/sysl/Codegen_test.go
@@ -4,10 +4,11 @@ import (
 	"bytes"
 	"testing"
 
+	"github.com/anz-bank/sysl/sysl2/sysl/syslutil"
+
 	"gopkg.in/alecthomas/kingpin.v2"
 
 	"github.com/anz-bank/sysl/sysl2/sysl/eval"
-	"github.com/anz-bank/sysl/sysl2/sysl/testutil"
 	"github.com/sirupsen/logrus/hooks/test"
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
@@ -265,7 +266,7 @@ func TestOutputForPureTokenOnlyRule(t *testing.T) {
 
 func GenerateCodeWithParams(
 	rootModel, model, rootTransform, transform, grammar, start string) ([]*CodeGenOutput, error) {
-	_, fs := testutil.WriteToMemOverlayFs("/")
+	_, fs := syslutil.WriteToMemOverlayFs("/")
 	return GenerateCodeWithParamsFs(
 		rootModel, model, rootTransform, transform, grammar, start, fs,
 	)

--- a/sysl2/sysl/diagutil_test.go
+++ b/sysl2/sysl/diagutil_test.go
@@ -3,7 +3,8 @@ package main
 import (
 	"testing"
 
-	"github.com/anz-bank/sysl/sysl2/sysl/testutil"
+	"github.com/anz-bank/sysl/sysl2/sysl/syslutil"
+
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -54,7 +55,7 @@ func TestDeflateAndEncode(t *testing.T) {
 func testOutputPlantuml(t *testing.T, output, output2 string) {
 	fs := afero.NewMemMapFs()
 	require.NoError(t, OutputPlantuml(output, plantumlDotCom, testPlantumlInput, fs))
-	testutil.AssertFsHasExactly(t, fs, output2)
+	syslutil.AssertFsHasExactly(t, fs, output2)
 }
 
 func TestOutputPlantumlWithPng(t *testing.T) {
@@ -113,7 +114,7 @@ func TestOutPutWithWrongFormat(t *testing.T) {
 
 	fs := afero.NewMemMapFs()
 	require.Error(t, OutputPlantuml("test.wrong", plantumlDotCom, testPlantumlInput, fs))
-	testutil.AssertFsHasExactly(t, fs)
+	syslutil.AssertFsHasExactly(t, fs)
 }
 
 func TestWrongHttpRequest(t *testing.T) {

--- a/sysl2/sysl/parse/Parser_test.go
+++ b/sysl2/sysl/parse/Parser_test.go
@@ -15,7 +15,6 @@ import (
 	"github.com/anz-bank/sysl/sysl2/sysl/msg"
 	"github.com/anz-bank/sysl/sysl2/sysl/pbutil"
 	"github.com/anz-bank/sysl/sysl2/sysl/syslutil"
-	"github.com/anz-bank/sysl/sysl2/sysl/testutil"
 	"github.com/golang/protobuf/proto"
 	"github.com/pkg/errors"
 	"github.com/spf13/afero"
@@ -517,12 +516,12 @@ func TestInferExprTypeNonTransform(t *testing.T) {
 		messages     map[string][]msg.Msg
 	}
 
-	memFs, fs := testutil.WriteToMemOverlayFs("../tests")
+	memFs, fs := syslutil.WriteToMemOverlayFs("../tests")
 	parser := NewParser()
 	expressions := map[string]*sysl.Expr{}
 	transform, appName, err := LoadAndGetDefaultApp("transform1.sysl", fs, parser)
 	require.NoError(t, err)
-	testutil.AssertFsHasExactly(t, memFs)
+	syslutil.AssertFsHasExactly(t, memFs)
 	viewName := "inferExprTypeNonTransform"
 	viewRetType := transform.GetApps()[appName].Views[viewName].GetRetType()
 
@@ -595,11 +594,11 @@ func TestInferExprTypeTransform(t *testing.T) {
 		messages     map[string][]msg.Msg
 	}
 
-	memFs, fs := testutil.WriteToMemOverlayFs("../tests")
+	memFs, fs := syslutil.WriteToMemOverlayFs("../tests")
 	parser := NewParser()
 	transform, appName, err := LoadAndGetDefaultApp("transform1.sysl", fs, parser)
 	require.NoError(t, err)
-	testutil.AssertFsHasExactly(t, memFs)
+	syslutil.AssertFsHasExactly(t, memFs)
 	views := transform.GetApps()[appName].Views
 
 	cases := map[string]struct {

--- a/sysl2/sysl/pbutil/output_test.go
+++ b/sysl2/sysl/pbutil/output_test.go
@@ -4,8 +4,9 @@ import (
 	"bytes"
 	"testing"
 
+	"github.com/anz-bank/sysl/sysl2/sysl/syslutil"
+
 	sysl "github.com/anz-bank/sysl/src/proto"
-	"github.com/anz-bank/sysl/sysl2/sysl/testutil"
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -103,7 +104,7 @@ func TestJSONPBNilModule(t *testing.T) {
 	fs := afero.NewMemMapFs()
 	filename := "out.pb.json"
 	require.Error(t, JSONPB(nil, filename, fs))
-	testutil.AssertFsHasExactly(t, fs)
+	syslutil.AssertFsHasExactly(t, fs)
 }
 
 func TestFJSONPB(t *testing.T) {
@@ -139,7 +140,7 @@ func TestTextPBNilModule(t *testing.T) {
 	fs := afero.NewMemMapFs()
 	filename := "/out.textpb"
 	require.Error(t, TextPB(nil, filename, fs))
-	testutil.AssertFsHasExactly(t, fs)
+	syslutil.AssertFsHasExactly(t, fs)
 }
 
 func TestFTextPB(t *testing.T) {

--- a/sysl2/sysl/seqs_test.go
+++ b/sysl2/sysl/seqs_test.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/anz-bank/sysl/sysl2/sysl/parse"
 	"github.com/anz-bank/sysl/sysl2/sysl/syslutil"
-	"github.com/anz-bank/sysl/sysl2/sysl/testutil"
 	"github.com/sirupsen/logrus/hooks/test"
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
@@ -125,10 +124,10 @@ func TestGenerateSequenceDiagramsToFormatNameAttributes(t *testing.T) {
 	t.Parallel()
 
 	logger, _ := test.NewNullLogger()
-	memFs, fs := testutil.WriteToMemOverlayFs("tests")
+	memFs, fs := syslutil.WriteToMemOverlayFs("tests")
 	m, err := parse.NewParser().Parse("sequence_diagram_name_format.sysl", fs)
 	require.NoError(t, err)
-	testutil.AssertFsHasExactly(t, memFs)
+	syslutil.AssertFsHasExactly(t, memFs)
 	al := MakeFormatParser(`%(@status?<color red>%(appname)</color>|%(appname))`)
 	el := MakeFormatParser(`%(@status? <color green>%(epname)</color>|%(epname))`)
 	p := &sequenceDiagParam{}
@@ -180,10 +179,10 @@ func TestGenerateSequenceDiagramsToFormatComplexAttributes(t *testing.T) {
 	t.Parallel()
 
 	logger, _ := test.NewNullLogger()
-	memFs, fs := testutil.WriteToMemOverlayFs("tests")
+	memFs, fs := syslutil.WriteToMemOverlayFs("tests")
 	m, err := parse.NewParser().Parse("sequence_diagram_name_format.sysl", fs)
 	require.NoError(t, err)
-	testutil.AssertFsHasExactly(t, memFs)
+	syslutil.AssertFsHasExactly(t, memFs)
 	al := MakeFormatParser(`%(@status?<color red>%(appname)</color>|%(appname))`)
 	el := MakeFormatParser(`%(@status? <color green>%(epname)</color>|%(epname))`)
 	p := &sequenceDiagParam{}
@@ -242,7 +241,7 @@ func TestLoadAppReturnError(t *testing.T) {
 	args := loadAppArgs{
 		"../../demo/simple/", "",
 	}
-	_, fs := testutil.WriteToMemOverlayFs(args.root)
+	_, fs := syslutil.WriteToMemOverlayFs(args.root)
 	logger, _ := test.NewNullLogger()
 	_, _, err := LoadSyslModule(args.root, args.models, fs, logger)
 	assert.Error(t, err)
@@ -254,12 +253,12 @@ func TestLoadApp(t *testing.T) {
 	args := loadAppArgs{
 		"./tests/", "sequence_diagram_test.sysl",
 	}
-	memFs, fs := testutil.WriteToMemOverlayFs("/")
+	memFs, fs := syslutil.WriteToMemOverlayFs("/")
 	logger, _ := test.NewNullLogger()
 	mod, name, err := LoadSyslModule(args.root, args.models, fs, logger)
 	require.NoError(t, err)
 	assert.NotNil(t, mod)
-	testutil.AssertFsHasExactly(t, memFs)
+	syslutil.AssertFsHasExactly(t, memFs)
 	apps := mod.GetApps()
 	app := apps["Database"]
 

--- a/sysl2/sysl/sysl_test.go
+++ b/sysl2/sysl/sysl_test.go
@@ -7,8 +7,9 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/anz-bank/sysl/sysl2/sysl/syslutil"
+
 	"github.com/anz-bank/sysl/sysl2/sysl/parse"
-	"github.com/anz-bank/sysl/sysl2/sysl/testutil"
 	"github.com/sirupsen/logrus"
 	"github.com/sirupsen/logrus/hooks/test"
 	"github.com/spf13/afero"
@@ -30,7 +31,7 @@ func assertLogEntry(
 
 func testMain2(t *testing.T, args []string, golden string) {
 	logger, _ := test.NewNullLogger()
-	_, fs := testutil.WriteToMemOverlayFs("/")
+	_, fs := syslutil.WriteToMemOverlayFs("/")
 	output := "out.textpb"
 	rc := main2(append([]string{"sysl", "pb", "-o", output}, args...), fs, logger, main3)
 	assert.Zero(t, rc)
@@ -58,7 +59,7 @@ func TestMain2JSON(t *testing.T) {
 
 func testMain2Stdout(t *testing.T, args []string, golden string) {
 	logger, _ := test.NewNullLogger()
-	memFs, fs := testutil.WriteToMemOverlayFs("/")
+	memFs, fs := syslutil.WriteToMemOverlayFs("/")
 	rc := main2(append([]string{"sysl", "pb", "-o", " - "}, args...), fs, logger, main3)
 	assert.Zero(t, rc)
 
@@ -68,7 +69,7 @@ func testMain2Stdout(t *testing.T, args []string, golden string) {
 	_, err = os.Stat("-")
 	assert.True(t, os.IsNotExist(err))
 
-	testutil.AssertFsHasExactly(t, memFs)
+	syslutil.AssertFsHasExactly(t, memFs)
 }
 
 func TestMain2TextPBStdout(t *testing.T) {
@@ -87,7 +88,7 @@ func TestMain2BadMode(t *testing.T) {
 	t.Parallel()
 
 	logger, _ := test.NewNullLogger()
-	memFs, fs := testutil.WriteToMemOverlayFs("/")
+	memFs, fs := syslutil.WriteToMemOverlayFs("/")
 	rc := main2(
 		[]string{
 			"sysl",
@@ -99,7 +100,7 @@ func TestMain2BadMode(t *testing.T) {
 		fs, logger, main3,
 	)
 	assert.NotZero(t, rc)
-	testutil.AssertFsHasExactly(t, memFs)
+	syslutil.AssertFsHasExactly(t, memFs)
 
 	_, err := os.Stat("-")
 	assert.True(t, os.IsNotExist(err))
@@ -109,7 +110,7 @@ func TestMain2BadLog(t *testing.T) {
 	t.Parallel()
 
 	logger, _ := test.NewNullLogger()
-	memFs, fs := testutil.WriteToMemOverlayFs("/")
+	memFs, fs := syslutil.WriteToMemOverlayFs("/")
 	rc := main2(
 		[]string{
 			"sysl",
@@ -121,14 +122,14 @@ func TestMain2BadLog(t *testing.T) {
 		fs, logger, main3,
 	)
 	assert.NotZero(t, rc)
-	testutil.AssertFsHasExactly(t, memFs)
+	syslutil.AssertFsHasExactly(t, memFs)
 }
 
 func TestMain2SeqdiagWithMissingFile(t *testing.T) {
 	t.Parallel()
 
 	logger, _ := test.NewNullLogger()
-	memFs, fs := testutil.WriteToMemOverlayFs("/")
+	memFs, fs := syslutil.WriteToMemOverlayFs("/")
 	rc := main2(
 		[]string{
 			"sd",
@@ -139,7 +140,7 @@ func TestMain2SeqdiagWithMissingFile(t *testing.T) {
 		fs, logger, main3,
 	)
 	assert.NotEqual(t, 0, rc)
-	testutil.AssertFsHasExactly(t, memFs)
+	syslutil.AssertFsHasExactly(t, memFs)
 }
 
 func TestMain2SeqdiagWithNonsensicalOutput(t *testing.T) {
@@ -147,7 +148,7 @@ func TestMain2SeqdiagWithNonsensicalOutput(t *testing.T) {
 
 	logger, hook := test.NewNullLogger()
 	out := "/out.zzz"
-	_, fs := testutil.WriteToMemOverlayFs("/")
+	_, fs := syslutil.WriteToMemOverlayFs("/")
 	rc := main2(
 		[]string{
 			"sysl",
@@ -170,7 +171,7 @@ func TestMain2WithBlackboxParams(t *testing.T) {
 
 	logger, hook := test.NewNullLogger()
 	out := filepath.Clean("/out1.png")
-	memFs, fs := testutil.WriteToMemOverlayFs("/")
+	memFs, fs := syslutil.WriteToMemOverlayFs("/")
 	rc := main2(
 		[]string{
 			"sysl",
@@ -186,7 +187,7 @@ func TestMain2WithBlackboxParams(t *testing.T) {
 	assert.Equal(t, 0, rc)
 	assert.Equal(t, logrus.WarnLevel, hook.LastEntry().Level)
 	assert.Equal(t, "blackbox 'Server <- DB' passed on commandline not hit\n", hook.LastEntry().Message)
-	testutil.AssertFsHasExactly(t, memFs, out)
+	syslutil.AssertFsHasExactly(t, memFs, out)
 }
 
 func TestMain2WithReadOnlyFs(t *testing.T) {
@@ -194,7 +195,7 @@ func TestMain2WithReadOnlyFs(t *testing.T) {
 
 	logger, hook := test.NewNullLogger()
 	out := "/out2.png"
-	_, fs := testutil.WriteToMemOverlayFs("/")
+	_, fs := syslutil.WriteToMemOverlayFs("/")
 	fs = afero.NewReadOnlyFs(fs)
 	rc := main2(
 		[]string{
@@ -217,7 +218,7 @@ func TestMain2WithBlackboxParamsFaultyArguments(t *testing.T) {
 	t.Parallel()
 
 	logger, hook := test.NewNullLogger()
-	memFs, fs := testutil.WriteToMemOverlayFs("/")
+	memFs, fs := syslutil.WriteToMemOverlayFs("/")
 	ret := main2(
 		[]string{
 			"sysl",
@@ -233,14 +234,14 @@ func TestMain2WithBlackboxParamsFaultyArguments(t *testing.T) {
 	assert.NotEqual(t, 0, ret)
 	assert.Equal(t, logrus.ErrorLevel, hook.LastEntry().Level)
 	assert.Equal(t, "expected KEY=VALUE got 'Server <- DB'", hook.LastEntry().Message)
-	testutil.AssertFsHasExactly(t, memFs)
+	syslutil.AssertFsHasExactly(t, memFs)
 }
 
 func TestMain2WithBlackboxSysl(t *testing.T) {
 	t.Parallel()
 
 	logger, hook := test.NewNullLogger()
-	memFs, fs := testutil.WriteToMemOverlayFs("/")
+	memFs, fs := syslutil.WriteToMemOverlayFs("/")
 	rc := main2(
 		[]string{
 			"sysl",
@@ -259,14 +260,14 @@ func TestMain2WithBlackboxSysl(t *testing.T) {
 		hook.Entries[len(hook.Entries)-2].Message)
 	assert.Equal(t, "blackbox 'SomeApp <- BarEndpoint' not hit in app 'Project :: Sequences :: SEQ-One'\n",
 		hook.Entries[len(hook.Entries)-3].Message)
-	testutil.AssertFsHasExactly(t, memFs, "/SEQ-One.png", "/SEQ-Two.png")
+	syslutil.AssertFsHasExactly(t, memFs, "/SEQ-One.png", "/SEQ-Two.png")
 }
 
 func TestMain2WithBlackboxSyslEmptyEndpoints(t *testing.T) {
 	t.Parallel()
 
 	logger, hook := test.NewNullLogger()
-	memFs, fs := testutil.WriteToMemOverlayFs("/")
+	memFs, fs := syslutil.WriteToMemOverlayFs("/")
 	rc := main2(
 		[]string{
 			"sysl",
@@ -280,7 +281,7 @@ func TestMain2WithBlackboxSyslEmptyEndpoints(t *testing.T) {
 	assert.NotEqual(t, 0, rc)
 	assert.Equal(t, logrus.ErrorLevel, hook.LastEntry().Level)
 	assert.Equal(t, "no call statements to build sequence diagram for endpoint PROJECT-E2E", hook.LastEntry().Message)
-	testutil.AssertFsHasExactly(t, memFs)
+	syslutil.AssertFsHasExactly(t, memFs)
 }
 
 func TestMain2Fatal(t *testing.T) {
@@ -297,7 +298,7 @@ func TestMain2WithGroupingParamsGroupParamAbsent(t *testing.T) {
 	t.Parallel()
 
 	logger, hook := test.NewNullLogger()
-	memFs, fs := testutil.WriteToMemOverlayFs("/")
+	memFs, fs := syslutil.WriteToMemOverlayFs("/")
 	rc := main2(
 		[]string{
 			"sysl",
@@ -312,14 +313,14 @@ func TestMain2WithGroupingParamsGroupParamAbsent(t *testing.T) {
 	assert.NotEqual(t, 0, rc)
 	assert.Equal(t, logrus.ErrorLevel, hook.LastEntry().Level)
 	assert.Equal(t, "expected argument for flag '-g'", hook.LastEntry().Message)
-	testutil.AssertFsHasExactly(t, memFs)
+	syslutil.AssertFsHasExactly(t, memFs)
 }
 
 func TestMain2WithGroupingParamsCommandline(t *testing.T) {
 	t.Parallel()
 
 	logger, _ := test.NewNullLogger()
-	memFs, fs := testutil.WriteToMemOverlayFs("/")
+	memFs, fs := syslutil.WriteToMemOverlayFs("/")
 	out := filepath.Clean("/out3.png")
 	rc := main2(
 		[]string{
@@ -333,14 +334,14 @@ func TestMain2WithGroupingParamsCommandline(t *testing.T) {
 		fs, logger, main3,
 	)
 	assert.Equal(t, 0, rc)
-	testutil.AssertFsHasExactly(t, memFs, out)
+	syslutil.AssertFsHasExactly(t, memFs, out)
 }
 
 func TestMain2WithGroupingParamsSysl(t *testing.T) {
 	t.Parallel()
 
 	logger, hook := test.NewNullLogger()
-	memFs, fs := testutil.WriteToMemOverlayFs("/")
+	memFs, fs := syslutil.WriteToMemOverlayFs("/")
 	rc := main2(
 		[]string{
 			"sysl",
@@ -355,14 +356,14 @@ func TestMain2WithGroupingParamsSysl(t *testing.T) {
 	assert.Equal(t, 0, rc)
 	assert.Equal(t, logrus.WarnLevel, hook.LastEntry().Level)
 	assert.Equal(t, "Ignoring groupby passed from command line", hook.LastEntry().Message)
-	testutil.AssertFsHasExactly(t, memFs, "/SEQ-One.png", "/SEQ-Two.png")
+	syslutil.AssertFsHasExactly(t, memFs, "/SEQ-One.png", "/SEQ-Two.png")
 }
 
 func TestMain2WithGenerateIntegrations(t *testing.T) {
 	t.Parallel()
 
 	logger, _ := test.NewNullLogger()
-	memFs, fs := testutil.WriteToMemOverlayFs("/")
+	memFs, fs := syslutil.WriteToMemOverlayFs("/")
 	out := "/indirect_1.png"
 	main2(
 		[]string{
@@ -375,14 +376,14 @@ func TestMain2WithGenerateIntegrations(t *testing.T) {
 		},
 		fs, logger, main3,
 	)
-	testutil.AssertFsHasExactly(t, memFs, out)
+	syslutil.AssertFsHasExactly(t, memFs, out)
 }
 
 func TestMain2WithGenerateCode(t *testing.T) {
 	t.Parallel()
 
 	logger, _ := test.NewNullLogger()
-	memFs, fs := testutil.WriteToMemOverlayFs("/")
+	memFs, fs := syslutil.WriteToMemOverlayFs("/")
 	root := "."
 	ret := main2(
 		[]string{
@@ -401,14 +402,14 @@ func TestMain2WithGenerateCode(t *testing.T) {
 	assert.Equal(t, 0, ret)
 	out, err := filepath.Abs(filepath.Join(root, "Model.java"))
 	require.NoError(t, err)
-	testutil.AssertFsHasExactly(t, memFs, out)
+	syslutil.AssertFsHasExactly(t, memFs, out)
 }
 
 func TestMain2WithGenerateCodeReadOnlyFs(t *testing.T) {
 	t.Parallel()
 
 	logger, hook := test.NewNullLogger()
-	_, fs := testutil.WriteToMemOverlayFs("/")
+	_, fs := syslutil.WriteToMemOverlayFs("/")
 	fs = afero.NewReadOnlyFs(fs)
 	ret := main2(
 		[]string{
@@ -433,7 +434,7 @@ func TestMain2WithTextPbMode(t *testing.T) {
 	t.Parallel()
 
 	logger, _ := test.NewNullLogger()
-	memFs, fs := testutil.WriteToMemOverlayFs("/")
+	memFs, fs := syslutil.WriteToMemOverlayFs("/")
 	out := "/out.textpb"
 	ret := main2(
 		[]string{
@@ -446,14 +447,14 @@ func TestMain2WithTextPbMode(t *testing.T) {
 		fs, logger, main3,
 	)
 	assert.Equal(t, 0, ret)
-	testutil.AssertFsHasExactly(t, memFs, out)
+	syslutil.AssertFsHasExactly(t, memFs, out)
 }
 
 func TestMain2WithJSONMode(t *testing.T) {
 	t.Parallel()
 
 	logger, _ := test.NewNullLogger()
-	memFs, fs := testutil.WriteToMemOverlayFs("/")
+	memFs, fs := syslutil.WriteToMemOverlayFs("/")
 	out := filepath.Clean("/out.json")
 	ret := main2(
 		[]string{
@@ -466,14 +467,14 @@ func TestMain2WithJSONMode(t *testing.T) {
 		fs, logger, main3,
 	)
 	assert.Equal(t, 0, ret)
-	testutil.AssertFsHasExactly(t, memFs, out)
+	syslutil.AssertFsHasExactly(t, memFs, out)
 }
 
 func TestMain2WithTextPbModeStdout(t *testing.T) {
 	t.Parallel()
 
 	logger, _ := test.NewNullLogger()
-	memFs, fs := testutil.WriteToMemOverlayFs("/")
+	memFs, fs := syslutil.WriteToMemOverlayFs("/")
 	ret := main2(
 		[]string{
 			"sysl",
@@ -485,14 +486,14 @@ func TestMain2WithTextPbModeStdout(t *testing.T) {
 		fs, logger, main3,
 	)
 	assert.Equal(t, 0, ret)
-	testutil.AssertFsHasExactly(t, memFs)
+	syslutil.AssertFsHasExactly(t, memFs)
 }
 
 func TestMain2WithJSONModeStdout(t *testing.T) {
 	t.Parallel()
 
 	logger, _ := test.NewNullLogger()
-	memFs, fs := testutil.WriteToMemOverlayFs("/")
+	memFs, fs := syslutil.WriteToMemOverlayFs("/")
 	ret := main2(
 		[]string{
 			"sysl",
@@ -504,39 +505,39 @@ func TestMain2WithJSONModeStdout(t *testing.T) {
 		fs, logger, main3,
 	)
 	assert.Equal(t, 0, ret)
-	testutil.AssertFsHasExactly(t, memFs)
+	syslutil.AssertFsHasExactly(t, memFs)
 }
 
 func TestMain2WithEmptySdParams(t *testing.T) {
 	t.Parallel()
 
 	logger, hook := test.NewNullLogger()
-	memFs, fs := testutil.WriteToMemOverlayFs("/")
+	memFs, fs := syslutil.WriteToMemOverlayFs("/")
 	main2([]string{"sysl", "sd", "-g", " ", "-o", "", "tests/groupby.sysl", "-a", " "}, fs, logger, main3)
 	assert.Equal(t, logrus.ErrorLevel, hook.LastEntry().Level)
 	assert.Equal(t, "'output' value passed is empty\n"+
 		"'app' value passed is empty\n"+
 		"'groupby' value passed is empty\n", hook.LastEntry().Message)
-	testutil.AssertFsHasExactly(t, memFs)
+	syslutil.AssertFsHasExactly(t, memFs)
 }
 
 func TestMain2WithEmptyPbParams(t *testing.T) {
 	t.Parallel()
 
 	logger, hook := test.NewNullLogger()
-	memFs, fs := testutil.WriteToMemOverlayFs("/")
+	memFs, fs := syslutil.WriteToMemOverlayFs("/")
 	main2([]string{"sysl", "pb", "-o", " ", "--mode", "", "tests/call.sysl"}, fs, logger, main3)
 	assert.Equal(t, logrus.ErrorLevel, hook.LastEntry().Level)
 	assert.Equal(t,
 		"'output' value passed is empty\n'mode' value passed is empty\n", hook.LastEntry().Message)
-	testutil.AssertFsHasExactly(t, memFs)
+	syslutil.AssertFsHasExactly(t, memFs)
 }
 
 func TestMain2WithEmptyGenParams(t *testing.T) {
 	t.Parallel()
 
 	logger, hook := test.NewNullLogger()
-	memFs, fs := testutil.WriteToMemOverlayFs("/")
+	memFs, fs := syslutil.WriteToMemOverlayFs("/")
 	main2([]string{"sysl", "gen", "--transform",
 		"tests/test.gen_multiple_annotations.sysl", "--grammar", " ", "--start", "", "--outdir", " "}, fs, logger, main3)
 	assert.Equal(t, logrus.ErrorLevel, hook.LastEntry().Level)
@@ -544,65 +545,65 @@ func TestMain2WithEmptyGenParams(t *testing.T) {
 		"'grammar' value passed is empty\n"+
 			"'start' value passed is empty\n"+
 			"'outdir' value passed is empty\n", hook.LastEntry().Message)
-	testutil.AssertFsHasExactly(t, memFs)
+	syslutil.AssertFsHasExactly(t, memFs)
 }
 
 func TestMain2WithEmptyIntsParams(t *testing.T) {
 	t.Parallel()
 
 	logger, hook := test.NewNullLogger()
-	memFs, fs := testutil.WriteToMemOverlayFs("/")
+	memFs, fs := syslutil.WriteToMemOverlayFs("/")
 	main2([]string{"sysl", "ints", "-o", "", "-j", " ", "indirect_1.sysl"}, fs, logger, main3)
 	assert.Equal(t, logrus.ErrorLevel, hook.LastEntry().Level)
 	assert.Equal(t,
 		"'output' value passed is empty\n"+
 			"'project' value passed is empty\n", hook.LastEntry().Message)
-	testutil.AssertFsHasExactly(t, memFs)
+	syslutil.AssertFsHasExactly(t, memFs)
 }
 
 func TestMain2WithDataMultipleFiles(t *testing.T) {
 	t.Parallel()
 	logger, _ := test.NewNullLogger()
-	memFs, fs := testutil.WriteToMemOverlayFs("/")
+	memFs, fs := syslutil.WriteToMemOverlayFs("/")
 	main2([]string{"sysl", "data", "-o", "%(epname).png", "tests/data.sysl", "-j", "Project"}, fs, logger, main3)
-	testutil.AssertFsHasExactly(t, memFs, "/Relational-Model.png", "/Object-Model.png")
+	syslutil.AssertFsHasExactly(t, memFs, "/Relational-Model.png", "/Object-Model.png")
 }
 
 func TestMain2WithDataSingleFile(t *testing.T) {
 	t.Parallel()
 	logger, _ := test.NewNullLogger()
-	memFs, fs := testutil.WriteToMemOverlayFs("/")
+	memFs, fs := syslutil.WriteToMemOverlayFs("/")
 	main2([]string{"sysl", "data", "-o", "data.png", "tests/data.sysl", "-j", "Project"}, fs, logger, main3)
-	testutil.AssertFsHasExactly(t, memFs, "/data.png")
+	syslutil.AssertFsHasExactly(t, memFs, "/data.png")
 }
 
 func TestMain2WithDataNoProject(t *testing.T) {
 	t.Parallel()
 	logger, testHook := test.NewNullLogger()
-	memFs, fs := testutil.WriteToMemOverlayFs("/")
+	memFs, fs := syslutil.WriteToMemOverlayFs("/")
 	main2([]string{"sysl", "data", "-o", "%(epname).png", "tests/data.sysl"}, fs, logger, main3)
 	assert.Equal(t, logrus.ErrorLevel, testHook.LastEntry().Level)
 	assert.Equal(t, "project not found in sysl", testHook.LastEntry().Message)
 	testHook.Reset()
-	testutil.AssertFsHasExactly(t, memFs)
+	syslutil.AssertFsHasExactly(t, memFs)
 }
 
 func TestMain2WithDataFilter(t *testing.T) {
 	t.Parallel()
 	logger, _ := test.NewNullLogger()
-	memFs, fs := testutil.WriteToMemOverlayFs("/")
+	memFs, fs := syslutil.WriteToMemOverlayFs("/")
 	main2([]string{"sysl", "data", "-o", "%(epname).png", "-f", "Object-Model.png", "tests/data.sysl", "-j",
 		"Project"}, fs, logger, main3)
-	testutil.AssertFsHasExactly(t, memFs, "/Object-Model.png")
+	syslutil.AssertFsHasExactly(t, memFs, "/Object-Model.png")
 }
 
 func TestMain2WithDataMultipleRelationships(t *testing.T) {
 	t.Parallel()
 	logger, _ := test.NewNullLogger()
-	memFs, fs := testutil.WriteToMemOverlayFs("/")
+	memFs, fs := syslutil.WriteToMemOverlayFs("/")
 	main2([]string{"sysl", "data", "-o", "%(epname).png", "tests/datareferences.sysl", "-j", "Project"},
 		fs, logger, main3)
-	testutil.AssertFsHasExactly(t, memFs, "/Relational-Model.png", "/Object-Model.png")
+	syslutil.AssertFsHasExactly(t, memFs, "/Relational-Model.png", "/Object-Model.png")
 }
 
 func TestMain2WithBinaryInfoCmd(t *testing.T) {
@@ -615,10 +616,10 @@ func TestMain2WithBinaryInfoCmd(t *testing.T) {
 func TestSwaggerExportCurrentDir(t *testing.T) {
 	t.Parallel()
 	logger, _ := test.NewNullLogger()
-	memFs, fs := testutil.WriteToMemOverlayFs("/")
+	memFs, fs := syslutil.WriteToMemOverlayFs("/")
 	main2([]string{"sysl", "export", "-o", "SIMPLE_SWAGGER_EXAMPLE.yaml", "-a", "testapp",
 		"exporter/test-data/SIMPLE_SWAGGER_EXAMPLE.sysl"}, fs, logger, main3)
-	testutil.AssertFsHasExactly(t, memFs, "/SIMPLE_SWAGGER_EXAMPLE.yaml")
+	syslutil.AssertFsHasExactly(t, memFs, "/SIMPLE_SWAGGER_EXAMPLE.yaml")
 }
 
 func TestSwaggerExportTargetDir(t *testing.T) {
@@ -648,7 +649,7 @@ func TestSwaggerExportJson(t *testing.T) {
 func TestSwaggerExportInvalid(t *testing.T) {
 	t.Parallel()
 	logger, _ := test.NewNullLogger()
-	_, fs := testutil.WriteToMemOverlayFs("/")
+	_, fs := syslutil.WriteToMemOverlayFs("/")
 	errInt := main2([]string{"sysl", "export", "-o", "SIMPLE_SWAGGER_EXAMPLE1.blah", "-a", "testapp",
 		"exporter/test-data/SIMPLE_SWAGGER_EXAMPLE.sysl"}, fs, logger, main3)
 	assert.True(t, errInt == 1)

--- a/sysl2/sysl/syslutil/fs_testutil.go
+++ b/sysl2/sysl/syslutil/fs_testutil.go
@@ -1,4 +1,4 @@
-package testutil
+package syslutil
 
 import (
 	"os"
@@ -6,7 +6,6 @@ import (
 	"sort"
 	"testing"
 
-	"github.com/anz-bank/sysl/sysl2/sysl/syslutil"
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -39,8 +38,8 @@ func AssertFsHasExactly(t *testing.T, fs afero.Fs, paths ...string) bool {
 }
 
 func WriteToMemOverlayFs(osRoot string) (memFs, fs afero.Fs) {
-	memFs = syslutil.NewChrootFs(afero.NewMemMapFs(), "/")
-	fs = afero.NewCopyOnWriteFs(syslutil.NewChrootFs(afero.NewOsFs(), osRoot), memFs)
+	memFs = NewChrootFs(afero.NewMemMapFs(), "/")
+	fs = afero.NewCopyOnWriteFs(NewChrootFs(afero.NewOsFs(), osRoot), memFs)
 	return
 }
 


### PR DESCRIPTION
Moving testutil into syslutil

Will easily be able to export test utilities, this avoids import cycles between syslutil and testutil
@anz-bank/sysl-developers
