### PR TITLE
Issue/407/unmarshal correct type

### DIFF
--- a/src/sysl/importers/import_openapi.py
+++ b/src/sysl/importers/import_openapi.py
@@ -173,15 +173,23 @@ class OpenApiTranslator:
                             schema = schema['schema']
 
                 if schema is not None:
-                    if schema.get('type') == 'array':
-                        returnValues['sequence of ' + schema['items']['$ref'].rpartition('/')[2]] = True
-                    else:
-                        returnValues[schema['$ref'].rpartition('/')[2]] = True
+                    varName = ""
+                    if rc.startswith('2'):
+                        varName = "ok <: "
+                    elif rc.startswith('4') or rc.startswith('5'):
+                        varName = "error <: "
+                    elif rc == 'default' or rc.startswith('x-'):
+                        self.warn('default responses and x-* responses are not implemented')
+                    if varName != "":
+                        if schema.get('type') == 'array':
+                            returnValues[varName + 'sequence of ' + schema['items']['$ref'].rpartition('/')[2]] = True
+                        else:
+                            returnValues[varName + schema['$ref'].rpartition('/')[2]] = True
 
-                if rc == 'default' or rc.startswith('x-'):
-                    self.warn('default responses and x-* responses are not implemented')
-
-            w(u'return {}', ', '.join(returnValues))
+            if len(returnValues) > 2:
+                self.error('invalid return value set:' + json.dumps(returnValues))
+            for rv in returnValues:
+                w(u'return {}', rv)
 
         for (path, api) in sorted(oaSpec['paths'].iteritems()):
             apiParams = api.pop('parameters') if 'parameters' in api else []

--- a/src/sysl/importers/import_openapi.py
+++ b/src/sysl/importers/import_openapi.py
@@ -164,7 +164,7 @@ class OpenApiTranslator:
             returnValues = OrderedDict()
 
             for rc, rspec in sorted(responses.iteritems()):
-                
+
                 if rc == 'default' or rc.startswith('x-'):
                     self.warn('default and x-* responses are not implemented')
                     continue
@@ -183,7 +183,7 @@ class OpenApiTranslator:
                         varName = "ok <: "
                     elif rc.startswith('4') or rc.startswith('5'):
                         varName = "error <: "
-                    
+
                     if varName != "":
                         if schema.get('type') == 'array':
                             returnValues[varName + 'sequence of ' + schema['items']['$ref'].rpartition('/')[2]] = True
@@ -192,11 +192,11 @@ class OpenApiTranslator:
 
             if len(returnValues) > 2:
                 self.error('invalid return value set:' + json.dumps(returnValues))
-            
+
             if len(returnValues) == 0:
-                w(u'return') 
+                w(u'return')
             else:
-                for rv in returnValues: 
+                for rv in returnValues:
                     w(u'return {}', rv)
 
         for (path, api) in sorted(oaSpec['paths'].iteritems()):

--- a/src/sysl/importers/import_openapi.py
+++ b/src/sysl/importers/import_openapi.py
@@ -164,6 +164,11 @@ class OpenApiTranslator:
             returnValues = OrderedDict()
 
             for rc, rspec in sorted(responses.iteritems()):
+                
+                if rc == 'default' or rc.startswith('x-'):
+                    self.warn('default and x-* responses are not implemented')
+                    continue
+
                 schema = None
                 if rspec.get('content', None):
                     schema = rspec['content']
@@ -178,8 +183,7 @@ class OpenApiTranslator:
                         varName = "ok <: "
                     elif rc.startswith('4') or rc.startswith('5'):
                         varName = "error <: "
-                    elif rc == 'default' or rc.startswith('x-'):
-                        self.warn('default responses and x-* responses are not implemented')
+                    
                     if varName != "":
                         if schema.get('type') == 'array':
                             returnValues[varName + 'sequence of ' + schema['items']['$ref'].rpartition('/')[2]] = True
@@ -188,8 +192,12 @@ class OpenApiTranslator:
 
             if len(returnValues) > 2:
                 self.error('invalid return value set:' + json.dumps(returnValues))
-            for rv in returnValues:
-                w(u'return {}', rv)
+            
+            if len(returnValues) == 0:
+                w(u'return') 
+            else:
+                for rv in returnValues: 
+                    w(u'return {}', rv)
 
         for (path, api) in sorted(oaSpec['paths'].iteritems()):
             apiParams = api.pop('parameters') if 'parameters' in api else []

--- a/src/sysl/importers/import_swagger.py
+++ b/src/sysl/importers/import_swagger.py
@@ -233,20 +233,19 @@ class SwaggerTranslator:
                         # ref: https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#responses-object
 
                         returnValues = OrderedDict()
-                        for key in sorted(responses):                            
+                        for key in sorted(responses):
                             if key == 'default' or key.startswith('x-'):
                                 self.warn('default and x-* responses are not implemented')
                                 continue
 
                             schema = responses.get(key, {}).get('schema')
-                            
+
                             if schema is not None:
                                 varName = ""
                                 if key.startswith('2'):
                                     varName = "ok <: "
                                 elif key.startswith('4') or key.startswith('5'):
                                     varName = "error <: "
-                                
 
                                 if varName != "":
                                     if schema.get('type') == 'array':
@@ -258,9 +257,9 @@ class SwaggerTranslator:
                             self.error('invalid return value set:' + json.dumps(returnValues))
 
                         if len(returnValues) == 0:
-                            w(u'return') 
+                            w(u'return')
                         else:
-                            for rv in returnValues: 
+                            for rv in returnValues:
                                 w(u'return {}', rv)
 
     def writeDefs(self, swag, w):

--- a/src/sysl/importers/import_swagger.py
+++ b/src/sysl/importers/import_swagger.py
@@ -236,14 +236,25 @@ class SwaggerTranslator:
                         for key in sorted(responses):
                             schema = responses.get(key, {}).get('schema')
                             if schema is not None:
-                                if schema.get('type') == 'array':
-                                    returnValues['sequence of ' + schema['items']['$ref'].rpartition('/')[2]] = True
-                                else:
-                                    returnValues[schema['$ref'].rpartition('/')[2]] = True
-                            if key.startswith('x-'):
-                                self.warn('x-* responses are not implemented')
+                                varName = ""
+                                if key.startswith('2'):
+                                    varName = "ok <: "
+                                elif key.startswith('4') or key.startswith('5'):
+                                    varName = "error <: "
+                                elif key == 'default' or key.startswith('x-'):
+                                    self.warn('default and x-* responses are not implemented')
 
-                        w(u'return {}'.format(', '.join(returnValues)))
+                                if varName != "":
+                                    if schema.get('type') == 'array':
+                                        returnValues[varName + 'sequence of ' + schema['items']['$ref'].rpartition('/')[2]] = True
+                                    else:
+                                        returnValues[varName + schema['$ref'].rpartition('/')[2]] = True
+                        
+                        if len(returnValues) > 2:
+                            self.error('invalid return value set:' + json.dumps(returnValues))
+                        
+                        for rv in returnValues:
+                            w(u'return {}', rv)
 
     def writeDefs(self, swag, w):
         w()

--- a/src/sysl/importers/import_swagger.py
+++ b/src/sysl/importers/import_swagger.py
@@ -233,28 +233,35 @@ class SwaggerTranslator:
                         # ref: https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#responses-object
 
                         returnValues = OrderedDict()
-                        for key in sorted(responses):
+                        for key in sorted(responses):                            
+                            if key == 'default' or key.startswith('x-'):
+                                self.warn('default and x-* responses are not implemented')
+                                continue
+
                             schema = responses.get(key, {}).get('schema')
+                            
                             if schema is not None:
                                 varName = ""
                                 if key.startswith('2'):
                                     varName = "ok <: "
                                 elif key.startswith('4') or key.startswith('5'):
                                     varName = "error <: "
-                                elif key == 'default' or key.startswith('x-'):
-                                    self.warn('default and x-* responses are not implemented')
+                                
 
                                 if varName != "":
                                     if schema.get('type') == 'array':
                                         returnValues[varName + 'sequence of ' + schema['items']['$ref'].rpartition('/')[2]] = True
                                     else:
                                         returnValues[varName + schema['$ref'].rpartition('/')[2]] = True
-                        
+
                         if len(returnValues) > 2:
                             self.error('invalid return value set:' + json.dumps(returnValues))
-                        
-                        for rv in returnValues:
-                            w(u'return {}', rv)
+
+                        if len(returnValues) == 0:
+                            w(u'return') 
+                        else:
+                            for rv in returnValues: 
+                                w(u'return {}', rv)
 
     def writeDefs(self, swag, w):
         w()

--- a/test/importers/test_import_openapi.py
+++ b/test/importers/test_import_openapi.py
@@ -57,7 +57,7 @@ components:
     /test:
         GET:
             | No description.
-            return SimpleObj
+            return ok <: SimpleObj
 
     #---------------------------------------------------------------------------
     # definitions
@@ -352,7 +352,7 @@ paths:
         /goat/delete-goat:
             POST ?goat_id=string:
                 | Delete a goat.
-                return Acknowledgement
+                return ok <: Acknowledgement
 
     #---------------------------------------------------------------------------
     # definitions
@@ -439,7 +439,7 @@ paths:
         /goat/get-goats:
             GET:
                 | Gotta get goats.
-                return sequence of Goat
+                return ok <: sequence of Goat
 
     #---------------------------------------------------------------------------
     # definitions
@@ -667,7 +667,7 @@ paths:
           description: 'here be default response'
       summary: Check goat status
 """)
-    expected_warnings = ['default responses and x-* responses are not implemented']
+    expected_warnings = ['default and x-* responses are not implemented']
     assert logger.warnings == expected_warnings
 
 
@@ -692,7 +692,7 @@ paths:
           description: 'here be an x-banana response'
       summary: Check goat status
 """)
-    expected_warnings = ['default responses and x-* responses are not implemented']
+    expected_warnings = ['default and x-* responses are not implemented']
     assert logger.warnings == expected_warnings
 
 

--- a/test/importers/test_import_openapi.py
+++ b/test/importers/test_import_openapi.py
@@ -25,6 +25,48 @@ def getOutputString(input):
     return str(w), logger
 
 
+def test_importing_simple_openapi_with_error_type():
+    output, _ = getOutputString(r"""
+"openapi": "3.0"
+info:
+  title: Simple
+paths:
+  /test:
+    get:
+      responses:
+        400:
+          description: "client error"
+          content:
+              application/json:
+                schema:
+                  $ref: "#/components/schemas/SimpleObj"
+components:
+  schemas:
+    SimpleObj:
+
+      type: object
+      properties:
+        name:
+          type: string
+""")
+    assert r"""
+ "Simple" [package=""]:
+    @description =:
+        | No description.
+
+    /test:
+        GET:
+            | No description.
+            return error <: SimpleObj
+
+    #---------------------------------------------------------------------------
+    # definitions
+
+    !type SimpleObj:
+        name <: string?:
+            @json_tag = "name"
+""" in output
+
 def test_importing_simple_openapi_with_json_tags():
     output, _ = getOutputString(r"""
 "openapi": "3.0"

--- a/test/importers/test_import_openapi.py
+++ b/test/importers/test_import_openapi.py
@@ -67,6 +67,7 @@ components:
             @json_tag = "name"
 """ in output
 
+
 def test_importing_simple_openapi_with_json_tags():
     output, _ = getOutputString(r"""
 "openapi": "3.0"

--- a/test/importers/test_import_swagger.py
+++ b/test/importers/test_import_swagger.py
@@ -978,9 +978,31 @@ def getOutputString(input):
 
 
 def test_importing_simple_swagger_with_json_tags():
+    output, _ = getOutputString(r"""
+swagger: "2.0"
+info:
+  title: Simple
+paths:
+  /test:
+    get:
+      responses:
+        400:
+          description: client error
+          schema:
+            $ref: '#/definitions/SimpleObj'
+definitions:
+  SimpleObj:
+
+    type: object
+    properties:
+      name:
+        type: string
+""")
+    assert 'return error <: SimpleObj' in output
+
+def test_importing_simple_swagger_with_json_tags():
     output, _ = getOutputString(SIMPLE_SWAGGER_EXAMPLE)
     assert 'name <: string?:\n            @json_tag = "name"' in output
-
 
 def test_importing_swagger_with_top_level_array():
     output, _ = getOutputString(SWAGGER_TOP_LEVEL_ARRAY_EXAMPLE)

--- a/test/importers/test_import_swagger.py
+++ b/test/importers/test_import_swagger.py
@@ -280,7 +280,7 @@ EXAMPLE_SWAGGER_SPEC_WITH_ENDPOINT_PATH_EXPECTED_SYSL = r"""
         /goat/delete-goat:
             POST ?goat_id=string:
                 | Delete a goat.
-                return Acknowledgement
+                return ok <: Acknowledgement
 
     #---------------------------------------------------------------------------
     # definitions
@@ -356,7 +356,7 @@ EXAMPLE_SWAGGER_SPEC_WITH_ENDPOINT_RETURNING_ARRAY_OF_DEFINED_OBJECT_TYPE_EXPECT
         /goat/get-goats:
             GET:
                 | Gotta get goats.
-                return sequence of Goat
+                return ok <: sequence of Goat
 
     #---------------------------------------------------------------------------
     # definitions
@@ -1072,13 +1072,13 @@ def test_import_of_swagger_path_with_error_response():
 
 def test_import_of_swagger_path_with_default_response_is_not_implemented():
     _, logger = getOutputString(EXAMPLE_SWAGGER_SPEC_WITH_ENDPOINT_PATH_WITH_DEFAULT_RESPONSE)
-    expected_warnings = []
+    expected_warnings = ['default and x-* responses are not implemented']
     assert logger.warnings == expected_warnings
 
 
 def test_import_of_swagger_path_with_x_dash_whatever_response_is_not_implemented():
     _, logger = getOutputString(EXAMPLE_SWAGGER_SPEC_WITH_ENDPOINT_PATH_WITH_X_DASH_WHATEVER_RESPONSE)
-    expected_warnings = ['x-* responses are not implemented']
+    expected_warnings = ['default and x-* responses are not implemented']
     assert logger.warnings == expected_warnings
 
 

--- a/test/importers/test_import_swagger.py
+++ b/test/importers/test_import_swagger.py
@@ -1000,9 +1000,11 @@ definitions:
 """)
     assert 'return error <: SimpleObj' in output
 
+
 def test_importing_simple_swagger_with_json_tags():
     output, _ = getOutputString(SIMPLE_SWAGGER_EXAMPLE)
     assert 'name <: string?:\n            @json_tag = "name"' in output
+
 
 def test_importing_swagger_with_top_level_array():
     output, _ = getOutputString(SWAGGER_TOP_LEVEL_ARRAY_EXAMPLE)


### PR DESCRIPTION
Fixes #407 (partially, see below)

The changes here are used by the SYSL->Go transforms to unmarshal the correct type. The inherent assumption is that there will be a 0..1 return types for OK conditions and 0..1 return types for error conditions.

An internal version of restlib was also updated to make use of this new functionality, this should be folded back in to the public restlib. However, that is outside the scope of this repository.

@anz-bank/sysl-developers
