### PR TITLE
Fix #430 - check for --help flag before checking empty flags

### DIFF
--- a/sysl2/sysl/cmd_runner.go
+++ b/sysl2/sysl/cmd_runner.go
@@ -84,6 +84,11 @@ func EnsureFlagsNonEmpty(cmd *kingpin.CmdClause, excludes ...string) {
 	}
 	fn := func(c *kingpin.ParseContext) error {
 		var errorMsg strings.Builder
+		for _, elem := range c.Elements {
+			if f, _ := elem.Clause.(*kingpin.FlagClause); f != nil && f.Model().Name == "help" {
+				return nil // help requested, don't need to check for empty flags
+			}
+		}
 		for _, f := range cmd.Model().Flags {
 			if inExcludes(f.Name) {
 				continue


### PR DESCRIPTION
Fixes #430 

If the --help flag is provided on a specific command, but that command has any empty-by-default flags the woould error out instead of showing the help text, fix that.

@anz-bank/sysl-developers
