### PR TITLE
Fix swagger import endpoint return values

### DIFF
--- a/sysl2/sysl/cmd_codegen.go
+++ b/sysl2/sysl/cmd_codegen.go
@@ -30,6 +30,8 @@ func (p *codegenCmd) Configure(app *kingpin.Application) *kingpin.CmdClause {
 	cmd.Flag("start", "start rule for the grammar").Default(".").StringVar(&p.start)
 	cmd.Flag("outdir", "output directory").Default(".").StringVar(&p.outDir)
 	cmd.Flag("validate-only", "Only Perform validation on the transform grammar").BoolVar(&p.validateOnly)
+	cmd.Flag("disable-validator", "Disable validation on the transform grammar").
+		Default("false").BoolVar(&p.disableValidator)
 	EnsureFlagsNonEmpty(cmd, "app-name")
 	return cmd
 }

--- a/sysl2/sysl/cmd_import.go
+++ b/sysl2/sysl/cmd_import.go
@@ -41,7 +41,7 @@ func (p *importCmd) Configure(app *kingpin.Application) *kingpin.CmdClause {
 		HintOptions(opts...).
 		EnumVar(&p.mode, opts...)
 
-	EnsureFlagsNonEmpty(cmd)
+	EnsureFlagsNonEmpty(cmd, "package")
 	return cmd
 }
 

--- a/sysl2/sysl/codegen.go
+++ b/sysl2/sysl/codegen.go
@@ -274,13 +274,15 @@ func GenerateCode(
 		return nil, err
 	}
 
-	grammarSysl, err := validate.LoadGrammar(codegenParams.grammar, fs)
-	if err != nil {
-		msg.NewMsg(msg.WarnValidationSkipped, []string{err.Error()}).LogMsg()
-	} else {
-		validator := validate.NewValidator(grammarSysl, tx.GetApps()[transformAppName], tfmParser)
-		validator.Validate(codegenParams.start)
-		validator.LogMessages()
+	if !codegenParams.disableValidator {
+		grammarSysl, err := validate.LoadGrammar(codegenParams.grammar, fs)
+		if err != nil {
+			msg.NewMsg(msg.WarnValidationSkipped, []string{err.Error()}).LogMsg()
+		} else {
+			validator := validate.NewValidator(grammarSysl, tx.GetApps()[transformAppName], tfmParser)
+			validator.Validate(codegenParams.start)
+			validator.LogMessages()
+		}
 	}
 
 	fileNames, err := applyTranformToModel(modelAppName, transformAppName, "filename", model, tx)

--- a/sysl2/sysl/eval/exprEval.go
+++ b/sysl2/sysl/eval/exprEval.go
@@ -250,7 +250,7 @@ func evalGetAttr(ee *exprEval, assign Scope, x *sysl.Expr_GetAttr_) *sysl.Value 
 	if isInternalMap(arg.GetMap()) {
 		switch key := x.GetAttr.Attr; key {
 		case "value":
-			ee.LogEntry().Warnf("Unnecessary use of .value")
+			ee.LogEntry().Debugf("Unnecessary use of .value")
 			fallthrough
 		case "key":
 			return arg.GetMap().Items[key]

--- a/sysl2/sysl/importer/endpoints.go
+++ b/sysl2/sysl/importer/endpoints.go
@@ -68,7 +68,6 @@ func buildResponses(path string, responses *spec.Responses, types TypeList, logg
 	}
 	if responses.Default != nil {
 		logger.Warnf("default responses not implemented, endpoint: %s", path)
-		outs = append(outs, Response{Text: "default"})
 	}
 
 	return outs

--- a/sysl2/sysl/importer/endpoints.go
+++ b/sysl2/sysl/importer/endpoints.go
@@ -51,7 +51,11 @@ func buildResponses(path string, responses *spec.Responses, types TypeList, logg
 				logger.Errorf("Responses type for code %d not found, endpoint: %s, skipping", statusCode, path)
 				continue
 			}
-			outs = append(outs, Response{Type: t})
+			text := "error"
+			if statusCode < 300 {
+				text = "ok"
+			}
+			outs = append(outs, Response{Text: text, Type: t})
 		} else {
 			outs = append(outs, Response{Text: fmt.Sprintf("%d", statusCode)})
 		}

--- a/sysl2/sysl/importer/tests-swagger/EXAMPLE_SWAGGER_SPEC_WITH_ENDPOINT_PATH.sysl
+++ b/sysl2/sysl/importer/tests-swagger/EXAMPLE_SWAGGER_SPEC_WITH_ENDPOINT_PATH.sysl
@@ -15,7 +15,7 @@ testapp "Goat CRUD API" [package="package_foo"]:
         /goat/delete-goat:
             POST ?goat_id=string:
                 | Delete a goat.
-                return Acknowledgement
+                return ok <: Acknowledgement
 
     #---------------------------------------------------------------------------
     # definitions

--- a/sysl2/sysl/importer/tests-swagger/EXAMPLE_SWAGGER_SPEC_WITH_ENDPOINT_PATH_WITH_DEFAULT_RESPONSE.sysl
+++ b/sysl2/sysl/importer/tests-swagger/EXAMPLE_SWAGGER_SPEC_WITH_ENDPOINT_PATH_WITH_DEFAULT_RESPONSE.sysl
@@ -15,7 +15,6 @@ testapp "Goat CRUD API" [package="package_foo"]:
         /goat/status:
             GET:
                 | Check goat status
-                return default
 
     #---------------------------------------------------------------------------
     # definitions

--- a/sysl2/sysl/importer/tests-swagger/EXAMPLE_SWAGGER_SPEC_WITH_ENDPOINT_PATH_WITH_ERROR_RESPONSE.sysl
+++ b/sysl2/sysl/importer/tests-swagger/EXAMPLE_SWAGGER_SPEC_WITH_ENDPOINT_PATH_WITH_ERROR_RESPONSE.sysl
@@ -15,7 +15,9 @@ testapp "Goat CRUD API" [package="package_foo"]:
         /goat/status:
             GET:
                 | Check goat status
-                return 200, 500
+                return 200
+                return 500
+                return 400
 
     #---------------------------------------------------------------------------
     # definitions

--- a/sysl2/sysl/importer/tests-swagger/EXAMPLE_SWAGGER_SPEC_WITH_ENDPOINT_PATH_WITH_ERROR_RESPONSE.sysl
+++ b/sysl2/sysl/importer/tests-swagger/EXAMPLE_SWAGGER_SPEC_WITH_ENDPOINT_PATH_WITH_ERROR_RESPONSE.sysl
@@ -16,8 +16,8 @@ testapp "Goat CRUD API" [package="package_foo"]:
             GET:
                 | Check goat status
                 return 200
-                return 500
                 return 400
+                return 500
 
     #---------------------------------------------------------------------------
     # definitions

--- a/sysl2/sysl/importer/tests-swagger/EXAMPLE_SWAGGER_SPEC_WITH_ENDPOINT_PATH_WITH_ERROR_RESPONSE.yaml
+++ b/sysl2/sysl/importer/tests-swagger/EXAMPLE_SWAGGER_SPEC_WITH_ENDPOINT_PATH_WITH_ERROR_RESPONSE.yaml
@@ -19,4 +19,6 @@ paths:
           description: 'here be status'
         '500':
           description: 'alas, the server is broken'
+        '400':
+          description: 'woopsies'
       summary: Check goat status

--- a/sysl2/sysl/importer/tests-swagger/EXAMPLE_SWAGGER_SPEC_WITH_ENDPOINT_RETURNING_ARRAY_OF_DEFINED_OBJECT_TYPE.sysl
+++ b/sysl2/sysl/importer/tests-swagger/EXAMPLE_SWAGGER_SPEC_WITH_ENDPOINT_RETURNING_ARRAY_OF_DEFINED_OBJECT_TYPE.sysl
@@ -15,7 +15,7 @@ testapp "Goat CRUD API" [package="package_foo"]:
         /goat/get-goats:
             GET:
                 | Gotta get goats.
-                return sequence of Goat
+                return ok <: sequence of Goat
 
     #---------------------------------------------------------------------------
     # definitions

--- a/sysl2/sysl/importer/tests-swagger/SIMPLE_SWAGGER_EXAMPLE.sysl
+++ b/sysl2/sysl/importer/tests-swagger/SIMPLE_SWAGGER_EXAMPLE.sysl
@@ -11,7 +11,7 @@ testapp "Simple" [package="package_foo"]:
     /test:
         GET:
             | No description.
-            return SimpleObj
+            return ok <: SimpleObj
 
     #---------------------------------------------------------------------------
     # definitions

--- a/sysl2/sysl/importer/tests-swagger/SIMPLE_SWAGGER_EXAMPLE_WITH_MULTI_LINE_COMMENTS.sysl
+++ b/sysl2/sysl/importer/tests-swagger/SIMPLE_SWAGGER_EXAMPLE_WITH_MULTI_LINE_COMMENTS.sysl
@@ -36,7 +36,7 @@ testapp "Simple" [package="package_foo"]:
             | porta, metus lacus lacinia arcu, eu rutrum ex libero at augue. Sed
             | maximus, est sit amet pretium commodo, tellus arcu facilisis
             | massa, vitae feugiat felis dui ac ipsum.
-            return SimpleObj
+            return ok <: SimpleObj
 
     #---------------------------------------------------------------------------
     # definitions

--- a/sysl2/sysl/importer/writer.go
+++ b/sysl2/sysl/importer/writer.go
@@ -232,14 +232,16 @@ func (w *writer) writeEndpoint(method string, endpoint Endpoint) {
 	if len(endpoint.Responses) > 0 {
 		var outs []string
 		for _, resp := range endpoint.Responses {
-			if resp.Type != nil {
-				outs = append(outs, getSyslTypeName(resp.Type))
-			} else {
-				outs = append(outs, resp.Text)
+			switch {
+			case resp.Type != nil && resp.Text != "":
+				outs = append(outs, fmt.Sprintf("return %s <: %s", resp.Text, getSyslTypeName(resp.Type)))
+			case resp.Type != nil:
+				outs = append(outs, "return "+getSyslTypeName(resp.Type))
+			default:
+				outs = append(outs, "return "+resp.Text)
 			}
 		}
-		sort.Strings(outs)
-		w.writeLines(fmt.Sprintf("return %s", strings.Join(outs, ", ")))
+		w.writeLines(outs...)
 	}
 
 	w.writeLines(PopIndent, PopIndent)

--- a/sysl2/sysl/importer/writer.go
+++ b/sysl2/sysl/importer/writer.go
@@ -8,6 +8,8 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/go-openapi/swag"
+
 	"github.com/sirupsen/logrus"
 )
 
@@ -232,13 +234,17 @@ func (w *writer) writeEndpoint(method string, endpoint Endpoint) {
 	if len(endpoint.Responses) > 0 {
 		var outs []string
 		for _, resp := range endpoint.Responses {
+			var newline string
 			switch {
 			case resp.Type != nil && resp.Text != "":
-				outs = append(outs, fmt.Sprintf("return %s <: %s", resp.Text, getSyslTypeName(resp.Type)))
+				newline = fmt.Sprintf("return %s <: %s", resp.Text, getSyslTypeName(resp.Type))
 			case resp.Type != nil:
-				outs = append(outs, "return "+getSyslTypeName(resp.Type))
+				newline = "return " + getSyslTypeName(resp.Type)
 			default:
-				outs = append(outs, "return "+resp.Text)
+				newline = "return " + resp.Text
+			}
+			if !swag.ContainsStrings(outs, newline) {
+				outs = append(outs, newline)
 			}
 		}
 		w.writeLines(outs...)

--- a/sysl2/sysl/importer/writer.go
+++ b/sysl2/sysl/importer/writer.go
@@ -247,6 +247,7 @@ func (w *writer) writeEndpoint(method string, endpoint Endpoint) {
 				outs = append(outs, newline)
 			}
 		}
+		sort.Strings(outs)
 		w.writeLines(outs...)
 	}
 

--- a/sysl2/sysl/parse/tests/foreign_import_swagger.sysl.golden.textpb
+++ b/sysl2/sysl/parse/tests/foreign_import_swagger.sysl.golden.textpb
@@ -34,7 +34,7 @@ apps: <
         >
         stmt: <
           ret: <
-            payload: "SimpleObj"
+            payload: "ok <: SimpleObj"
           >
         >
         rest_params: <

--- a/sysl2/sysl/types.go
+++ b/sysl2/sysl/types.go
@@ -43,10 +43,11 @@ type VarManager interface {
 }
 
 type CmdContextParamCodegen struct {
-	rootTransform string
-	transform     string
-	grammar       string
-	start         string
+	rootTransform    string
+	transform        string
+	grammar          string
+	start            string
+	disableValidator bool
 }
 
 type CmdContextParamSeqgen struct {


### PR DESCRIPTION
Resync the go swagger importer to the python changes.
swagger imports correctly sets the return types for endpoints

@anz-bank/sysl-developers
