### PR TITLE
Revert "Fix GetTypeDetail()"

### DIFF
--- a/sysl2/sysl/syslutil/typeutil.go
+++ b/sysl2/sysl/syslutil/typeutil.go
@@ -1,10 +1,6 @@
 package syslutil
 
-import (
-	"strings"
-
-	sysl "github.com/anz-bank/sysl/src/proto"
-)
+import sysl "github.com/anz-bank/sysl/src/proto"
 
 // GetTypeDetail returns name of the type and details in string format
 func GetTypeDetail(t *sysl.Type) (typeName string, typeDetail string) {
@@ -14,14 +10,15 @@ func GetTypeDetail(t *sysl.Type) (typeName string, typeDetail string) {
 		typeDetail = sysl.Type_Primitive_name[int32(x.Primitive)]
 	case *sysl.Type_TypeRef:
 		typeName = "type_ref"
-		switch {
-		case x.TypeRef.Ref != nil && len(x.TypeRef.Ref.Path) == 1:
+		if x.TypeRef.Ref != nil && len(x.TypeRef.Ref.Path) == 1 {
 			typeDetail = x.TypeRef.Ref.Path[0]
-		case x.TypeRef.Ref.Appname != nil:
+			if x.TypeRef.Ref.Appname != nil {
+				typeDetail = x.TypeRef.Ref.Appname.Part[0] + "." + typeDetail
+			}
+		} else {
 			typeDetail = x.TypeRef.Ref.Appname.Part[0]
-		default:
-			typeDetail = strings.Join(x.TypeRef.Ref.Path, ".")
 		}
+
 	case *sysl.Type_Sequence:
 		typeName = "sequence"
 		_, d := GetTypeDetail(x.Sequence)


### PR DESCRIPTION
This reverts commit 771451069c4472acca66bd6ff6d6445cbc44bbe6.

This change removed the application scoping for types and broke the Go code generator.