### PR TITLE
Handle NativeDataType correctly in all places it can be parsed

### DIFF
--- a/pkg/parse/utils.go
+++ b/pkg/parse/utils.go
@@ -1,6 +1,9 @@
 package parse
 
 import (
+	"math"
+	"strings"
+
 	"github.com/antlr/antlr4/runtime/Go/antlr"
 	sysl "github.com/anz-bank/sysl/pkg/proto_old"
 )
@@ -24,4 +27,53 @@ func (s sourceCtxHelper) Get(ctx *antlr.BaseParserRuleContext) *sysl.SourceConte
 			Col:  int32(start.GetColumn()),
 		},
 	}
+}
+
+func primitiveFromNativeDataType(native antlr.TerminalNode) (*sysl.Type_Primitive_, *sysl.Type_Constraint) {
+	if native == nil {
+		return nil, nil
+	}
+	text := strings.ToUpper(native.GetText())
+	primitiveType := sysl.Type_Primitive(sysl.Type_Primitive_value[text])
+	if primitiveType != sysl.Type_NO_Primitive {
+		return &sysl.Type_Primitive_{Primitive: primitiveType}, nil
+	}
+
+	var constraint *sysl.Type_Constraint
+	switch text {
+	case "INT32":
+		primitiveType = sysl.Type_Primitive(sysl.Type_Primitive_value["INT"])
+		constraint = &sysl.Type_Constraint{
+			Range: &sysl.Type_Constraint_Range{
+				Min: &sysl.Value{
+					Value: &sysl.Value_I{
+						I: math.MinInt32,
+					},
+				},
+				Max: &sysl.Value{
+					Value: &sysl.Value_I{
+						I: math.MaxInt32,
+					},
+				},
+			},
+		}
+
+	case "INT64":
+		primitiveType = sysl.Type_Primitive(sysl.Type_Primitive_value["INT"])
+		constraint = &sysl.Type_Constraint{
+			Range: &sysl.Type_Constraint_Range{
+				Min: &sysl.Value{
+					Value: &sysl.Value_I{
+						I: math.MinInt64,
+					},
+				},
+				Max: &sysl.Value{
+					Value: &sysl.Value_I{
+						I: math.MaxInt64,
+					},
+				},
+			},
+		}
+	}
+	return &sysl.Type_Primitive_{Primitive: primitiveType}, constraint
 }


### PR DESCRIPTION
Fixes the handling of NativeDataType from the parser to ensure int32/int64 are correctly loaded

Fix #460 

@anz-bank/sysl-developers
