### PR TITLE
Fix issue with unit tests depending on demo/simple/sysl-ints.sysl

### DIFF
--- a/demo/Readme.md
+++ b/demo/Readme.md
@@ -1,0 +1,5 @@
+# demo/
+
+## Warning
+These examples have test case dependencies, think carefuly before changing them
+

--- a/demo/simple/sysl-ints.sysl
+++ b/demo/simple/sysl-ints.sysl
@@ -11,8 +11,8 @@ System1:
 System2:
     endpoint: ...
 
-Project:
-    this:
+Project [appfmt="%(appname)"]:
+    _:
         IntegratedSystem
         System1
         System2


### PR DESCRIPTION
Go tests started failing after #468 due to a change to demo/simple/sysl-ints.sysl. 
Most local instances didn't fail due to the fact that go test caches test results; since the sysl file wasn't being watched it changed without the tests being re-run. 

This fixes that issue. 

I still need to do some investigation on why it passed CI to start with. 

@anz-bank/sysl-developers
