### PR TITLE
Switch to displaying an actual diff when parse tests fail

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -44,6 +44,7 @@ require (
 	github.com/olekukonko/tablewriter v0.0.4 // indirect
 	github.com/pelletier/go-toml v1.6.0 // indirect
 	github.com/pkg/errors v0.8.1
+	github.com/pmezard/go-difflib v1.0.0
 	github.com/rogpeppe/go-internal v1.5.0 // indirect
 	github.com/rubenv/pygmentize v0.0.0-20150323185546-0a6438ede9e4
 	github.com/russross/blackfriday v2.0.0+incompatible


### PR DESCRIPTION
Current output on errors:
```
Parser_test.go:269: 
        	Error Trace:	Parser_test.go:269
        	            				Parser_test.go:573
        	Error:      	Received unexpected error:
        	            	exit status 1
        	            	diff -yw "tests/alias.sysl.golden.textpb" "/var/folders/z8/f5j7zd3n5q1_f_vm_s64vg8h0000gn/T/sysl-test-685025872.textpb"
        	            	github.com/anz-bank/sysl/pkg/parse.parseAndCompare
        	            		/Users/gordonj7/git/sysl/pkg/parse/Parser_test.go:238
        	            	github.com/anz-bank/sysl/pkg/parse.parseAndCompareWithGolden
        	            		/Users/gordonj7/git/sysl/pkg/parse/Parser_test.go:257
        	            	github.com/anz-bank/sysl/pkg/parse.testParseAgainstGoldenWithSourceContext
        	            		/Users/gordonj7/git/sysl/pkg/parse/Parser_test.go:268
        	            	github.com/anz-bank/sysl/pkg/parse.TestTypeAlias
        	            		/Users/gordonj7/git/sysl/pkg/parse/Parser_test.go:573
        	            	testing.tRunner
        	            		/usr/local/go/src/testing/testing.go:865
        	            	runtime.goexit
        	            		/usr/local/go/src/runtime/asm_amd64.s:1337
        	Test:       	TestTypeAlias


```

New behaviour:

```
Parser_test.go:240: 
        	Error Trace:	Parser_test.go:240
        	            				Parser_test.go:544
        	Error:      	Received unexpected error:
        	            	--- Expected: tests/alias.sysl.golden.textpb
        	            	+++ Actual
        	            	@@ -83,3 +83,3 @@
        	            	                 ref: <
        	            	-                  path: "foo"
        	            	+                  path: "Error"
        	            	                 >
        	            	
        	            	github.com/anz-bank/sysl/pkg/parse.parseAndCompare
        	            		/Users/gordonj7/git/sysl/pkg/parse/Parser_test.go:213
        	            	github.com/anz-bank/sysl/pkg/parse.parseAndCompareWithGolden
        	            		/Users/gordonj7/git/sysl/pkg/parse/Parser_test.go:228
        	            	github.com/anz-bank/sysl/pkg/parse.testParseAgainstGoldenWithSourceContext
        	            		/Users/gordonj7/git/sysl/pkg/parse/Parser_test.go:239
        	            	github.com/anz-bank/sysl/pkg/parse.TestTypeAlias
        	            		/Users/gordonj7/git/sysl/pkg/parse/Parser_test.go:544
        	            	testing.tRunner
        	            		/usr/local/go/src/testing/testing.go:865
        	            	runtime.goexit
        	            		/usr/local/go/src/runtime/asm_amd64.s:1337
        	Test:       	TestTypeAlias


```

I have purposely removed the retain error files behaviour because tests really should not be touching the filesystem! 

@anz-bank/sysl-developers
