### PR TITLE
Feature/refactor listener

### DIFF
--- a/pkg/parse/Parser_test.go
+++ b/pkg/parse/Parser_test.go
@@ -400,12 +400,6 @@ func TestInplaceTuple(t *testing.T) {
 	testParseAgainstGolden(t, "tests/inplace_tuple.sysl", "")
 }
 
-func TestRelational(t *testing.T) {
-	t.Parallel()
-
-	testParseAgainstGolden(t, "tests/school.sysl", "")
-}
-
 func TestImports(t *testing.T) {
 	t.Parallel()
 
@@ -418,7 +412,7 @@ func TestForeignImports(t *testing.T) {
 	testParseAgainstGolden(t, "tests/foreign_import_swagger.sysl", "")
 }
 
-func TestRootArg(t *testing.T) {
+func TestRootArgAndRelational(t *testing.T) {
 	t.Parallel()
 
 	testParseAgainstGolden(t, "school.sysl", "tests")

--- a/pkg/parse/listener_impl.go
+++ b/pkg/parse/listener_impl.go
@@ -323,11 +323,7 @@ func (s *TreeShapeListener) EnterField_type(ctx *parser.Field_typeContext) {
 	if ctx.QN() != nil {
 		type1.Opt = true
 	}
-	type1.SourceContext = &sysl.SourceContext{
-		Start: &sysl.SourceContext_Location{
-			Line: int32(ctx.GetStart().GetLine()),
-		},
-	}
+	type1.SourceContext = s.sc.Get(ctx.BaseParserRuleContext)
 
 	if ctx.Annotations() != nil {
 		if type1.Attrs == nil {
@@ -557,11 +553,7 @@ func (s *TreeShapeListener) EnterField(ctx *parser.FieldContext) {
 		}
 	}
 
-	type1.SourceContext = &sysl.SourceContext{
-		Start: &sysl.SourceContext_Location{
-			Line: int32(ctx.GetStart().GetLine()),
-		},
-	}
+	type1.SourceContext = s.sc.Get(ctx.BaseParserRuleContext)
 	if ctx.QSTRING() != nil {
 		type1.Docstring = fromQString(ctx.QSTRING().GetText())
 	}
@@ -922,11 +914,7 @@ func (s *TreeShapeListener) EnterQuery_var(ctx *parser.Query_varContext) {
 		rest_param.Type.Opt = true
 	}
 
-	rest_param.Type.SourceContext = &sysl.SourceContext{
-		Start: &sysl.SourceContext_Location{
-			Line: int32(ctx.GetStart().GetLine()),
-		},
-	}
+	rest_param.Type.SourceContext = s.sc.Get(ctx.BaseParserRuleContext)
 	s.method_urlparams = append(s.method_urlparams, rest_param)
 }
 
@@ -970,11 +958,7 @@ func (s *TreeShapeListener) EnterHttp_path_var_with_type(ctx *parser.Http_path_v
 		Type: type1,
 	}
 
-	rest_param.Type.SourceContext = &sysl.SourceContext{
-		Start: &sysl.SourceContext_Location{
-			Line: int32(ctx.GetStart().GetLine()),
-		},
-	}
+	rest_param.Type.SourceContext = s.sc.Get(ctx.BaseParserRuleContext)
 
 	s.rest_urlparams = append(s.rest_urlparams, rest_param)
 	s.endpointName += ctx.CURLY_OPEN().GetText() + var_name + ctx.CURLY_CLOSE().GetText()
@@ -1561,12 +1545,8 @@ func (s *TreeShapeListener) EnterMethod_def(ctx *parser.Method_defContext) {
 			qcopy := &sysl.Endpoint_RestParams_QueryParam{
 				Name: q.Name,
 				Type: &sysl.Type{
-					Type: q.Type.Type,
-					SourceContext: &sysl.SourceContext{
-						Start: &sysl.SourceContext_Location{
-							Line: int32(ctx.GetStart().GetLine()),
-						},
-					},
+					Type:          q.Type.Type,
+					SourceContext: s.sc.Get(ctx.BaseParserRuleContext),
 				},
 			}
 			qparams = append(qparams, qcopy)

--- a/pkg/parse/listener_impl.go
+++ b/pkg/parse/listener_impl.go
@@ -33,8 +33,9 @@ type TreeShapeListener struct {
 	appname  string
 	typename string
 
-	currentTypePath PathStack
-	viewname        string
+	currentTypePath     PathStack
+	currentEndpointPath PathStack
+	viewname            string
 
 	fieldname             []string
 	url_prefix            []string
@@ -74,8 +75,9 @@ func NewTreeShapeListener() *TreeShapeListener {
 		module: &sysl.Module{
 			Apps: map[string]*sysl.Application{},
 		},
-		opmap:           opmap,
-		currentTypePath: NewPathStack("."),
+		opmap:               opmap,
+		currentTypePath:     NewPathStack("."),
+		currentEndpointPath: NewPathStack("/"),
 	}
 }
 
@@ -1792,14 +1794,14 @@ func (s *TreeShapeListener) ExitCollector_stmts(ctx *parser.Collector_stmtsConte
 
 // EnterCollector is called when production collector is entered.
 func (s *TreeShapeListener) EnterCollector(ctx *parser.CollectorContext) {
-	s.typename = ctx.COLLECTOR().GetText()
-	ep := s.module.Apps[s.appname].Endpoints[s.typename]
+	collector := ctx.COLLECTOR().GetText()
+	ep := s.module.Apps[s.appname].Endpoints[collector]
 
 	if ep == nil {
 		ep = &sysl.Endpoint{
-			Name: s.typename,
+			Name: collector,
 		}
-		s.module.Apps[s.appname].Endpoints[s.typename] = ep
+		s.module.Apps[s.appname].Endpoints[collector] = ep
 	}
 
 	if ctx.Collector_stmts(0) != nil {
@@ -1814,14 +1816,14 @@ func (s *TreeShapeListener) EnterCollector(ctx *parser.CollectorContext) {
 
 // ExitCollector is called when production collector is exited.
 func (s *TreeShapeListener) ExitCollector(ctx *parser.CollectorContext) {
+	collector := ctx.COLLECTOR().GetText()
 	if ctx.Collector_stmts(0) != nil {
 		s.popScope()
 	}
-	ep := s.module.Apps[s.appname].Endpoints[s.typename]
+	ep := s.module.Apps[s.appname].Endpoints[collector]
 	if len(ep.Attrs) == 0 {
 		ep.Attrs = nil
 	}
-	s.typename = ""
 }
 
 // EnterEvent is called when production event is entered.

--- a/pkg/parse/tests/alias.sysl.golden.textpb
+++ b/pkg/parse/tests/alias.sysl.golden.textpb
@@ -46,8 +46,14 @@ apps: <
             value: <
               primitive: STRING
               source_context: <
+                file: "tests/alias.sysl"
                 start: <
                   line: 7
+                  col: 18
+                >
+                end: <
+                  line: 7
+                  col: 18
                 >
               >
             >
@@ -85,8 +91,14 @@ apps: <
                 >
               >
               source_context: <
+                file: "tests/alias.sysl"
                 start: <
                   line: 10
+                  col: 15
+                >
+                end: <
+                  line: 10
+                  col: 15
                 >
               >
             >
@@ -96,8 +108,14 @@ apps: <
             value: <
               primitive: STRING
               source_context: <
+                file: "tests/alias.sysl"
                 start: <
                   line: 11
+                  col: 18
+                >
+                end: <
+                  line: 11
+                  col: 18
                 >
               >
             >

--- a/pkg/parse/tests/bad_order.sysl.golden.textpb
+++ b/pkg/parse/tests/bad_order.sysl.golden.textpb
@@ -41,8 +41,14 @@ apps: <
             type: <
               primitive: INT
               source_context: <
+                file: "tests/bad_order.sysl"
                 start: <
                   line: 3
+                  col: 13
+                >
+                end: <
+                  line: 3
+                  col: 19
                 >
               >
             >
@@ -53,8 +59,14 @@ apps: <
               primitive: INT
               opt: true
               source_context: <
+                file: "tests/bad_order.sysl"
                 start: <
                   line: 3
+                  col: 23
+                >
+                end: <
+                  line: 3
+                  col: 32
                 >
               >
             >
@@ -65,8 +77,14 @@ apps: <
               primitive: INT
               opt: true
               source_context: <
+                file: "tests/bad_order.sysl"
                 start: <
                   line: 3
+                  col: 34
+                >
+                end: <
+                  line: 3
+                  col: 44
                 >
               >
             >
@@ -76,8 +94,14 @@ apps: <
             type: <
               primitive: INT
               source_context: <
+                file: "tests/bad_order.sysl"
                 start: <
                   line: 2
+                  col: 5
+                >
+                end: <
+                  line: 2
+                  col: 13
                 >
               >
             >
@@ -123,8 +147,14 @@ apps: <
             type: <
               primitive: INT
               source_context: <
+                file: "tests/bad_order.sysl"
                 start: <
                   line: 2
+                  col: 5
+                >
+                end: <
+                  line: 2
+                  col: 13
                 >
               >
             >
@@ -134,8 +164,14 @@ apps: <
             type: <
               primitive: INT
               source_context: <
+                file: "tests/bad_order.sysl"
                 start: <
                   line: 6
+                  col: 15
+                >
+                end: <
+                  line: 6
+                  col: 25
                 >
               >
             >

--- a/pkg/parse/tests/docstrings.sysl.golden.textpb
+++ b/pkg/parse/tests/docstrings.sysl.golden.textpb
@@ -1,143 +1,155 @@
-apps {
+apps: <
   key: "Another App"
-  value {
-    name {
+  value: <
+    name: <
       part: "Another App"
-    }
-    endpoints {
+    >
+    endpoints: <
       key: "Endpoint"
-      value {
+      value: <
         name: "Endpoint"
-        attrs {
+        attrs: <
           key: "description"
-          value {
+          value: <
             s: "multi-line documentation comment use it for long comments"
-          }
-        }
-        stmt {
-          action {
+          >
+        >
+        stmt: <
+          action: <
             action: "..."
-          }
-        }
-      }
-    }
-  }
-}
-apps {
+          >
+        >
+      >
+    >
+  >
+>
+apps: <
   key: "App"
-  value {
-    name {
+  value: <
+    name: <
       part: "App"
-    }
-    attrs {
+    >
+    attrs: <
       key: "description"
-      value {
+      value: <
         s: "multi-line documentation comment use it for long comments"
-      }
-    }
-    endpoints {
+      >
+    >
+    endpoints: <
       key: "..."
-      value {
+      value: <
         name: "..."
-      }
-    }
-  }
-}
-apps {
+      >
+    >
+  >
+>
+apps: <
   key: "Model"
-  value {
-    name {
+  value: <
+    name: <
       part: "Model"
-    }
-    types {
+    >
+    types: <
       key: "TableName"
-      value {
-        attrs {
+      value: <
+        attrs: <
           key: "description"
-          value {
+          value: <
             s: "multi-line documentation comment use it for long comments"
-          }
-        }
-      }
-    }
-  }
-}
-apps {
+          >
+        >
+      >
+    >
+  >
+>
+apps: <
   key: "ModelTwo"
-  value {
-    name {
+  value: <
+    name: <
       part: "ModelTwo"
-    }
-    types {
+    >
+    types: <
       key: "TableName"
-      value {
-        tuple {
-          attr_defs {
+      value: <
+        tuple: <
+          attr_defs: <
             key: "field"
-            value {
+            value: <
               primitive: STRING
-              attrs {
+              attrs: <
                 key: "description"
-                value {
+                value: <
                   s: "multi-line documentation comment use it for long comments"
-                }
-              }
-              source_context {
-                start {
+                >
+              >
+              source_context: <
+                file: "tests/docstrings.sysl"
+                start: <
                   line: 33
-                }
-              }
-            }
-          }
-          attr_defs {
+                  col: 17
+                >
+                end: <
+                  line: 36
+                  col: 8
+                >
+              >
+            >
+          >
+          attr_defs: <
             key: "field2"
-            value {
+            value: <
               primitive: STRING
               docstring: "short description here"
-              source_context {
-                start {
+              source_context: <
+                file: "tests/docstrings.sysl"
+                start: <
                   line: 36
-                }
-              }
-            }
-          }
-        }
-      }
-    }
-  }
-}
-apps {
+                  col: 18
+                >
+                end: <
+                  line: 36
+                  col: 18
+                >
+              >
+            >
+          >
+        >
+      >
+    >
+  >
+>
+apps: <
   key: "Yet Another App"
-  value {
-    name {
+  value: <
+    name: <
       part: "Yet Another App"
-    }
-    endpoints {
+    >
+    endpoints: <
       key: "AnotherEndpoint"
-      value {
+      value: <
         name: "AnotherEndpoint"
-        stmt {
-          action {
+        stmt: <
+          action: <
             action: "| a multi line text statement use it to well"
-          }
-        }
-        stmt {
-          action {
+          >
+        >
+        stmt: <
+          action: <
             action: "another text statement"
-          }
-        }
-      }
-    }
-    endpoints {
+          >
+        >
+      >
+    >
+    endpoints: <
       key: "Endpoint"
-      value {
+      value: <
         name: "Endpoint"
-        stmt {
-          action {
+        stmt: <
+          action: <
             action: "a simple text statement"
-          }
-        }
-      }
-    }
-  }
-}
+          >
+        >
+      >
+    >
+  >
+>

--- a/pkg/parse/tests/foreign_import_swagger.sysl.golden.textpb
+++ b/pkg/parse/tests/foreign_import_swagger.sysl.golden.textpb
@@ -59,8 +59,13 @@ apps: <
               >
               opt: true
               source_context: <
+                file: "tests/foreign_import_swagger.yaml"
                 start: <
                   line: 21
+                  col: 16
+                >
+                end: <
+                  line: 22
                 >
               >
             >
@@ -127,8 +132,14 @@ apps: <
             name: "depth"
             type: <
               source_context: <
+                file: "tests/foreign_import_swagger.sysl"
                 start: <
                   line: 19
+                  col: 13
+                >
+                end: <
+                  line: 19
+                  col: 19
                 >
               >
             >
@@ -139,8 +150,14 @@ apps: <
               primitive: INT
               opt: true
               source_context: <
+                file: "tests/foreign_import_swagger.sysl"
                 start: <
                   line: 19
+                  col: 29
+                >
+                end: <
+                  line: 19
+                  col: 38
                 >
               >
             >
@@ -151,8 +168,14 @@ apps: <
               primitive: INT
               opt: true
               source_context: <
+                file: "tests/foreign_import_swagger.sysl"
                 start: <
                   line: 19
+                  col: 40
+                >
+                end: <
+                  line: 19
+                  col: 50
                 >
               >
             >
@@ -180,8 +203,14 @@ apps: <
               >
               opt: true
               source_context: <
+                file: "tests/foreign_import_swagger.sysl"
                 start: <
                   line: 16
+                  col: 18
+                >
+                end: <
+                  line: 16
+                  col: 24
                 >
               >
             >

--- a/pkg/parse/tests/inplace_tuple.sysl.golden.textpb
+++ b/pkg/parse/tests/inplace_tuple.sysl.golden.textpb
@@ -19,8 +19,14 @@ apps: <
                 >
               >
               source_context: <
+                file: "tests/inplace_tuple.sysl"
                 start: <
                   line: 19
+                  col: 15
+                >
+                end: <
+                  line: 19
+                  col: 31
                 >
               >
             >
@@ -53,8 +59,14 @@ apps: <
                 >
               >
               source_context: <
+                file: "tests/inplace_tuple.sysl"
                 start: <
                   line: 14
+                  col: 15
+                >
+                end: <
+                  line: 14
+                  col: 31
                 >
               >
             >
@@ -71,8 +83,14 @@ apps: <
                 scale: 2
               >
               source_context: <
+                file: "tests/inplace_tuple.sysl"
                 start: <
                   line: 15
+                  col: 15
+                >
+                end: <
+                  line: 15
+                  col: 27
                 >
               >
             >
@@ -87,8 +105,14 @@ apps: <
                 >
               >
               source_context: <
+                file: "tests/inplace_tuple.sysl"
                 start: <
                   line: 13
+                  col: 15
+                >
+                end: <
+                  line: 13
+                  col: 25
                 >
               >
             >
@@ -121,8 +145,14 @@ apps: <
                 >
               >
               source_context: <
+                file: "tests/inplace_tuple.sysl"
                 start: <
                   line: 9
+                  col: 15
+                >
+                end: <
+                  line: 9
+                  col: 31
                 >
               >
             >
@@ -151,8 +181,14 @@ apps: <
                     >
                   >
                   source_context: <
+                    file: "tests/inplace_tuple.sysl"
                     start: <
                       line: 5
+                      col: 22
+                    >
+                    end: <
+                      line: 5
+                      col: 22
                     >
                   >
                 >
@@ -176,8 +212,14 @@ apps: <
                     >
                   >
                   source_context: <
+                    file: "tests/inplace_tuple.sysl"
                     start: <
                       line: 6
+                      col: 23
+                    >
+                    end: <
+                      line: 6
+                      col: 23
                     >
                   >
                 >
@@ -202,8 +244,14 @@ apps: <
                     >
                   >
                   source_context: <
+                    file: "tests/inplace_tuple.sysl"
                     start: <
                       line: 4
+                      col: 24
+                    >
+                    end: <
+                      line: 4
+                      col: 24
                     >
                   >
                 >
@@ -227,14 +275,26 @@ apps: <
                   >
                 >
                 source_context: <
+                  file: "tests/inplace_tuple.sysl"
                   start: <
                     line: 3
+                    col: 20
+                  >
+                  end: <
+                    line: 3
+                    col: 27
                   >
                 >
               >
               source_context: <
+                file: "tests/inplace_tuple.sysl"
                 start: <
                   line: 3
+                  col: 20
+                >
+                end: <
+                  line: 3
+                  col: 27
                 >
               >
             >
@@ -264,8 +324,13 @@ apps: <
                 >
               >
               source_context: <
+                file: "tests/inplace_tuple.sysl"
                 start: <
                   line: 56
+                  col: 8
+                >
+                end: <
+                  line: 67
                 >
               >
             >
@@ -279,8 +344,14 @@ apps: <
                 >
               >
               source_context: <
+                file: "tests/inplace_tuple.sysl"
                 start: <
                   line: 49
+                  col: 8
+                >
+                end: <
+                  line: 56
+                  col: 8
                 >
               >
             >
@@ -298,8 +369,14 @@ apps: <
               no_type: <
               >
               source_context: <
+                file: "tests/inplace_tuple.sysl"
                 start: <
                   line: 58
+                  col: 12
+                >
+                end: <
+                  line: 58
+                  col: 12
                 >
               >
             >
@@ -309,8 +386,14 @@ apps: <
             value: <
               primitive: BOOL
               source_context: <
+                file: "tests/inplace_tuple.sysl"
                 start: <
                   line: 59
+                  col: 26
+                >
+                end: <
+                  line: 59
+                  col: 26
                 >
               >
             >
@@ -321,8 +404,14 @@ apps: <
               no_type: <
               >
               source_context: <
+                file: "tests/inplace_tuple.sysl"
                 start: <
                   line: 57
+                  col: 12
+                >
+                end: <
+                  line: 57
+                  col: 12
                 >
               >
             >
@@ -338,8 +427,14 @@ apps: <
                     >
                   >
                   source_context: <
+                    file: "tests/inplace_tuple.sysl"
                     start: <
                       line: 60
+                      col: 12
+                    >
+                    end: <
+                      line: 64
+                      col: 12
                     >
                   >
                 >
@@ -357,8 +452,13 @@ apps: <
                     >
                   >
                   source_context: <
+                    file: "tests/inplace_tuple.sysl"
                     start: <
                       line: 64
+                      col: 12
+                    >
+                    end: <
+                      line: 67
                     >
                   >
                 >
@@ -378,8 +478,14 @@ apps: <
               no_type: <
               >
               source_context: <
+                file: "tests/inplace_tuple.sysl"
                 start: <
                   line: 62
+                  col: 16
+                >
+                end: <
+                  line: 62
+                  col: 16
                 >
               >
             >
@@ -390,8 +496,14 @@ apps: <
               no_type: <
               >
               source_context: <
+                file: "tests/inplace_tuple.sysl"
                 start: <
                   line: 61
+                  col: 16
+                >
+                end: <
+                  line: 61
+                  col: 16
                 >
               >
             >
@@ -402,8 +514,14 @@ apps: <
               no_type: <
               >
               source_context: <
+                file: "tests/inplace_tuple.sysl"
                 start: <
                   line: 63
+                  col: 16
+                >
+                end: <
+                  line: 63
+                  col: 16
                 >
               >
             >
@@ -421,8 +539,14 @@ apps: <
               no_type: <
               >
               source_context: <
+                file: "tests/inplace_tuple.sysl"
                 start: <
                   line: 65
+                  col: 16
+                >
+                end: <
+                  line: 65
+                  col: 16
                 >
               >
             >
@@ -433,8 +557,14 @@ apps: <
               no_type: <
               >
               source_context: <
+                file: "tests/inplace_tuple.sysl"
                 start: <
                   line: 66
+                  col: 16
+                >
+                end: <
+                  line: 66
+                  col: 16
                 >
               >
             >
@@ -452,8 +582,14 @@ apps: <
               no_type: <
               >
               source_context: <
+                file: "tests/inplace_tuple.sysl"
                 start: <
                   line: 51
+                  col: 12
+                >
+                end: <
+                  line: 51
+                  col: 12
                 >
               >
             >
@@ -463,8 +599,14 @@ apps: <
             value: <
               primitive: DATE
               source_context: <
+                file: "tests/inplace_tuple.sysl"
                 start: <
                   line: 53
+                  col: 23
+                >
+                end: <
+                  line: 53
+                  col: 23
                 >
               >
             >
@@ -475,8 +617,14 @@ apps: <
               no_type: <
               >
               source_context: <
+                file: "tests/inplace_tuple.sysl"
                 start: <
                   line: 52
+                  col: 12
+                >
+                end: <
+                  line: 52
+                  col: 12
                 >
               >
             >
@@ -487,8 +635,14 @@ apps: <
               no_type: <
               >
               source_context: <
+                file: "tests/inplace_tuple.sysl"
                 start: <
                   line: 54
+                  col: 12
+                >
+                end: <
+                  line: 54
+                  col: 12
                 >
               >
             >
@@ -514,8 +668,14 @@ apps: <
                 >
               >
               source_context: <
+                file: "tests/inplace_tuple.sysl"
                 start: <
                   line: 50
+                  col: 20
+                >
+                end: <
+                  line: 50
+                  col: 38
                 >
               >
             >
@@ -543,8 +703,14 @@ apps: <
                     >
                   >
                   source_context: <
+                    file: "tests/inplace_tuple.sysl"
                     start: <
                       line: 55
+                      col: 36
+                    >
+                    end: <
+                      line: 55
+                      col: 54
                     >
                   >
                 >
@@ -568,8 +734,14 @@ apps: <
                 >
               >
               source_context: <
+                file: "tests/inplace_tuple.sysl"
                 start: <
                   line: 26
+                  col: 15
+                >
+                end: <
+                  line: 26
+                  col: 27
                 >
               >
             >
@@ -584,8 +756,14 @@ apps: <
                 >
               >
               source_context: <
+                file: "tests/inplace_tuple.sysl"
                 start: <
                   line: 27
+                  col: 15
+                >
+                end: <
+                  line: 27
+                  col: 30
                 >
               >
             >
@@ -600,8 +778,14 @@ apps: <
                 >
               >
               source_context: <
+                file: "tests/inplace_tuple.sysl"
                 start: <
                   line: 24
+                  col: 16
+                >
+                end: <
+                  line: 24
+                  col: 27
                 >
               >
             >
@@ -617,8 +801,14 @@ apps: <
                 >
               >
               source_context: <
+                file: "tests/inplace_tuple.sysl"
                 start: <
                   line: 25
+                  col: 15
+                >
+                end: <
+                  line: 25
+                  col: 31
                 >
               >
             >
@@ -639,8 +829,14 @@ apps: <
                 >
               >
               source_context: <
+                file: "tests/inplace_tuple.sysl"
                 start: <
                   line: 29
+                  col: 18
+                >
+                end: <
+                  line: 29
+                  col: 18
                 >
               >
             >
@@ -655,8 +851,14 @@ apps: <
                 >
               >
               source_context: <
+                file: "tests/inplace_tuple.sysl"
                 start: <
                   line: 23
+                  col: 18
+                >
+                end: <
+                  line: 23
+                  col: 31
                 >
               >
             >
@@ -677,8 +879,14 @@ apps: <
                 >
               >
               source_context: <
+                file: "tests/inplace_tuple.sysl"
                 start: <
                   line: 28
+                  col: 20
+                >
+                end: <
+                  line: 28
+                  col: 20
                 >
               >
             >
@@ -695,8 +903,14 @@ apps: <
             value: <
               primitive: XML
               source_context: <
+                file: "tests/inplace_tuple.sysl"
                 start: <
                   line: 36
+                  col: 22
+                >
+                end: <
+                  line: 36
+                  col: 22
                 >
               >
             >
@@ -706,8 +920,14 @@ apps: <
             value: <
               primitive: INT
               source_context: <
+                file: "tests/inplace_tuple.sysl"
                 start: <
                   line: 32
+                  col: 20
+                >
+                end: <
+                  line: 32
+                  col: 20
                 >
               >
             >
@@ -729,8 +949,14 @@ apps: <
                 >
               >
               source_context: <
+                file: "tests/inplace_tuple.sysl"
                 start: <
                   line: 34
+                  col: 20
+                >
+                end: <
+                  line: 34
+                  col: 34
                 >
               >
             >
@@ -744,8 +970,14 @@ apps: <
                 >
               >
               source_context: <
+                file: "tests/inplace_tuple.sysl"
                 start: <
                   line: 35
+                  col: 22
+                >
+                end: <
+                  line: 35
+                  col: 32
                 >
               >
             >
@@ -760,8 +992,14 @@ apps: <
                 >
               >
               source_context: <
+                file: "tests/inplace_tuple.sysl"
                 start: <
                   line: 33
+                  col: 21
+                >
+                end: <
+                  line: 33
+                  col: 28
                 >
               >
             >
@@ -794,8 +1032,14 @@ apps: <
                 >
               >
               source_context: <
+                file: "tests/inplace_tuple.sysl"
                 start: <
                   line: 44
+                  col: 16
+                >
+                end: <
+                  line: 44
+                  col: 45
                 >
               >
             >
@@ -810,8 +1054,14 @@ apps: <
                 >
               >
               source_context: <
+                file: "tests/inplace_tuple.sysl"
                 start: <
                   line: 39
+                  col: 16
+                >
+                end: <
+                  line: 39
+                  col: 26
                 >
               >
             >
@@ -827,14 +1077,26 @@ apps: <
                   >
                 >
                 source_context: <
+                  file: "tests/inplace_tuple.sysl"
                   start: <
                     line: 40
+                    col: 17
+                  >
+                  end: <
+                    line: 40
+                    col: 34
                   >
                 >
               >
               source_context: <
+                file: "tests/inplace_tuple.sysl"
                 start: <
                   line: 40
+                  col: 17
+                >
+                end: <
+                  line: 40
+                  col: 34
                 >
               >
             >
@@ -857,8 +1119,14 @@ apps: <
                 >
               >
               source_context: <
+                file: "tests/inplace_tuple.sysl"
                 start: <
                   line: 42
+                  col: 18
+                >
+                end: <
+                  line: 42
+                  col: 32
                 >
               >
             >
@@ -885,8 +1153,14 @@ apps: <
                 >
               >
               source_context: <
+                file: "tests/inplace_tuple.sysl"
                 start: <
                   line: 43
+                  col: 18
+                >
+                end: <
+                  line: 43
+                  col: 59
                 >
               >
             >
@@ -909,14 +1183,26 @@ apps: <
                   >
                 >
                 source_context: <
+                  file: "tests/inplace_tuple.sysl"
                   start: <
                     line: 45
+                    col: 16
+                  >
+                  end: <
+                    line: 45
+                    col: 32
                   >
                 >
               >
               source_context: <
+                file: "tests/inplace_tuple.sysl"
                 start: <
                   line: 45
+                  col: 16
+                >
+                end: <
+                  line: 45
+                  col: 32
                 >
               >
             >
@@ -938,14 +1224,26 @@ apps: <
                   >
                 >
                 source_context: <
+                  file: "tests/inplace_tuple.sysl"
                   start: <
                     line: 46
+                    col: 23
+                  >
+                  end: <
+                    line: 46
+                    col: 30
                   >
                 >
               >
               source_context: <
+                file: "tests/inplace_tuple.sysl"
                 start: <
                   line: 46
+                  col: 23
+                >
+                end: <
+                  line: 46
+                  col: 30
                 >
               >
             >
@@ -967,8 +1265,14 @@ apps: <
                 >
               >
               source_context: <
+                file: "tests/inplace_tuple.sysl"
                 start: <
                   line: 41
+                  col: 18
+                >
+                end: <
+                  line: 41
+                  col: 27
                 >
               >
             >

--- a/pkg/parse/tests/inplace_tuple.sysl.golden.textpb
+++ b/pkg/parse/tests/inplace_tuple.sysl.golden.textpb
@@ -507,7 +507,7 @@ apps: <
                 >
                 ref: <
                   appname: <
-                    part: "My "
+                    part: "My"
                   >
                   path: "Tuple Model"
                   path: "TopLevelPayload"
@@ -536,7 +536,7 @@ apps: <
                     >
                     ref: <
                       appname: <
-                        part: "My "
+                        part: "My"
                       >
                       path: "Tuple Model"
                       path: "Response"
@@ -786,7 +786,7 @@ apps: <
                 >
                 ref: <
                   appname: <
-                    part: "My "
+                    part: "My"
                   >
                   path: "Client Model"
                   path: "Request"
@@ -876,8 +876,8 @@ apps: <
                 >
                 ref: <
                   appname: <
-                    part: "My "
-                    part: "    Browser "
+                    part: "My"
+                    part: "Browser"
                   >
                   path: "Client Model"
                   path: "Request"

--- a/pkg/parse/tests/library.sysl.golden.textpb
+++ b/pkg/parse/tests/library.sysl.golden.textpb
@@ -1,343 +1,421 @@
-apps {
+apps: <
   key: "School"
-  value {
-    name {
+  value: <
+    name: <
       part: "School"
-    }
-    types {
+    >
+    types: <
       key: "Class"
-      value {
-        relation {
-          attr_defs {
+      value: <
+        relation: <
+          attr_defs: <
             key: "Id"
-            value {
+            value: <
               primitive: INT
-              attrs {
+              attrs: <
                 key: "patterns"
-                value {
-                  a {
-                    elt {
+                value: <
+                  a: <
+                    elt: <
                       s: "pk"
-                    }
-                    elt {
+                    >
+                    elt: <
                       s: "autoinc"
-                    }
-                  }
-                }
-              }
-              source_context {
-                start {
+                    >
+                  >
+                >
+              >
+              source_context: <
+                file: "tests/school.sysl"
+                start: <
                   line: 3
-                }
-              }
-            }
-          }
-          primary_key {
+                  col: 14
+                >
+                end: <
+                  line: 3
+                  col: 32
+                >
+              >
+            >
+          >
+          primary_key: <
             attr_name: "Id"
-          }
-        }
-      }
-    }
-    types {
+          >
+        >
+      >
+    >
+    types: <
       key: "Student"
-      value {
-        relation {
-          attr_defs {
+      value: <
+        relation: <
+          attr_defs: <
             key: "ClassId"
-            value {
-              attrs {
-                key: "description"
-                value {
-                  s: "describe the table"
-                }
-              }
-              type_ref {
-                context {
-                  appname {
+            value: <
+              type_ref: <
+                context: <
+                  appname: <
                     part: "School"
-                  }
+                  >
                   path: "Student"
-                }
-                ref {
+                >
+                ref: <
                   path: "Class"
                   path: "Idd"
-                }
-              }
-              source_context {
-                start {
-                  line: 7
-                }
-              }
-            }
-          }
-          attr_defs {
-            key: "Id"
-            value {
-              primitive: INT
-              attrs {
+                >
+              >
+              attrs: <
                 key: "description"
-                value {
+                value: <
                   s: "describe the table"
-                }
-              }
-              attrs {
-                key: "patterns"
-                value {
-                  a {
-                    elt {
-                      s: "pk"
-                    }
-                  }
-                }
-              }
-              source_context {
-                start {
-                  line: 6
-                }
-              }
-            }
-          }
-          primary_key {
-            attr_name: "Id"
-          }
-        }
-        attrs {
-          key: "description"
-          value {
-            s: "describe the table"
-          }
-        }
-      }
-    }
-  }
-}
-apps {
-  key: "SchoolLibrary"
-  value {
-    name {
-      part: "SchoolLibrary"
-    }
-    types {
-      key: "Book"
-      value {
-        relation {
-          attr_defs {
-            key: "Author"
-            value {
-              primitive: STRING
-              source_context {
-                start {
-                  line: 13
-                }
-              }
-            }
-          }
-          attr_defs {
-            key: "BookId"
-            value {
+                >
+              >
+              source_context: <
+                file: "tests/school.sysl"
+                start: <
+                  line: 7
+                  col: 19
+                >
+                end: <
+                  line: 7
+                  col: 25
+                >
+              >
+            >
+          >
+          attr_defs: <
+            key: "Id"
+            value: <
               primitive: INT
-              attrs {
+              attrs: <
+                key: "description"
+                value: <
+                  s: "describe the table"
+                >
+              >
+              attrs: <
                 key: "patterns"
-                value {
-                  a {
-                    elt {
+                value: <
+                  a: <
+                    elt: <
                       s: "pk"
-                    }
-                    elt {
-                      s: "autoinc"
-                    }
-                  }
-                }
-              }
-              source_context {
-                start {
-                  line: 11
-                }
-              }
-            }
-          }
-          attr_defs {
-            key: "name"
-            value {
+                    >
+                  >
+                >
+              >
+              source_context: <
+                file: "tests/school.sysl"
+                start: <
+                  line: 6
+                  col: 14
+                >
+                end: <
+                  line: 6
+                  col: 22
+                >
+              >
+            >
+          >
+          primary_key: <
+            attr_name: "Id"
+          >
+        >
+        attrs: <
+          key: "description"
+          value: <
+            s: "describe the table"
+          >
+        >
+      >
+    >
+  >
+>
+apps: <
+  key: "SchoolLibrary"
+  value: <
+    name: <
+      part: "SchoolLibrary"
+    >
+    types: <
+      key: "Book"
+      value: <
+        relation: <
+          attr_defs: <
+            key: "Author"
+            value: <
               primitive: STRING
-              source_context {
-                start {
-                  line: 12
-                }
-              }
-            }
-          }
-          primary_key {
-            attr_name: "BookId"
-          }
-        }
-      }
-    }
-    types {
-      key: "Borrow"
-      value {
-        relation {
-          attr_defs {
+              source_context: <
+                file: "tests/library.sysl"
+                start: <
+                  line: 13
+                  col: 18
+                >
+                end: <
+                  line: 13
+                  col: 18
+                >
+              >
+            >
+          >
+          attr_defs: <
             key: "BookId"
-            value {
-              attrs {
+            value: <
+              primitive: INT
+              attrs: <
                 key: "patterns"
-                value {
-                  a {
-                    elt {
+                value: <
+                  a: <
+                    elt: <
                       s: "pk"
-                    }
-                  }
-                }
-              }
-              type_ref {
-                context {
-                  appname {
+                    >
+                    elt: <
+                      s: "autoinc"
+                    >
+                  >
+                >
+              >
+              source_context: <
+                file: "tests/library.sysl"
+                start: <
+                  line: 11
+                  col: 18
+                >
+                end: <
+                  line: 11
+                  col: 36
+                >
+              >
+            >
+          >
+          attr_defs: <
+            key: "name"
+            value: <
+              primitive: STRING
+              source_context: <
+                file: "tests/library.sysl"
+                start: <
+                  line: 12
+                  col: 16
+                >
+                end: <
+                  line: 12
+                  col: 16
+                >
+              >
+            >
+          >
+          primary_key: <
+            attr_name: "BookId"
+          >
+        >
+      >
+    >
+    types: <
+      key: "Borrow"
+      value: <
+        relation: <
+          attr_defs: <
+            key: "BookId"
+            value: <
+              type_ref: <
+                context: <
+                  appname: <
                     part: "SchoolLibrary"
-                  }
+                  >
                   path: "Borrow"
-                }
-                ref {
+                >
+                ref: <
                   path: "Book"
                   path: "BookId"
-                }
-              }
-              source_context {
-                start {
-                  line: 16
-                }
-              }
-            }
-          }
-          attr_defs {
-            key: "DueDate"
-            value {
-              primitive: DATE
-              source_context {
-                start {
-                  line: 17
-                }
-              }
-            }
-          }
-          attr_defs {
-            key: "MemberId"
-            value {
-              attrs {
+                >
+              >
+              attrs: <
                 key: "patterns"
-                value {
-                  a {
-                    elt {
+                value: <
+                  a: <
+                    elt: <
                       s: "pk"
-                    }
-                  }
-                }
-              }
-              type_ref {
-                context {
-                  appname {
+                    >
+                  >
+                >
+              >
+              source_context: <
+                file: "tests/library.sysl"
+                start: <
+                  line: 16
+                  col: 18
+                >
+                end: <
+                  line: 16
+                  col: 34
+                >
+              >
+            >
+          >
+          attr_defs: <
+            key: "DueDate"
+            value: <
+              primitive: DATE
+              source_context: <
+                file: "tests/library.sysl"
+                start: <
+                  line: 17
+                  col: 19
+                >
+                end: <
+                  line: 17
+                  col: 19
+                >
+              >
+            >
+          >
+          attr_defs: <
+            key: "MemberId"
+            value: <
+              type_ref: <
+                context: <
+                  appname: <
                     part: "SchoolLibrary"
-                  }
+                  >
                   path: "Borrow"
-                }
-                ref {
+                >
+                ref: <
                   path: "Member"
                   path: "MemberId"
-                }
-              }
-              source_context {
-                start {
+                >
+              >
+              attrs: <
+                key: "patterns"
+                value: <
+                  a: <
+                    elt: <
+                      s: "pk"
+                    >
+                  >
+                >
+              >
+              source_context: <
+                file: "tests/library.sysl"
+                start: <
                   line: 15
-                }
-              }
-            }
-          }
-          primary_key {
+                  col: 20
+                >
+                end: <
+                  line: 15
+                  col: 40
+                >
+              >
+            >
+          >
+          primary_key: <
             attr_name: "MemberId"
             attr_name: "BookId"
-          }
-        }
-      }
-    }
-    types {
+          >
+        >
+      >
+    >
+    types: <
       key: "Member"
-      value {
-        relation {
-          attr_defs {
+      value: <
+        relation: <
+          attr_defs: <
             key: "MemberId"
-            value {
-              attrs {
-                key: "description"
-                value {
-                  s: "\n"
-                }
-              }
-              type_ref {
-                context {
-                  appname {
+            value: <
+              type_ref: <
+                context: <
+                  appname: <
                     part: "SchoolLibrary"
-                  }
+                  >
                   path: "Member"
-                }
-                ref {
+                >
+                ref: <
                   path: "Student"
                   path: "Id"
-                }
-              }
-              source_context {
-                start {
+                >
+              >
+              attrs: <
+                key: "description"
+                value: <
+                  s: "\n"
+                >
+              >
+              source_context: <
+                file: "tests/library.sysl"
+                start: <
                   line: 6
-                }
-              }
-            }
-          }
-          attr_defs {
+                  col: 20
+                >
+                end: <
+                  line: 7
+                  col: 8
+                >
+              >
+            >
+          >
+          attr_defs: <
             key: "amount"
-            value {
+            value: <
               primitive: DECIMAL
-              constraint {
-                length {
+              constraint: <
+                length: <
                   max: 14
-                }
+                >
                 precision: 14
                 scale: 2
-              }
-              source_context {
-                start {
+              >
+              source_context: <
+                file: "tests/library.sysl"
+                start: <
                   line: 9
-                }
-              }
-            }
-          }
-          attr_defs {
+                  col: 18
+                >
+                end: <
+                  line: 9
+                  col: 30
+                >
+              >
+            >
+          >
+          attr_defs: <
             key: "city"
-            value {
+            value: <
               primitive: STRING
-              constraint {
-                length {
+              constraint: <
+                length: <
                   max: 100
-                }
-              }
-              source_context {
-                start {
+                >
+              >
+              source_context: <
+                file: "tests/library.sysl"
+                start: <
                   line: 8
-                }
-              }
-            }
-          }
-          attr_defs {
+                  col: 16
+                >
+                end: <
+                  line: 8
+                  col: 26
+                >
+              >
+            >
+          >
+          attr_defs: <
             key: "name"
-            value {
+            value: <
               primitive: STRING
-              source_context {
-                start {
+              source_context: <
+                file: "tests/library.sysl"
+                start: <
                   line: 7
-                }
-              }
-            }
-          }
-        }
-      }
-    }
-  }
-}
+                  col: 16
+                >
+                end: <
+                  line: 7
+                  col: 16
+                >
+              >
+            >
+          >
+        >
+      >
+    >
+  >
+>

--- a/pkg/parse/tests/mixin.sysl.golden.textpb
+++ b/pkg/parse/tests/mixin.sysl.golden.textpb
@@ -1,254 +1,272 @@
-apps {
+apps: <
   key: "API"
-  value {
-    name {
+  value: <
+    name: <
       part: "API"
-    }
-    endpoints {
+    >
+    endpoints: <
       key: "Service Call"
-      value {
+      value: <
         name: "Service Call"
-      }
-    }
-    types {
+      >
+    >
+    types: <
       key: "UberUser"
-      value {
-        tuple {
-          attr_defs {
+      value: <
+        tuple: <
+          attr_defs: <
             key: "user"
-            value {
-              type_ref {
-                context {
-                  appname {
+            value: <
+              type_ref: <
+                context: <
+                  appname: <
                     part: "API"
-                  }
+                  >
                   path: "UberUser"
-                }
-                ref {
+                >
+                ref: <
                   path: "User"
-                }
-              }
-              source_context {
-                start {
+                >
+              >
+              source_context: <
+                file: "tests/mixin.sysl"
+                start: <
                   line: 19
-                }
-              }
-            }
-          }
-        }
-      }
-    }
-    types {
+                  col: 16
+                >
+                end: <
+                  line: 19
+                  col: 16
+                >
+              >
+            >
+          >
+        >
+      >
+    >
+    types: <
       key: "User"
-      value {
-        relation {
-          attr_defs {
+      value: <
+        relation: <
+          attr_defs: <
             key: "id"
-            value {
+            value: <
               primitive: INT
-              attrs {
+              attrs: <
                 key: "description"
-                value {
+                value: <
                   s: "some description"
-                }
-              }
-              source_context {
-                start {
+                >
+              >
+              source_context: <
+                file: "tests/mixin.sysl"
+                start: <
                   line: 4
-                }
-              }
-            }
-          }
-        }
-        attrs {
+                  col: 14
+                >
+                end: <
+                  line: 4
+                  col: 14
+                >
+              >
+            >
+          >
+        >
+        attrs: <
           key: "description"
-          value {
+          value: <
             s: "some description"
-          }
-        }
-        attrs {
+          >
+        >
+        attrs: <
           key: "patterns"
-          value {
-            a {
-              elt {
+          value: <
+            a: <
+              elt: <
                 s: "foo"
-              }
-            }
-          }
-        }
-      }
-    }
-    mixin2 {
-      name {
+              >
+            >
+          >
+        >
+      >
+    >
+    views: <
+      key: "FooTransform"
+      value: <
+        param: <
+          name: "number"
+          type: <
+            primitive: INT
+          >
+        >
+        ret_type: <
+          primitive: INT
+        >
+        expr: <
+          transform: <
+            arg: <
+              name: "number"
+            >
+            scopevar: "."
+            stmt: <
+              assign: <
+                name: "out"
+                expr: <
+                  binexpr: <
+                    op: ADD
+                    lhs: <
+                      name: "number"
+                    >
+                    rhs: <
+                      literal: <
+                        i: 1
+                      >
+                    >
+                  >
+                >
+              >
+            >
+          >
+        >
+      >
+    >
+    mixin2: <
+      name: <
         part: "Relational Model"
-      }
-    }
-    mixin2 {
-      name {
+      >
+    >
+    mixin2: <
+      name: <
         part: "TransformApp"
-      }
-    }
-    views {
-      key: "FooTransform"
-      value {
-        param {
-          name: "number"
-          type {
-            primitive: INT
-          }
-        }
-        ret_type {
-          primitive: INT
-        }
-        expr {
-          transform {
-            arg {
-              name: "number"
-            }
-            scopevar: "."
-            stmt {
-              assign {
-                name: "out"
-                expr {
-                  binexpr {
-                    op: ADD
-                    lhs {
-                      name: "number"
-                    }
-                    rhs {
-                      literal {
-                        i: 1
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
-    }
-  }
-}
-apps {
+      >
+    >
+  >
+>
+apps: <
   key: "Relational Model"
-  value {
-    name {
+  value: <
+    name: <
       part: "Relational Model"
-    }
-    attrs {
+    >
+    attrs: <
       key: "patterns"
-      value {
-        a {
-          elt {
+      value: <
+        a: <
+          elt: <
             s: "abstract"
-          }
-        }
-      }
-    }
-    types {
+          >
+        >
+      >
+    >
+    types: <
       key: "User"
-      value {
-        relation {
-          attr_defs {
+      value: <
+        relation: <
+          attr_defs: <
             key: "id"
-            value {
+            value: <
               primitive: INT
-              attrs {
+              attrs: <
                 key: "description"
-                value {
+                value: <
                   s: "some description"
-                }
-              }
-              source_context {
-                start {
+                >
+              >
+              source_context: <
+                file: "tests/mixin.sysl"
+                start: <
                   line: 4
-                }
-              }
-            }
-          }
-        }
-        attrs {
+                  col: 14
+                >
+                end: <
+                  line: 4
+                  col: 14
+                >
+              >
+            >
+          >
+        >
+        attrs: <
           key: "description"
-          value {
+          value: <
             s: "some description"
-          }
-        }
-        attrs {
+          >
+        >
+        attrs: <
           key: "patterns"
-          value {
-            a {
-              elt {
+          value: <
+            a: <
+              elt: <
                 s: "foo"
-              }
-            }
-          }
-        }
-      }
-    }
-  }
-}
-apps {
+              >
+            >
+          >
+        >
+      >
+    >
+  >
+>
+apps: <
   key: "TransformApp"
-  value {
-    name {
+  value: <
+    name: <
       part: "TransformApp"
-    }
-    attrs {
+    >
+    attrs: <
       key: "package"
-      value {
+      value: <
         s: "com.foo.example"
-      }
-    }
-    attrs {
+      >
+    >
+    attrs: <
       key: "patterns"
-      value {
-        a {
-          elt {
+      value: <
+        a: <
+          elt: <
             s: "abstract"
-          }
-        }
-      }
-    }
-    views {
+          >
+        >
+      >
+    >
+    views: <
       key: "FooTransform"
-      value {
-        param {
+      value: <
+        param: <
           name: "number"
-          type {
+          type: <
             primitive: INT
-          }
-        }
-        ret_type {
+          >
+        >
+        ret_type: <
           primitive: INT
-        }
-        expr {
-          transform {
-            arg {
+        >
+        expr: <
+          transform: <
+            arg: <
               name: "number"
-            }
+            >
             scopevar: "."
-            stmt {
-              assign {
+            stmt: <
+              assign: <
                 name: "out"
-                expr {
-                  binexpr {
+                expr: <
+                  binexpr: <
                     op: ADD
-                    lhs {
+                    lhs: <
                       name: "number"
-                    }
-                    rhs {
-                      literal {
+                    >
+                    rhs: <
+                      literal: <
                         i: 1
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
-    }
-  }
-}
+                      >
+                    >
+                  >
+                >
+              >
+            >
+          >
+        >
+      >
+    >
+  >
+>

--- a/pkg/parse/tests/petshop.sysl.golden.textpb
+++ b/pkg/parse/tests/petshop.sysl.golden.textpb
@@ -45,8 +45,14 @@ apps: <
               primitive: DECIMAL
               opt: true
               source_context: <
+                file: "tests/petshop.sysl"
                 start: <
                   line: 56
+                  col: 23
+                >
+                end: <
+                  line: 56
+                  col: 30
                 >
               >
             >
@@ -66,8 +72,14 @@ apps: <
                 >
               >
               source_context: <
+                file: "tests/petshop.sysl"
                 start: <
                   line: 57
+                  col: 17
+                >
+                end: <
+                  line: 57
+                  col: 36
                 >
               >
             >
@@ -78,8 +90,14 @@ apps: <
               primitive: STRING
               opt: true
               source_context: <
+                file: "tests/petshop.sysl"
                 start: <
                   line: 53
+                  col: 16
+                >
+                end: <
+                  line: 53
+                  col: 22
                 >
               >
             >
@@ -100,14 +118,26 @@ apps: <
                   >
                 >
                 source_context: <
+                  file: "tests/petshop.sysl"
                   start: <
                     line: 55
+                    col: 16
+                  >
+                  end: <
+                    line: 55
+                    col: 23
                   >
                 >
               >
               source_context: <
+                file: "tests/petshop.sysl"
                 start: <
                   line: 55
+                  col: 16
+                >
+                end: <
+                  line: 55
+                  col: 23
                 >
               >
             >
@@ -118,8 +148,14 @@ apps: <
               primitive: STRING
               opt: true
               source_context: <
+                file: "tests/petshop.sysl"
                 start: <
                   line: 54
+                  col: 19
+                >
+                end: <
+                  line: 54
+                  col: 25
                 >
               >
             >
@@ -137,8 +173,14 @@ apps: <
               primitive: DATE
               opt: true
               source_context: <
+                file: "tests/petshop.sysl"
                 start: <
                   line: 49
+                  col: 15
+                >
+                end: <
+                  line: 49
+                  col: 19
                 >
               >
             >
@@ -158,8 +200,14 @@ apps: <
                 >
               >
               source_context: <
+                file: "tests/petshop.sysl"
                 start: <
                   line: 50
+                  col: 17
+                >
+                end: <
+                  line: 50
+                  col: 36
                 >
               >
             >
@@ -170,8 +218,14 @@ apps: <
               primitive: STRING
               opt: true
               source_context: <
+                file: "tests/petshop.sysl"
                 start: <
                   line: 48
+                  col: 16
+                >
+                end: <
+                  line: 48
+                  col: 22
                 >
               >
             >
@@ -189,8 +243,14 @@ apps: <
               primitive: DATE
               opt: true
               source_context: <
+                file: "tests/petshop.sysl"
                 start: <
                   line: 61
+                  col: 15
+                >
+                end: <
+                  line: 61
+                  col: 19
                 >
               >
             >
@@ -200,8 +260,14 @@ apps: <
             value: <
               primitive: INT
               source_context: <
+                file: "tests/petshop.sysl"
                 start: <
                   line: 63
+                  col: 19
+                >
+                end: <
+                  line: 63
+                  col: 19
                 >
               >
             >
@@ -212,8 +278,14 @@ apps: <
               primitive: STRING
               opt: true
               source_context: <
+                file: "tests/petshop.sysl"
                 start: <
                   line: 60
+                  col: 16
+                >
+                end: <
+                  line: 60
+                  col: 22
                 >
               >
             >
@@ -224,8 +296,14 @@ apps: <
               primitive: INT
               opt: true
               source_context: <
+                file: "tests/petshop.sysl"
                 start: <
                   line: 62
+                  col: 19
+                >
+                end: <
+                  line: 62
+                  col: 22
                 >
               >
             >
@@ -253,14 +331,26 @@ apps: <
                   >
                 >
                 source_context: <
+                  file: "tests/petshop.sysl"
                   start: <
                     line: 44
+                    col: 18
+                  >
+                  end: <
+                    line: 44
+                    col: 25
                   >
                 >
               >
               source_context: <
+                file: "tests/petshop.sysl"
                 start: <
                   line: 44
+                  col: 18
+                >
+                end: <
+                  line: 44
+                  col: 25
                 >
               >
             >
@@ -281,14 +371,26 @@ apps: <
                   >
                 >
                 source_context: <
+                  file: "tests/petshop.sysl"
                   start: <
                     line: 43
+                    col: 21
+                  >
+                  end: <
+                    line: 43
+                    col: 28
                   >
                 >
               >
               source_context: <
+                file: "tests/petshop.sysl"
                 start: <
                   line: 43
+                  col: 21
+                >
+                end: <
+                  line: 43
+                  col: 28
                 >
               >
             >
@@ -299,8 +401,14 @@ apps: <
               primitive: INT
               opt: true
               source_context: <
+                file: "tests/petshop.sysl"
                 start: <
                   line: 45
+                  col: 19
+                >
+                end: <
+                  line: 45
+                  col: 22
                 >
               >
             >
@@ -1063,8 +1171,14 @@ apps: <
               >
               opt: true
               source_context: <
+                file: "tests/petshop.sysl"
                 start: <
                   line: 13
+                  col: 23
+                >
+                end: <
+                  line: 13
+                  col: 36
                 >
               >
             >
@@ -1080,8 +1194,14 @@ apps: <
               >
               opt: true
               source_context: <
+                file: "tests/petshop.sysl"
                 start: <
                   line: 14
+                  col: 21
+                >
+                end: <
+                  line: 14
+                  col: 32
                 >
               >
             >
@@ -1104,8 +1224,14 @@ apps: <
                 >
               >
               source_context: <
+                file: "tests/petshop.sysl"
                 start: <
                   line: 9
+                  col: 19
+                >
+                end: <
+                  line: 9
+                  col: 37
                 >
               >
             >
@@ -1116,8 +1242,14 @@ apps: <
               primitive: STRING
               opt: true
               source_context: <
+                file: "tests/petshop.sysl"
                 start: <
                   line: 10
+                  col: 21
+                >
+                end: <
+                  line: 10
+                  col: 27
                 >
               >
             >
@@ -1128,8 +1260,14 @@ apps: <
               primitive: INT
               opt: true
               source_context: <
+                file: "tests/petshop.sysl"
                 start: <
                   line: 15
+                  col: 19
+                >
+                end: <
+                  line: 15
+                  col: 22
                 >
               >
             >
@@ -1140,8 +1278,14 @@ apps: <
               primitive: INT
               opt: true
               source_context: <
+                file: "tests/petshop.sysl"
                 start: <
                   line: 12
+                  col: 19
+                >
+                end: <
+                  line: 12
+                  col: 22
                 >
               >
             >
@@ -1152,8 +1296,14 @@ apps: <
               primitive: STRING
               opt: true
               source_context: <
+                file: "tests/petshop.sysl"
                 start: <
                   line: 11
+                  col: 19
+                >
+                end: <
+                  line: 11
+                  col: 25
                 >
               >
             >
@@ -1174,8 +1324,14 @@ apps: <
               primitive: DATE
               opt: true
               source_context: <
+                file: "tests/petshop.sysl"
                 start: <
                   line: 5
+                  col: 15
+                >
+                end: <
+                  line: 5
+                  col: 19
                 >
               >
             >
@@ -1198,8 +1354,14 @@ apps: <
                 >
               >
               source_context: <
+                file: "tests/petshop.sysl"
                 start: <
                   line: 3
+                  col: 22
+                >
+                end: <
+                  line: 3
+                  col: 40
                 >
               >
             >
@@ -1209,8 +1371,14 @@ apps: <
             value: <
               primitive: INT
               source_context: <
+                file: "tests/petshop.sysl"
                 start: <
                   line: 6
+                  col: 17
+                >
+                end: <
+                  line: 6
+                  col: 17
                 >
               >
             >
@@ -1221,8 +1389,14 @@ apps: <
               primitive: STRING
               opt: true
               source_context: <
+                file: "tests/petshop.sysl"
                 start: <
                   line: 4
+                  col: 16
+                >
+                end: <
+                  line: 4
+                  col: 22
                 >
               >
             >
@@ -1263,8 +1437,14 @@ apps: <
                 >
               >
               source_context: <
+                file: "tests/petshop.sysl"
                 start: <
                   line: 25
+                  col: 22
+                >
+                end: <
+                  line: 25
+                  col: 46
                 >
               >
             >
@@ -1295,8 +1475,14 @@ apps: <
                 >
               >
               source_context: <
+                file: "tests/petshop.sysl"
                 start: <
                   line: 26
+                  col: 17
+                >
+                end: <
+                  line: 26
+                  col: 31
                 >
               >
             >
@@ -1328,8 +1514,14 @@ apps: <
                 >
               >
               source_context: <
+                file: "tests/petshop.sysl"
                 start: <
                   line: 19
+                  col: 19
+                >
+                end: <
+                  line: 19
+                  col: 25
                 >
               >
             >
@@ -1340,8 +1532,14 @@ apps: <
               primitive: DATE
               opt: true
               source_context: <
+                file: "tests/petshop.sysl"
                 start: <
                   line: 21
+                  col: 15
+                >
+                end: <
+                  line: 21
+                  col: 19
                 >
               >
             >
@@ -1352,8 +1550,14 @@ apps: <
               primitive: STRING
               opt: true
               source_context: <
+                file: "tests/petshop.sysl"
                 start: <
                   line: 20
+                  col: 16
+                >
+                end: <
+                  line: 20
+                  col: 22
                 >
               >
             >
@@ -1364,8 +1568,14 @@ apps: <
               primitive: INT
               opt: true
               source_context: <
+                file: "tests/petshop.sysl"
                 start: <
                   line: 22
+                  col: 19
+                >
+                end: <
+                  line: 22
+                  col: 22
                 >
               >
             >
@@ -1388,8 +1598,14 @@ apps: <
                 >
               >
               source_context: <
+                file: "tests/petshop.sysl"
                 start: <
                   line: 18
+                  col: 17
+                >
+                end: <
+                  line: 18
+                  col: 35
                 >
               >
             >
@@ -1423,8 +1639,14 @@ apps: <
             value: <
               primitive: INT
               source_context: <
+                file: "tests/petshop.sysl"
                 start: <
                   line: 117
+                  col: 19
+                >
+                end: <
+                  line: 117
+                  col: 19
                 >
               >
             >
@@ -1435,8 +1657,14 @@ apps: <
               primitive: DATE
               opt: true
               source_context: <
+                file: "tests/petshop.sysl"
                 start: <
                   line: 119
+                  col: 15
+                >
+                end: <
+                  line: 119
+                  col: 19
                 >
               >
             >
@@ -1447,8 +1675,14 @@ apps: <
               primitive: INT
               opt: true
               source_context: <
+                file: "tests/petshop.sysl"
                 start: <
                   line: 121
+                  col: 19
+                >
+                end: <
+                  line: 121
+                  col: 22
                 >
               >
             >
@@ -1459,8 +1693,14 @@ apps: <
               primitive: STRING
               opt: true
               source_context: <
+                file: "tests/petshop.sysl"
                 start: <
                   line: 118
+                  col: 16
+                >
+                end: <
+                  line: 118
+                  col: 22
                 >
               >
             >
@@ -1471,8 +1711,14 @@ apps: <
               primitive: INT
               opt: true
               source_context: <
+                file: "tests/petshop.sysl"
                 start: <
                   line: 120
+                  col: 19
+                >
+                end: <
+                  line: 120
+                  col: 22
                 >
               >
             >
@@ -1482,8 +1728,14 @@ apps: <
             value: <
               primitive: INT
               source_context: <
+                file: "tests/petshop.sysl"
                 start: <
                   line: 116
+                  col: 17
+                >
+                end: <
+                  line: 116
+                  col: 17
                 >
               >
             >

--- a/pkg/parse/tests/project.sysl.golden.textpb
+++ b/pkg/parse/tests/project.sysl.golden.textpb
@@ -1,761 +1,785 @@
-apps {
+apps: <
   key: "A_B"
-  value {
-    name {
+  value: <
+    name: <
       part: "A_B"
-    }
-    endpoints {
+    >
+    endpoints: <
       key: "C_D"
-      value {
+      value: <
         name: "C_D"
-        stmt {
-          call {
-            target {
+        stmt: <
+          call: <
+            target: <
               part: "anz_com"
-            }
+            >
             endpoint: "homepage"
-          }
-        }
-        stmt {
-          call {
-            target {
+          >
+        >
+        stmt: <
+          call: <
+            target: <
               part: "Test - App"
-            }
+            >
             endpoint: "Test - Endpoint"
-          }
-        }
-      }
-    }
-    endpoints {
+          >
+        >
+      >
+    >
+    endpoints: <
       key: "DDD"
-      value {
+      value: <
         name: "DDD"
-        stmt {
-          cond {
+        stmt: <
+          cond: <
             test: "some condition is true"
-            stmt {
-              action {
+            stmt: <
+              action: <
                 action: "Test - App -> eventName"
-              }
-            }
-            stmt {
-              call {
-                target {
+              >
+            >
+            stmt: <
+              call: <
+                target: <
                   part: "Test - App"
-                }
+                >
                 endpoint: "Endpoint2"
-              }
-            }
-            stmt {
-              cond {
+              >
+            >
+            stmt: <
+              cond: <
                 test: "result not ok"
-                stmt {
-                  ret {
+                stmt: <
+                  ret: <
                     payload: "not ok1"
-                  }
-                }
-              }
-            }
-            stmt {
-              group {
+                  >
+                >
+              >
+            >
+            stmt: <
+              group: <
                 title: "else"
-                stmt {
-                  ret {
+                stmt: <
+                  ret: <
                     payload: "ok"
-                  }
-                }
-              }
-            }
-          }
-        }
-        stmt {
-          group {
+                  >
+                >
+              >
+            >
+          >
+        >
+        stmt: <
+          group: <
             title: "else some other condition"
-            stmt {
-              action {
+            stmt: <
+              action: <
                 action: "top level else_statment"
-              }
-            }
-            stmt {
-              cond {
+              >
+            >
+            stmt: <
+              cond: <
                 test: "\"some constraint\""
-                stmt {
-                  ret {
+                stmt: <
+                  ret: <
                     payload: "ok"
-                  }
-                }
-              }
-            }
-            stmt {
-              group {
+                  >
+                >
+              >
+            >
+            stmt: <
+              group: <
                 title: "Else"
-                stmt {
-                  ret {
+                stmt: <
+                  ret: <
                     payload: "not ok"
-                  }
-                }
-              }
-            }
-          }
-        }
-        stmt {
-          action {
+                  >
+                >
+              >
+            >
+          >
+        >
+        stmt: <
+          action: <
             action: "do some more stuff"
-          }
-        }
-      }
-    }
-    endpoints {
+          >
+        >
+      >
+    >
+    endpoints: <
       key: "EEE"
-      value {
+      value: <
         name: "EEE"
-        stmt {
-          action {
+        stmt: <
+          action: <
             action: "..."
-          }
-        }
-      }
-    }
-    endpoints {
+          >
+        >
+      >
+    >
+    endpoints: <
       key: "Send document to customer"
-      value {
+      value: <
         name: "Send document to customer"
-      }
-    }
-  }
-}
-apps {
+      >
+    >
+  >
+>
+apps: <
   key: "External :: App"
-  value {
-    name {
+  value: <
+    name: <
       part: "External"
       part: "App"
-    }
-    endpoints {
+    >
+    endpoints: <
       key: "Endpoint"
-      value {
+      value: <
         name: "Endpoint"
-        stmt {
-          action {
+        stmt: <
+          action: <
             action: "..."
-          }
-        }
-      }
-    }
-    types {
+          >
+        >
+      >
+    >
+    types: <
       key: "Request"
-      value {
-        tuple {
-          attr_defs {
+      value: <
+        tuple: <
+          attr_defs: <
             key: "id"
-            value {
+            value: <
               primitive: INT
-              source_context {
-                start {
+              source_context: <
+                file: "tests/test1.sysl"
+                start: <
                   line: 52
-                }
-              }
-            }
-          }
-          attr_defs {
+                  col: 14
+                >
+                end: <
+                  line: 52
+                  col: 14
+                >
+              >
+            >
+          >
+          attr_defs: <
             key: "val"
-            value {
+            value: <
               primitive: STRING
-              source_context {
-                start {
+              source_context: <
+                file: "tests/test1.sysl"
+                start: <
                   line: 53
-                }
-              }
-            }
-          }
-        }
-      }
-    }
-    types {
+                  col: 15
+                >
+                end: <
+                  line: 53
+                  col: 15
+                >
+              >
+            >
+          >
+        >
+      >
+    >
+    types: <
       key: "Response"
-      value {
-        tuple {
-          attr_defs {
+      value: <
+        tuple: <
+          attr_defs: <
             key: "val"
-            value {
+            value: <
               primitive: STRING
-              source_context {
-                start {
+              source_context: <
+                file: "tests/test1.sysl"
+                start: <
                   line: 55
-                }
-              }
-            }
-          }
-        }
-      }
-    }
-  }
-}
-apps {
+                  col: 15
+                >
+                end: <
+                  line: 55
+                  col: 15
+                >
+              >
+            >
+          >
+        >
+      >
+    >
+  >
+>
+apps: <
   key: "My Todo App"
-  value {
-    name {
+  value: <
+    name: <
       part: "My Todo App"
-    }
-    attrs {
+    >
+    attrs: <
       key: "patterns"
-      value {
-        a {
-          elt {
+      value: <
+        a: <
+          elt: <
             s: "webapp"
-          }
-        }
-      }
-    }
-    endpoints {
+          >
+        >
+      >
+    >
+    endpoints: <
       key: "Add Note"
-      value {
+      value: <
         name: "Add Note"
-        attrs {
+        attrs: <
           key: "patterns"
-          value {
-            a {
-              elt {
+          value: <
+            a: <
+              elt: <
                 s: "somepattern"
-              }
-            }
-          }
-        }
-      }
-    }
-  }
-}
-apps {
+              >
+            >
+          >
+        >
+      >
+    >
+  >
+>
+apps: <
   key: "Project :: Integrations"
-  value {
-    name {
+  value: <
+    name: <
       part: "Project"
       part: "Integrations"
-    }
-    attrs {
+    >
+    attrs: <
       key: "title"
-      value {
+      value: <
         s: "%(epname): %(eplongname)"
-      }
-    }
-    endpoints {
+      >
+    >
+    endpoints: <
       key: "PROJECT-E2E"
-      value {
+      value: <
         name: "PROJECT-E2E"
         long_name: "End to End Integrations"
-        attrs {
+        attrs: <
           key: "page"
-          value {
+          value: <
             s: "Solution Design Doc"
-          }
-        }
-        attrs {
+          >
+        >
+        attrs: <
           key: "passthrough"
-          value {
-            a {
-              elt {
+          value: <
+            a: <
+              elt: <
                 s: "anz_com"
-              }
-              elt {
+              >
+              elt: <
                 s: "My Todo App"
-              }
-              elt {
+              >
+              elt: <
                 s: "A_B"
-              }
-            }
-          }
-        }
-        stmt {
-          action {
+              >
+            >
+          >
+        >
+        stmt: <
+          action: <
             action: "SomeApp"
-          }
-        }
-        stmt {
-          action {
+          >
+        >
+        stmt: <
+          action: <
             action: "Test - App"
-          }
-        }
-      }
-    }
-  }
-}
-apps {
+          >
+        >
+      >
+    >
+  >
+>
+apps: <
   key: "Project :: Sequences"
-  value {
-    name {
+  value: <
+    name: <
       part: "Project"
       part: "Sequences"
-    }
-    endpoints {
+    >
+    endpoints: <
       key: "SEQ-One"
-      value {
+      value: <
         name: "SEQ-One"
-        stmt {
-          call {
-            target {
+        stmt: <
+          call: <
+            target: <
               part: "SomeApp"
-            }
+            >
             endpoint: "FooEndpoint"
-          }
-        }
-      }
-    }
-  }
-}
-apps {
+          >
+        >
+      >
+    >
+  >
+>
+apps: <
   key: "Rest Service"
-  value {
-    name {
+  value: <
+    name: <
       part: "Rest Service"
-    }
-    endpoints {
+    >
+    endpoints: <
       key: ".. * <- *"
-      value {
+      value: <
         name: ".. * <- *"
-        stmt {
-          action {
+        stmt: <
+          action: <
             action: "GET /foo"
-          }
-          attrs {
+          >
+          attrs: <
             key: "some_id"
-            value {
+            value: <
               s: "project_id"
-            }
-          }
-        }
-      }
-    }
-    endpoints {
+            >
+          >
+        >
+      >
+    >
+    endpoints: <
       key: "GET /foo"
-      value {
+      value: <
         name: "GET /foo"
-        attrs {
+        attrs: <
           key: "patterns"
-          value {
-            a {
-              elt {
+          value: <
+            a: <
+              elt: <
                 s: "rest"
-              }
-            }
-          }
-        }
-        attrs {
+              >
+            >
+          >
+        >
+        attrs: <
           key: "some_id"
-          value {
+          value: <
             s: "project_id"
-          }
-        }
-        stmt {
-          action {
+          >
+        >
+        stmt: <
+          action: <
             action: "..."
-          }
-        }
-        rest_params {
+          >
+        >
+        rest_params: <
           method: GET
           path: "/foo"
-        }
-      }
-    }
-  }
-}
-apps {
+        >
+      >
+    >
+  >
+>
+apps: <
   key: "SomeApp"
-  value {
-    name {
+  value: <
+    name: <
       part: "SomeApp"
-    }
-    attrs {
+    >
+    attrs: <
       key: "app_desc"
-      value {
-        s: "this comment belongs to the app defined \'above\'"
-      }
-    }
-    attrs {
+      value: <
+        s: "this comment belongs to the app defined 'above'"
+      >
+    >
+    attrs: <
       key: "array"
-      value {
-        a {
-          elt {
+      value: <
+        a: <
+          elt: <
             s: "one"
-          }
-          elt {
+          >
+          elt: <
             s: "two"
-          }
-        }
-      }
-    }
-    attrs {
+          >
+        >
+      >
+    >
+    attrs: <
       key: "array_of_arrays"
-      value {
-        a {
-          elt {
-            a {
-              elt {
+      value: <
+        a: <
+          elt: <
+            a: <
+              elt: <
                 s: "one"
-              }
-              elt {
+              >
+              elt: <
                 s: "two"
-              }
-            }
-          }
-        }
-      }
-    }
-    attrs {
+              >
+            >
+          >
+        >
+      >
+    >
+    attrs: <
       key: "comment"
-      value {
+      value: <
         s: ""
-      }
-    }
-    attrs {
+      >
+    >
+    attrs: <
       key: "comment.second"
-      value {
+      value: <
         s: ""
-      }
-    }
-    attrs {
+      >
+    >
+    attrs: <
       key: "package"
-      value {
+      value: <
         s: ""
-      }
-    }
-    attrs {
+      >
+    >
+    attrs: <
       key: "version"
-      value {
+      value: <
         s: "1.1.1"
-      }
-    }
-    endpoints {
+      >
+    >
+    endpoints: <
       key: ".. * <- *"
-      value {
+      value: <
         name: ".. * <- *"
-        stmt {
-          action {
+        stmt: <
+          action: <
             action: "FooEndpoint"
-          }
-          attrs {
+          >
+          attrs: <
             key: "some_id"
-            value {
+            value: <
               s: "project_id"
-            }
-          }
-        }
-        stmt {
-          call {
-            target {
+            >
+          >
+        >
+        stmt: <
+          call: <
+            target: <
               part: "Test - App"
-            }
+            >
             endpoint: "Test - Endpoint"
-          }
-          attrs {
+          >
+          attrs: <
             key: "some_id"
-            value {
+            value: <
               s: "project_id"
-            }
-          }
-        }
-      }
-    }
-    endpoints {
+            >
+          >
+        >
+      >
+    >
+    endpoints: <
       key: "Endpoint"
-      value {
+      value: <
         name: "Endpoint"
-        stmt {
-          action {
+        stmt: <
+          action: <
             action: "..."
-          }
-        }
-      }
-    }
-    endpoints {
+          >
+        >
+      >
+    >
+    endpoints: <
       key: "Event"
-      value {
+      value: <
         name: "Event"
         is_pubsub: true
-        stmt {
-          ret {
-            payload: "\"customer details\""
-          }
-        }
-        param {
+        param: <
           name: "App.member"
-          type {
-            no_type {
-            }
-          }
-        }
-        param {
+          type: <
+            no_type: <
+            >
+          >
+        >
+        param: <
           name: "request"
-          type {
-            type_ref {
-              ref {
-                appname {
+          type: <
+            type_ref: <
+              ref: <
+                appname: <
                   part: "SomeApp"
-                }
+                >
                 path: "SomeType"
-              }
-            }
-          }
-        }
-      }
-    }
-    endpoints {
+              >
+            >
+          >
+        >
+        stmt: <
+          ret: <
+            payload: "\"customer details\""
+          >
+        >
+      >
+    >
+    endpoints: <
       key: "FooEndpoint"
-      value {
+      value: <
         name: "FooEndpoint"
-        attrs {
+        attrs: <
           key: "some_id"
-          value {
+          value: <
             s: "project_id"
-          }
-        }
-        stmt {
-          call {
-            target {
+          >
+        >
+        stmt: <
+          call: <
+            target: <
               part: "Test - App"
-            }
+            >
             endpoint: "Test - Endpoint"
-          }
-          attrs {
+          >
+          attrs: <
             key: "some_id"
-            value {
+            value: <
               s: "project_id"
-            }
-          }
-        }
-      }
-    }
-    endpoints {
+            >
+          >
+        >
+      >
+    >
+    endpoints: <
       key: "Test - App -> eventName"
-      value {
+      value: <
         name: "Test - App -> eventName"
-        attrs {
+        attrs: <
           key: "patterns"
-          value {
-            a {
-              elt {
+          value: <
+            a: <
+              elt: <
                 s: "mq"
-              }
-            }
-          }
-        }
-        source {
+              >
+            >
+          >
+        >
+        source: <
           part: "Test - App"
-        }
-        stmt {
-          action {
+        >
+        stmt: <
+          action: <
             action: "\"\""
-          }
-        }
-        stmt {
-          action {
-            action: "\'\'"
-          }
-        }
-        stmt {
-          action {
-            action: "\'asdf\'"
-          }
-        }
-        stmt {
-          action {
+          >
+        >
+        stmt: <
+          action: <
+            action: "''"
+          >
+        >
+        stmt: <
+          action: <
+            action: "'asdf'"
+          >
+        >
+        stmt: <
+          action: <
             action: "\"quoted statement: use special chars here like ?? :: etc\""
-          }
-        }
-        stmt {
-          action {
-            action: "\"test: single quotes \'above\'\""
-          }
-        }
-        stmt {
-          action {
+          >
+        >
+        stmt: <
+          action: <
+            action: "\"test: single quotes 'above'\""
+          >
+        >
+        stmt: <
+          action: <
             action: "do something"
-          }
-        }
-        stmt {
-          action {
+          >
+        >
+        stmt: <
+          action: <
             action: "| Some multiline comments that you can use for documentation. This is last line."
-          }
-        }
-        stmt {
-          action {
+          >
+        >
+        stmt: <
+          action: <
             action: "handle event eventName"
-          }
-        }
-      }
-    }
-  }
-}
-apps {
+          >
+        >
+      >
+    >
+  >
+>
+apps: <
   key: "Test - App"
-  value {
-    name {
+  value: <
+    name: <
       part: "Test - App"
-    }
-    endpoints {
+    >
+    endpoints: <
       key: "Endpoint2"
-      value {
+      value: <
         name: "Endpoint2"
-        attrs {
+        attrs: <
           key: "ep_desc"
-          value {
+          value: <
             s: "this comment belongs to the Endpoint2 defined above"
-          }
-        }
-        stmt {
-          action {
-            action: "| Single line statement"
-          }
-        }
-        stmt {
-          call {
-            target {
-              part: "Test - App"
-            }
-            endpoint: "eventName"
-          }
-        }
-        param {
+          >
+        >
+        param: <
           name: "request"
-          type {
-            set {
-              type_ref {
-                ref {
-                  appname {
+          type: <
+            set: <
+              type_ref: <
+                ref: <
+                  appname: <
                     part: "SomeApp"
-                  }
+                  >
                   path: "SomeType"
-                }
-              }
-            }
-          }
-        }
-      }
-    }
-    endpoints {
+                >
+              >
+            >
+          >
+        >
+        stmt: <
+          action: <
+            action: "| Single line statement"
+          >
+        >
+        stmt: <
+          call: <
+            target: <
+              part: "Test - App"
+            >
+            endpoint: "eventName"
+          >
+        >
+      >
+    >
+    endpoints: <
       key: "Test - Endpoint"
-      value {
+      value: <
         name: "Test - Endpoint"
-        stmt {
-          call {
-            target {
+        param: <
+          name: "request"
+          type: <
+            type_ref: <
+              ref: <
+                appname: <
+                  part: "SomeApp"
+                >
+                path: "SomeType"
+              >
+            >
+          >
+        >
+        stmt: <
+          call: <
+            target: <
               part: "External"
               part: "App"
-            }
+            >
             endpoint: "Endpoint"
-          }
-        }
-        stmt {
-          call {
-            target {
+          >
+        >
+        stmt: <
+          call: <
+            target: <
               part: "Rest Service"
-            }
+            >
             endpoint: "GET /foo"
-          }
-        }
-        stmt {
-          cond {
+          >
+        >
+        stmt: <
+          cond: <
             test: "value == one"
-            stmt {
-              action {
+            stmt: <
+              action: <
                 action: "do something"
-              }
-            }
-          }
-        }
-        stmt {
-          group {
+              >
+            >
+          >
+        >
+        stmt: <
+          group: <
             title: "else if value == two"
-            stmt {
-              action {
+            stmt: <
+              action: <
                 action: "do something else"
-              }
-            }
-          }
-        }
-        stmt {
-          group {
+              >
+            >
+          >
+        >
+        stmt: <
+          group: <
             title: "else"
-            stmt {
-              ret {
+            stmt: <
+              ret: <
                 payload: "ok"
-              }
-            }
-          }
-        }
-        param {
-          name: "request"
-          type {
-            type_ref {
-              ref {
-                appname {
-                  part: "SomeApp"
-                }
-                path: "SomeType"
-              }
-            }
-          }
-        }
-      }
-    }
-    endpoints {
+              >
+            >
+          >
+        >
+      >
+    >
+    endpoints: <
       key: "another event"
-      value {
+      value: <
         name: "another event"
         is_pubsub: true
-      }
-    }
-    endpoints {
+      >
+    >
+    endpoints: <
       key: "eventName"
-      value {
+      value: <
         name: "eventName"
         is_pubsub: true
-        stmt {
-          call {
-            target {
-              part: "SomeApp"
-            }
-            endpoint: "Test - App -> eventName"
-          }
-        }
-        param {
+        param: <
           name: "in"
-          type {
+          type: <
             primitive: STRING
-          }
-        }
-      }
-    }
-  }
-}
-apps {
+          >
+        >
+        stmt: <
+          call: <
+            target: <
+              part: "SomeApp"
+            >
+            endpoint: "Test - App -> eventName"
+          >
+        >
+      >
+    >
+  >
+>
+apps: <
   key: "anz_com"
-  value {
-    name {
+  value: <
+    name: <
       part: "anz_com"
-    }
-    endpoints {
+    >
+    endpoints: <
       key: "homepage"
-      value {
+      value: <
         name: "homepage"
-      }
-    }
-    types {
+      >
+    >
+    types: <
       key: "Response"
-      value {
-        tuple {
-          attr_defs {
+      value: <
+        tuple: <
+          attr_defs: <
             key: "val"
-            value {
+            value: <
               primitive: STRING
-              source_context {
-                start {
+              source_context: <
+                file: "tests/test1.sysl"
+                start: <
                   line: 64
-                }
-              }
-            }
-          }
-        }
-      }
-    }
-  }
-}
+                  col: 15
+                >
+                end: <
+                  line: 64
+                  col: 15
+                >
+              >
+            >
+          >
+        >
+      >
+    >
+  >
+>

--- a/pkg/parse/tests/rest_api_query_params.sysl.golden.textpb
+++ b/pkg/parse/tests/rest_api_query_params.sysl.golden.textpb
@@ -42,8 +42,14 @@ apps: <
             type: <
               primitive: INT
               source_context: <
+                file: "tests/rest_api_query_params.sysl"
                 start: <
                   line: 3
+                  col: 13
+                >
+                end: <
+                  line: 3
+                  col: 19
                 >
               >
             >
@@ -54,8 +60,14 @@ apps: <
               primitive: INT
               opt: true
               source_context: <
+                file: "tests/rest_api_query_params.sysl"
                 start: <
                   line: 3
+                  col: 23
+                >
+                end: <
+                  line: 3
+                  col: 32
                 >
               >
             >
@@ -66,8 +78,14 @@ apps: <
               primitive: INT
               opt: true
               source_context: <
+                file: "tests/rest_api_query_params.sysl"
                 start: <
                   line: 3
+                  col: 34
+                >
+                end: <
+                  line: 3
+                  col: 44
                 >
               >
             >
@@ -124,8 +142,14 @@ apps: <
                 >
               >
               source_context: <
+                file: "tests/rest_api_query_params.sysl"
                 start: <
                   line: 5
+                  col: 9
+                >
+                end: <
+                  line: 5
+                  col: 23
                 >
               >
             >
@@ -180,8 +204,14 @@ apps: <
             type: <
               primitive: INT
               source_context: <
+                file: "tests/rest_api_query_params.sysl"
                 start: <
                   line: 9
+                  col: 32
+                >
+                end: <
+                  line: 9
+                  col: 38
                 >
               >
             >
@@ -202,8 +232,14 @@ apps: <
                 >
               >
               source_context: <
+                file: "tests/rest_api_query_params.sysl"
                 start: <
                   line: 5
+                  col: 9
+                >
+                end: <
+                  line: 5
+                  col: 23
                 >
               >
             >

--- a/pkg/parse/tests/rest_url_params.sysl.golden.textpb
+++ b/pkg/parse/tests/rest_url_params.sysl.golden.textpb
@@ -31,8 +31,14 @@ apps: <
             type: <
               primitive: INT
               source_context: <
+                file: "tests/rest_url_params.sysl"
                 start: <
                   line: 2
+                  col: 5
+                >
+                end: <
+                  line: 2
+                  col: 14
                 >
               >
             >
@@ -42,8 +48,14 @@ apps: <
             type: <
               primitive: INT
               source_context: <
+                file: "tests/rest_url_params.sysl"
                 start: <
                   line: 3
+                  col: 9
+                >
+                end: <
+                  line: 3
+                  col: 18
                 >
               >
             >
@@ -53,8 +65,14 @@ apps: <
             type: <
               primitive: INT
               source_context: <
+                file: "tests/rest_url_params.sysl"
                 start: <
                   line: 4
+                  col: 13
+                >
+                end: <
+                  line: 4
+                  col: 23
                 >
               >
             >
@@ -64,8 +82,14 @@ apps: <
             type: <
               primitive: INT
               source_context: <
+                file: "tests/rest_url_params.sysl"
                 start: <
                   line: 5
+                  col: 17
+                >
+                end: <
+                  line: 5
+                  col: 26
                 >
               >
             >
@@ -75,8 +99,14 @@ apps: <
             type: <
               primitive: INT
               source_context: <
+                file: "tests/rest_url_params.sysl"
                 start: <
                   line: 6
+                  col: 21
+                >
+                end: <
+                  line: 6
+                  col: 31
                 >
               >
             >

--- a/pkg/parse/tests/school.sysl.golden.textpb
+++ b/pkg/parse/tests/school.sysl.golden.textpb
@@ -1,113 +1,131 @@
-apps {
+apps: <
   key: "School"
-  value {
-    name {
+  value: <
+    name: <
       part: "School"
-    }
-    types {
+    >
+    types: <
       key: "Class"
-      value {
-        relation {
-          attr_defs {
+      value: <
+        relation: <
+          attr_defs: <
             key: "Id"
-            value {
+            value: <
               primitive: INT
-              attrs {
+              attrs: <
                 key: "patterns"
-                value {
-                  a {
-                    elt {
+                value: <
+                  a: <
+                    elt: <
                       s: "pk"
-                    }
-                    elt {
+                    >
+                    elt: <
                       s: "autoinc"
-                    }
-                  }
-                }
-              }
-              source_context {
-                start {
+                    >
+                  >
+                >
+              >
+              source_context: <
+                file: "school.sysl"
+                start: <
                   line: 3
-                }
-              }
-            }
-          }
-          primary_key {
+                  col: 14
+                >
+                end: <
+                  line: 3
+                  col: 32
+                >
+              >
+            >
+          >
+          primary_key: <
             attr_name: "Id"
-          }
-        }
-      }
-    }
-    types {
+          >
+        >
+      >
+    >
+    types: <
       key: "Student"
-      value {
-        relation {
-          attr_defs {
+      value: <
+        relation: <
+          attr_defs: <
             key: "ClassId"
-            value {
-              attrs {
-                key: "description"
-                value {
-                  s: "describe the table"
-                }
-              }
-              type_ref {
-                context {
-                  appname {
+            value: <
+              type_ref: <
+                context: <
+                  appname: <
                     part: "School"
-                  }
+                  >
                   path: "Student"
-                }
-                ref {
+                >
+                ref: <
                   path: "Class"
                   path: "Idd"
-                }
-              }
-              source_context {
-                start {
-                  line: 7
-                }
-              }
-            }
-          }
-          attr_defs {
-            key: "Id"
-            value {
-              primitive: INT
-              attrs {
+                >
+              >
+              attrs: <
                 key: "description"
-                value {
+                value: <
                   s: "describe the table"
-                }
-              }
-              attrs {
+                >
+              >
+              source_context: <
+                file: "school.sysl"
+                start: <
+                  line: 7
+                  col: 19
+                >
+                end: <
+                  line: 7
+                  col: 25
+                >
+              >
+            >
+          >
+          attr_defs: <
+            key: "Id"
+            value: <
+              primitive: INT
+              attrs: <
+                key: "description"
+                value: <
+                  s: "describe the table"
+                >
+              >
+              attrs: <
                 key: "patterns"
-                value {
-                  a {
-                    elt {
+                value: <
+                  a: <
+                    elt: <
                       s: "pk"
-                    }
-                  }
-                }
-              }
-              source_context {
-                start {
+                    >
+                  >
+                >
+              >
+              source_context: <
+                file: "school.sysl"
+                start: <
                   line: 6
-                }
-              }
-            }
-          }
-          primary_key {
+                  col: 14
+                >
+                end: <
+                  line: 6
+                  col: 22
+                >
+              >
+            >
+          >
+          primary_key: <
             attr_name: "Id"
-          }
-        }
-        attrs {
+          >
+        >
+        attrs: <
           key: "description"
-          value {
+          value: <
             s: "describe the table"
-          }
-        }
-      }
-    }
-  }
-}
+          >
+        >
+      >
+    >
+  >
+>

--- a/pkg/parse/tests/sequence_type.sysl.golden.textpb
+++ b/pkg/parse/tests/sequence_type.sysl.golden.textpb
@@ -14,8 +14,13 @@ apps: <
               sequence: <
                 primitive: INT
                 source_context: <
+                  file: "tests/sequence_type.sysl"
                   start: <
                     line: 4
+                    col: 13
+                  >
+                  end: <
+                    line: 5
                   >
                 >
               >
@@ -27,8 +32,13 @@ apps: <
               >
               opt: true
               source_context: <
+                file: "tests/sequence_type.sysl"
                 start: <
                   line: 4
+                  col: 13
+                >
+                end: <
+                  line: 5
                 >
               >
             >

--- a/pkg/parse/tests/test1.sysl.golden.textpb
+++ b/pkg/parse/tests/test1.sysl.golden.textpb
@@ -1,618 +1,642 @@
-apps {
+apps: <
   key: "A_B"
-  value {
-    name {
+  value: <
+    name: <
       part: "A_B"
-    }
-    endpoints {
+    >
+    endpoints: <
       key: "C_D"
-      value {
+      value: <
         name: "C_D"
-        stmt {
-          call {
-            target {
+        stmt: <
+          call: <
+            target: <
               part: "anz_com"
-            }
+            >
             endpoint: "homepage"
-          }
-        }
-        stmt {
-          call {
-            target {
+          >
+        >
+        stmt: <
+          call: <
+            target: <
               part: "Test - App"
-            }
+            >
             endpoint: "Test - Endpoint"
-          }
-        }
-      }
-    }
-    endpoints {
+          >
+        >
+      >
+    >
+    endpoints: <
       key: "DDD"
-      value {
+      value: <
         name: "DDD"
-        stmt {
-          cond {
+        stmt: <
+          cond: <
             test: "some condition is true"
-            stmt {
-              action {
+            stmt: <
+              action: <
                 action: "Test - App -> eventName"
-              }
-            }
-            stmt {
-              call {
-                target {
+              >
+            >
+            stmt: <
+              call: <
+                target: <
                   part: "Test - App"
-                }
+                >
                 endpoint: "Endpoint2"
-              }
-            }
-            stmt {
-              cond {
+              >
+            >
+            stmt: <
+              cond: <
                 test: "result not ok"
-                stmt {
-                  ret {
+                stmt: <
+                  ret: <
                     payload: "not ok1"
-                  }
-                }
-              }
-            }
-            stmt {
-              group {
+                  >
+                >
+              >
+            >
+            stmt: <
+              group: <
                 title: "else"
-                stmt {
-                  ret {
+                stmt: <
+                  ret: <
                     payload: "ok"
-                  }
-                }
-              }
-            }
-          }
-        }
-        stmt {
-          group {
+                  >
+                >
+              >
+            >
+          >
+        >
+        stmt: <
+          group: <
             title: "else some other condition"
-            stmt {
-              action {
+            stmt: <
+              action: <
                 action: "top level else_statment"
-              }
-            }
-            stmt {
-              cond {
+              >
+            >
+            stmt: <
+              cond: <
                 test: "\"some constraint\""
-                stmt {
-                  ret {
+                stmt: <
+                  ret: <
                     payload: "ok"
-                  }
-                }
-              }
-            }
-            stmt {
-              group {
+                  >
+                >
+              >
+            >
+            stmt: <
+              group: <
                 title: "Else"
-                stmt {
-                  ret {
+                stmt: <
+                  ret: <
                     payload: "not ok"
-                  }
-                }
-              }
-            }
-          }
-        }
-        stmt {
-          action {
+                  >
+                >
+              >
+            >
+          >
+        >
+        stmt: <
+          action: <
             action: "do some more stuff"
-          }
-        }
-      }
-    }
-    endpoints {
+          >
+        >
+      >
+    >
+    endpoints: <
       key: "EEE"
-      value {
+      value: <
         name: "EEE"
-        stmt {
-          action {
+        stmt: <
+          action: <
             action: "..."
-          }
-        }
-      }
-    }
-    endpoints {
+          >
+        >
+      >
+    >
+    endpoints: <
       key: "Send document to customer"
-      value {
+      value: <
         name: "Send document to customer"
-      }
-    }
-  }
-}
-apps {
+      >
+    >
+  >
+>
+apps: <
   key: "External :: App"
-  value {
-    name {
+  value: <
+    name: <
       part: "External"
       part: "App"
-    }
-    endpoints {
+    >
+    endpoints: <
       key: "Endpoint"
-      value {
+      value: <
         name: "Endpoint"
-        stmt {
-          action {
+        stmt: <
+          action: <
             action: "..."
-          }
-        }
-      }
-    }
-    types {
+          >
+        >
+      >
+    >
+    types: <
       key: "Request"
-      value {
-        tuple {
-          attr_defs {
+      value: <
+        tuple: <
+          attr_defs: <
             key: "id"
-            value {
+            value: <
               primitive: INT
-              source_context {
-                start {
+              source_context: <
+                file: "tests/test1.sysl"
+                start: <
                   line: 52
-                }
-              }
-            }
-          }
-          attr_defs {
+                  col: 14
+                >
+                end: <
+                  line: 52
+                  col: 14
+                >
+              >
+            >
+          >
+          attr_defs: <
             key: "val"
-            value {
+            value: <
               primitive: STRING
-              source_context {
-                start {
+              source_context: <
+                file: "tests/test1.sysl"
+                start: <
                   line: 53
-                }
-              }
-            }
-          }
-        }
-      }
-    }
-    types {
+                  col: 15
+                >
+                end: <
+                  line: 53
+                  col: 15
+                >
+              >
+            >
+          >
+        >
+      >
+    >
+    types: <
       key: "Response"
-      value {
-        tuple {
-          attr_defs {
+      value: <
+        tuple: <
+          attr_defs: <
             key: "val"
-            value {
+            value: <
               primitive: STRING
-              source_context {
-                start {
+              source_context: <
+                file: "tests/test1.sysl"
+                start: <
                   line: 55
-                }
-              }
-            }
-          }
-        }
-      }
-    }
-  }
-}
-apps {
+                  col: 15
+                >
+                end: <
+                  line: 55
+                  col: 15
+                >
+              >
+            >
+          >
+        >
+      >
+    >
+  >
+>
+apps: <
   key: "My Todo App"
-  value {
-    name {
+  value: <
+    name: <
       part: "My Todo App"
-    }
-    attrs {
+    >
+    attrs: <
       key: "patterns"
-      value {
-        a {
-          elt {
+      value: <
+        a: <
+          elt: <
             s: "webapp"
-          }
-        }
-      }
-    }
-    endpoints {
+          >
+        >
+      >
+    >
+    endpoints: <
       key: "Add Note"
-      value {
+      value: <
         name: "Add Note"
-        attrs {
+        attrs: <
           key: "patterns"
-          value {
-            a {
-              elt {
+          value: <
+            a: <
+              elt: <
                 s: "somepattern"
-              }
-            }
-          }
-        }
-      }
-    }
-  }
-}
-apps {
+              >
+            >
+          >
+        >
+      >
+    >
+  >
+>
+apps: <
   key: "Rest Service"
-  value {
-    name {
+  value: <
+    name: <
       part: "Rest Service"
-    }
-    endpoints {
+    >
+    endpoints: <
       key: "GET /foo"
-      value {
+      value: <
         name: "GET /foo"
-        attrs {
+        attrs: <
           key: "patterns"
-          value {
-            a {
-              elt {
+          value: <
+            a: <
+              elt: <
                 s: "rest"
-              }
-            }
-          }
-        }
-        stmt {
-          action {
+              >
+            >
+          >
+        >
+        stmt: <
+          action: <
             action: "..."
-          }
-        }
-        rest_params {
+          >
+        >
+        rest_params: <
           method: GET
           path: "/foo"
-        }
-      }
-    }
-  }
-}
-apps {
+        >
+      >
+    >
+  >
+>
+apps: <
   key: "SomeApp"
-  value {
-    name {
+  value: <
+    name: <
       part: "SomeApp"
-    }
-    attrs {
+    >
+    attrs: <
       key: "app_desc"
-      value {
-        s: "this comment belongs to the app defined \'above\'"
-      }
-    }
-    attrs {
+      value: <
+        s: "this comment belongs to the app defined 'above'"
+      >
+    >
+    attrs: <
       key: "array"
-      value {
-        a {
-          elt {
+      value: <
+        a: <
+          elt: <
             s: "one"
-          }
-          elt {
+          >
+          elt: <
             s: "two"
-          }
-        }
-      }
-    }
-    attrs {
+          >
+        >
+      >
+    >
+    attrs: <
       key: "array_of_arrays"
-      value {
-        a {
-          elt {
-            a {
-              elt {
+      value: <
+        a: <
+          elt: <
+            a: <
+              elt: <
                 s: "one"
-              }
-              elt {
+              >
+              elt: <
                 s: "two"
-              }
-            }
-          }
-        }
-      }
-    }
-    attrs {
+              >
+            >
+          >
+        >
+      >
+    >
+    attrs: <
       key: "comment"
-      value {
+      value: <
         s: ""
-      }
-    }
-    attrs {
+      >
+    >
+    attrs: <
       key: "comment.second"
-      value {
+      value: <
         s: ""
-      }
-    }
-    attrs {
+      >
+    >
+    attrs: <
       key: "package"
-      value {
+      value: <
         s: ""
-      }
-    }
-    attrs {
+      >
+    >
+    attrs: <
       key: "version"
-      value {
+      value: <
         s: "1.1.1"
-      }
-    }
-    endpoints {
+      >
+    >
+    endpoints: <
       key: "Endpoint"
-      value {
+      value: <
         name: "Endpoint"
-        stmt {
-          action {
+        stmt: <
+          action: <
             action: "..."
-          }
-        }
-      }
-    }
-    endpoints {
+          >
+        >
+      >
+    >
+    endpoints: <
       key: "Event"
-      value {
+      value: <
         name: "Event"
         is_pubsub: true
-        stmt {
-          ret {
-            payload: "\"customer details\""
-          }
-        }
-        param {
+        param: <
           name: "App.member"
-          type {
-            no_type {
-            }
-          }
-        }
-        param {
+          type: <
+            no_type: <
+            >
+          >
+        >
+        param: <
           name: "request"
-          type {
-            type_ref {
-              ref {
-                appname {
+          type: <
+            type_ref: <
+              ref: <
+                appname: <
                   part: "SomeApp"
-                }
+                >
                 path: "SomeType"
-              }
-            }
-          }
-        }
-      }
-    }
-    endpoints {
+              >
+            >
+          >
+        >
+        stmt: <
+          ret: <
+            payload: "\"customer details\""
+          >
+        >
+      >
+    >
+    endpoints: <
       key: "FooEndpoint"
-      value {
+      value: <
         name: "FooEndpoint"
-        stmt {
-          call {
-            target {
+        stmt: <
+          call: <
+            target: <
               part: "Test - App"
-            }
+            >
             endpoint: "Test - Endpoint"
-          }
-        }
-      }
-    }
-    endpoints {
+          >
+        >
+      >
+    >
+    endpoints: <
       key: "Test - App -> eventName"
-      value {
+      value: <
         name: "Test - App -> eventName"
-        attrs {
+        attrs: <
           key: "patterns"
-          value {
-            a {
-              elt {
+          value: <
+            a: <
+              elt: <
                 s: "mq"
-              }
-            }
-          }
-        }
-        source {
+              >
+            >
+          >
+        >
+        source: <
           part: "Test - App"
-        }
-        stmt {
-          action {
+        >
+        stmt: <
+          action: <
             action: "\"\""
-          }
-        }
-        stmt {
-          action {
-            action: "\'\'"
-          }
-        }
-        stmt {
-          action {
-            action: "\'asdf\'"
-          }
-        }
-        stmt {
-          action {
+          >
+        >
+        stmt: <
+          action: <
+            action: "''"
+          >
+        >
+        stmt: <
+          action: <
+            action: "'asdf'"
+          >
+        >
+        stmt: <
+          action: <
             action: "\"quoted statement: use special chars here like ?? :: etc\""
-          }
-        }
-        stmt {
-          action {
-            action: "\"test: single quotes \'above\'\""
-          }
-        }
-        stmt {
-          action {
+          >
+        >
+        stmt: <
+          action: <
+            action: "\"test: single quotes 'above'\""
+          >
+        >
+        stmt: <
+          action: <
             action: "do something"
-          }
-        }
-        stmt {
-          action {
+          >
+        >
+        stmt: <
+          action: <
             action: "| Some multiline comments that you can use for documentation. This is last line."
-          }
-        }
-        stmt {
-          action {
+          >
+        >
+        stmt: <
+          action: <
             action: "handle event eventName"
-          }
-        }
-      }
-    }
-  }
-}
-apps {
+          >
+        >
+      >
+    >
+  >
+>
+apps: <
   key: "Test - App"
-  value {
-    name {
+  value: <
+    name: <
       part: "Test - App"
-    }
-    endpoints {
+    >
+    endpoints: <
       key: "Endpoint2"
-      value {
+      value: <
         name: "Endpoint2"
-        attrs {
+        attrs: <
           key: "ep_desc"
-          value {
+          value: <
             s: "this comment belongs to the Endpoint2 defined above"
-          }
-        }
-        stmt {
-          action {
-            action: "| Single line statement"
-          }
-        }
-        stmt {
-          call {
-            target {
-              part: "Test - App"
-            }
-            endpoint: "eventName"
-          }
-        }
-        param {
+          >
+        >
+        param: <
           name: "request"
-          type {
-            set {
-              type_ref {
-                ref {
-                  appname {
+          type: <
+            set: <
+              type_ref: <
+                ref: <
+                  appname: <
                     part: "SomeApp"
-                  }
+                  >
                   path: "SomeType"
-                }
-              }
-            }
-          }
-        }
-      }
-    }
-    endpoints {
+                >
+              >
+            >
+          >
+        >
+        stmt: <
+          action: <
+            action: "| Single line statement"
+          >
+        >
+        stmt: <
+          call: <
+            target: <
+              part: "Test - App"
+            >
+            endpoint: "eventName"
+          >
+        >
+      >
+    >
+    endpoints: <
       key: "Test - Endpoint"
-      value {
+      value: <
         name: "Test - Endpoint"
-        stmt {
-          call {
-            target {
+        param: <
+          name: "request"
+          type: <
+            type_ref: <
+              ref: <
+                appname: <
+                  part: "SomeApp"
+                >
+                path: "SomeType"
+              >
+            >
+          >
+        >
+        stmt: <
+          call: <
+            target: <
               part: "External"
               part: "App"
-            }
+            >
             endpoint: "Endpoint"
-          }
-        }
-        stmt {
-          call {
-            target {
+          >
+        >
+        stmt: <
+          call: <
+            target: <
               part: "Rest Service"
-            }
+            >
             endpoint: "GET /foo"
-          }
-        }
-        stmt {
-          cond {
+          >
+        >
+        stmt: <
+          cond: <
             test: "value == one"
-            stmt {
-              action {
+            stmt: <
+              action: <
                 action: "do something"
-              }
-            }
-          }
-        }
-        stmt {
-          group {
+              >
+            >
+          >
+        >
+        stmt: <
+          group: <
             title: "else if value == two"
-            stmt {
-              action {
+            stmt: <
+              action: <
                 action: "do something else"
-              }
-            }
-          }
-        }
-        stmt {
-          group {
+              >
+            >
+          >
+        >
+        stmt: <
+          group: <
             title: "else"
-            stmt {
-              ret {
+            stmt: <
+              ret: <
                 payload: "ok"
-              }
-            }
-          }
-        }
-        param {
-          name: "request"
-          type {
-            type_ref {
-              ref {
-                appname {
-                  part: "SomeApp"
-                }
-                path: "SomeType"
-              }
-            }
-          }
-        }
-      }
-    }
-    endpoints {
+              >
+            >
+          >
+        >
+      >
+    >
+    endpoints: <
       key: "another event"
-      value {
+      value: <
         name: "another event"
         is_pubsub: true
-      }
-    }
-    endpoints {
+      >
+    >
+    endpoints: <
       key: "eventName"
-      value {
+      value: <
         name: "eventName"
         is_pubsub: true
-        stmt {
-          call {
-            target {
-              part: "SomeApp"
-            }
-            endpoint: "Test - App -> eventName"
-          }
-        }
-        param {
+        param: <
           name: "in"
-          type {
+          type: <
             primitive: STRING
-          }
-        }
-      }
-    }
-  }
-}
-apps {
+          >
+        >
+        stmt: <
+          call: <
+            target: <
+              part: "SomeApp"
+            >
+            endpoint: "Test - App -> eventName"
+          >
+        >
+      >
+    >
+  >
+>
+apps: <
   key: "anz_com"
-  value {
-    name {
+  value: <
+    name: <
       part: "anz_com"
-    }
-    endpoints {
+    >
+    endpoints: <
       key: "homepage"
-      value {
+      value: <
         name: "homepage"
-      }
-    }
-    types {
+      >
+    >
+    types: <
       key: "Response"
-      value {
-        tuple {
-          attr_defs {
+      value: <
+        tuple: <
+          attr_defs: <
             key: "val"
-            value {
+            value: <
               primitive: STRING
-              source_context {
-                start {
+              source_context: <
+                file: "tests/test1.sysl"
+                start: <
                   line: 64
-                }
-              }
-            }
-          }
-        }
-      }
-    }
-  }
-}
+                  col: 15
+                >
+                end: <
+                  line: 64
+                  col: 15
+                >
+              >
+            >
+          >
+        >
+      >
+    >
+  >
+>

--- a/pkg/parse/tests/test2.sysl.golden.textpb
+++ b/pkg/parse/tests/test2.sysl.golden.textpb
@@ -1,243 +1,315 @@
-apps {
+apps: <
   key: "Request"
-  value {
-    name {
+  value: <
+    name: <
       part: "Request"
-    }
-    types {
+    >
+    types: <
       key: "Input"
-      value {
-        tuple {
-          attr_defs {
+      value: <
+        tuple: <
+          attr_defs: <
             key: "field1"
-            value {
+            value: <
               primitive: INT
-              source_context {
-                start {
+              source_context: <
+                file: "tests/test2.sysl"
+                start: <
                   line: 22
-                }
-              }
-            }
-          }
-        }
-      }
-    }
-  }
-}
-apps {
+                  col: 18
+                >
+                end: <
+                  line: 22
+                  col: 18
+                >
+              >
+            >
+          >
+        >
+      >
+    >
+  >
+>
+apps: <
   key: "Response"
-  value {
-    name {
+  value: <
+    name: <
       part: "Response"
-    }
-    types {
+    >
+    types: <
       key: "Output"
-      value {
-        tuple {
-          attr_defs {
+      value: <
+        tuple: <
+          attr_defs: <
             key: "field1"
-            value {
-              type_ref {
-                context {
-                  appname {
+            value: <
+              type_ref: <
+                context: <
+                  appname: <
                     part: "Response"
-                  }
+                  >
                   path: "Output"
-                }
-                ref {
+                >
+                ref: <
                   path: "Request"
-                }
-              }
-              source_context {
-                start {
+                >
+              >
+              source_context: <
+                file: "tests/test2.sysl"
+                start: <
                   line: 26
-                }
-              }
-            }
-          }
-        }
-      }
-    }
-  }
-}
-apps {
+                  col: 18
+                >
+                end: <
+                  line: 26
+                  col: 18
+                >
+              >
+            >
+          >
+        >
+      >
+    >
+  >
+>
+apps: <
   key: "Tuple Model"
-  value {
-    name {
+  value: <
+    name: <
       part: "Tuple Model"
-    }
-    types {
+    >
+    types: <
       key: "Foo"
-      value {
-        tuple {
-          attr_defs {
+      value: <
+        tuple: <
+          attr_defs: <
             key: "id"
-            value {
+            value: <
               primitive: INT
-              attrs {
+              attrs: <
                 key: "description"
-                value {
+                value: <
                   s: "some description"
-                }
-              }
-              source_context {
-                start {
+                >
+              >
+              source_context: <
+                file: "tests/test2.sysl"
+                start: <
                   line: 4
-                }
-              }
-            }
-          }
-        }
-        attrs {
+                  col: 14
+                >
+                end: <
+                  line: 4
+                  col: 14
+                >
+              >
+            >
+          >
+        >
+        attrs: <
           key: "description"
-          value {
+          value: <
             s: "some description"
-          }
-        }
-      }
-    }
-    types {
+          >
+        >
+      >
+    >
+    types: <
       key: "PersonName"
-      value {
-        tuple {
-          attr_defs {
+      value: <
+        tuple: <
+          attr_defs: <
             key: "first_name"
-            value {
+            value: <
               primitive: STRING
-              source_context {
-                start {
+              source_context: <
+                file: "tests/test2.sysl"
+                start: <
                   line: 16
-                }
-              }
-            }
-          }
-          attr_defs {
+                  col: 22
+                >
+                end: <
+                  line: 16
+                  col: 22
+                >
+              >
+            >
+          >
+          attr_defs: <
             key: "last_name"
-            value {
+            value: <
               primitive: STRING
-              source_context {
-                start {
+              source_context: <
+                file: "tests/test2.sysl"
+                start: <
                   line: 18
-                }
-              }
-            }
-          }
-          attr_defs {
+                  col: 21
+                >
+                end: <
+                  line: 18
+                  col: 21
+                >
+              >
+            >
+          >
+          attr_defs: <
             key: "middle_name"
-            value {
-              list {
-                type {
+            value: <
+              list: <
+                type: <
                   primitive: STRING
-                  source_context {
-                    start {
+                  source_context: <
+                    file: "tests/test2.sysl"
+                    start: <
                       line: 17
-                    }
-                  }
-                }
-              }
-            }
-          }
-          attr_defs {
+                      col: 29
+                    >
+                    end: <
+                      line: 17
+                      col: 29
+                    >
+                  >
+                >
+              >
+            >
+          >
+          attr_defs: <
             key: "title"
-            value {
+            value: <
               primitive: STRING
-              source_context {
-                start {
+              source_context: <
+                file: "tests/test2.sysl"
+                start: <
                   line: 15
-                }
-              }
-            }
-          }
-        }
-      }
-    }
-    types {
+                  col: 17
+                >
+                end: <
+                  line: 15
+                  col: 17
+                >
+              >
+            >
+          >
+        >
+      >
+    >
+    types: <
       key: "TableName"
-      value {
-        tuple {
-          attr_defs {
+      value: <
+        tuple: <
+          attr_defs: <
             key: "fieldname"
-            value {
+            value: <
               primitive: STRING
-              attrs {
+              attrs: <
                 key: "description"
-                value {
+                value: <
                   s: "Multi-line annotation statement"
-                }
-              }
-              source_context {
-                start {
+                >
+              >
+              source_context: <
+                file: "tests/test2.sysl"
+                start: <
                   line: 10
-                }
-              }
-            }
-          }
-          attr_defs {
+                  col: 21
+                >
+                end: <
+                  line: 10
+                  col: 21
+                >
+              >
+            >
+          >
+          attr_defs: <
             key: "fieldname2"
-            value {
-              attrs {
-                key: "description"
-                value {
-                  s: "Multi-line annotation statement"
-                }
-              }
-              set {
+            value: <
+              set: <
                 primitive: STRING
-                source_context {
-                  start {
+                source_context: <
+                  file: "tests/test2.sysl"
+                  start: <
                     line: 11
-                  }
-                }
-              }
-              source_context {
-                start {
-                  line: 11
-                }
-              }
-            }
-          }
-          attr_defs {
-            key: "ids"
-            value {
-              attrs {
+                    col: 22
+                  >
+                  end: <
+                    line: 11
+                    col: 29
+                  >
+                >
+              >
+              attrs: <
                 key: "description"
-                value {
+                value: <
                   s: "Multi-line annotation statement"
-                }
-              }
-              set {
-                type_ref {
-                  context {
-                    appname {
+                >
+              >
+              source_context: <
+                file: "tests/test2.sysl"
+                start: <
+                  line: 11
+                  col: 22
+                >
+                end: <
+                  line: 11
+                  col: 29
+                >
+              >
+            >
+          >
+          attr_defs: <
+            key: "ids"
+            value: <
+              set: <
+                type_ref: <
+                  context: <
+                    appname: <
                       part: "Tuple Model"
-                    }
+                    >
                     path: "TableName"
-                  }
-                  ref {
+                  >
+                  ref: <
                     path: "Foo"
-                  }
-                }
-                source_context {
-                  start {
+                  >
+                >
+                source_context: <
+                  file: "tests/test2.sysl"
+                  start: <
                     line: 12
-                  }
-                }
-              }
-              source_context {
-                start {
+                    col: 15
+                  >
+                  end: <
+                    line: 12
+                    col: 22
+                  >
+                >
+              >
+              attrs: <
+                key: "description"
+                value: <
+                  s: "Multi-line annotation statement"
+                >
+              >
+              source_context: <
+                file: "tests/test2.sysl"
+                start: <
                   line: 12
-                }
-              }
-            }
-          }
-        }
-        attrs {
+                  col: 15
+                >
+                end: <
+                  line: 12
+                  col: 22
+                >
+              >
+            >
+          >
+        >
+        attrs: <
           key: "description"
-          value {
+          value: <
             s: "Multi-line annotation statement"
-          }
-        }
-      }
-    }
-  }
-}
+          >
+        >
+      >
+    >
+  >
+>

--- a/pkg/parse/tests/test4.sysl.golden.textpb
+++ b/pkg/parse/tests/test4.sysl.golden.textpb
@@ -1,280 +1,334 @@
-apps {
+apps: <
   key: "Browser App"
-  value {
-    name {
+  value: <
+    name: <
       part: "Browser App"
-    }
-    endpoints {
+    >
+    endpoints: <
       key: "EP"
-      value {
+      value: <
         name: "EP"
-        param {
+        param: <
           name: "p1"
-          type {
-            type_ref {
-              ref {
-                appname {
+          type: <
+            type_ref: <
+              ref: <
+                appname: <
                   part: "GO"
                   part: "Sample"
                   part: "My Todo App"
-                }
+                >
                 path: "id"
-              }
-            }
-          }
-        }
-      }
-    }
-    endpoints {
+              >
+            >
+          >
+        >
+      >
+    >
+    endpoints: <
       key: "EP1"
-      value {
+      value: <
         name: "EP1"
-        param {
+        param: <
           name: "p2"
-          type {
-            type_ref {
-              ref {
-                appname {
+          type: <
+            type_ref: <
+              ref: <
+                appname: <
                   part: "Sample"
                   part: "My Todo App"
-                }
+                >
                 path: "id"
-              }
-            }
-          }
-        }
-      }
-    }
-    endpoints {
+              >
+            >
+          >
+        >
+      >
+    >
+    endpoints: <
       key: "EP2"
-      value {
+      value: <
         name: "EP2"
-        param {
+        param: <
           name: "p3"
-          type {
-            type_ref {
-              ref {
-                appname {
+          type: <
+            type_ref: <
+              ref: <
+                appname: <
                   part: "My Todo App"
-                }
+                >
                 path: "id"
-              }
-            }
-          }
-        }
-      }
-    }
-    endpoints {
+              >
+            >
+          >
+        >
+      >
+    >
+    endpoints: <
       key: "EP3"
-      value {
+      value: <
         name: "EP3"
-        param {
+        param: <
           name: "p4"
-          type {
-            type_ref {
-              ref {
-                appname {
+          type: <
+            type_ref: <
+              ref: <
+                appname: <
                   part: "id"
-                }
-              }
-            }
-          }
-        }
-      }
-    }
-    types {
+                >
+              >
+            >
+          >
+        >
+      >
+    >
+    types: <
       key: "Data"
-      value {
-        tuple {
-          attr_defs {
+      value: <
+        tuple: <
+          attr_defs: <
             key: "id"
-            value {
-              type_ref {
-                context {
-                  appname {
+            value: <
+              type_ref: <
+                context: <
+                  appname: <
                     part: "Browser App"
-                  }
+                  >
                   path: "Data"
-                }
-                ref {
-                  appname {
+                >
+                ref: <
+                  appname: <
                     part: "GO"
                     part: "Sample"
-                  }
+                  >
                   path: "My Todo App"
                   path: "id"
-                }
-              }
-              source_context {
-                start {
+                >
+              >
+              source_context: <
+                file: "tests/test4.sysl"
+                start: <
                   line: 18
-                }
-              }
-            }
-          }
-          attr_defs {
+                  col: 14
+                >
+                end: <
+                  line: 18
+                  col: 42
+                >
+              >
+            >
+          >
+          attr_defs: <
             key: "id2"
-            value {
-              type_ref {
-                context {
-                  appname {
+            value: <
+              type_ref: <
+                context: <
+                  appname: <
                     part: "Browser App"
-                  }
+                  >
                   path: "Data"
-                }
-                ref {
-                  appname {
+                >
+                ref: <
+                  appname: <
                     part: "Sample"
-                  }
+                  >
                   path: "My Todo App"
                   path: "id"
-                }
-              }
-              source_context {
-                start {
+                >
+              >
+              source_context: <
+                file: "tests/test4.sysl"
+                start: <
                   line: 19
-                }
-              }
-            }
-          }
-          attr_defs {
+                  col: 15
+                >
+                end: <
+                  line: 19
+                  col: 37
+                >
+              >
+            >
+          >
+          attr_defs: <
             key: "id3"
-            value {
-              type_ref {
-                context {
-                  appname {
+            value: <
+              type_ref: <
+                context: <
+                  appname: <
                     part: "Browser App"
-                  }
+                  >
                   path: "Data"
-                }
-                ref {
+                >
+                ref: <
                   path: "My Todo App"
                   path: "id"
-                }
-              }
-              source_context {
-                start {
+                >
+              >
+              source_context: <
+                file: "tests/test4.sysl"
+                start: <
                   line: 20
-                }
-              }
-            }
-          }
-        }
-      }
-    }
-  }
-}
-apps {
+                  col: 15
+                >
+                end: <
+                  line: 20
+                  col: 27
+                >
+              >
+            >
+          >
+        >
+      >
+    >
+  >
+>
+apps: <
   key: "GO ::Sample:: My Todo App"
-  value {
-    name {
+  value: <
+    name: <
       part: "GO"
       part: "Sample"
       part: "My Todo App"
-    }
-    types {
+    >
+    types: <
       key: "Todo"
-      value {
-        tuple {
-          attr_defs {
+      value: <
+        tuple: <
+          attr_defs: <
             key: "id"
-            value {
+            value: <
               primitive: INT
-              source_context {
-                start {
+              source_context: <
+                file: "tests/test4.sysl"
+                start: <
                   line: 3
-                }
-              }
-            }
-          }
-          attr_defs {
+                  col: 14
+                >
+                end: <
+                  line: 3
+                  col: 14
+                >
+              >
+            >
+          >
+          attr_defs: <
             key: "note"
-            value {
+            value: <
               primitive: STRING
-              source_context {
-                start {
+              source_context: <
+                file: "tests/test4.sysl"
+                start: <
                   line: 4
-                }
-              }
-            }
-          }
-        }
-      }
-    }
-  }
-}
-apps {
+                  col: 16
+                >
+                end: <
+                  line: 4
+                  col: 16
+                >
+              >
+            >
+          >
+        >
+      >
+    >
+  >
+>
+apps: <
   key: "My Todo App"
-  value {
-    name {
+  value: <
+    name: <
       part: "My Todo App"
-    }
-    types {
+    >
+    types: <
       key: "Todo"
-      value {
-        tuple {
-          attr_defs {
+      value: <
+        tuple: <
+          attr_defs: <
             key: "id"
-            value {
+            value: <
               primitive: INT
-              source_context {
-                start {
+              source_context: <
+                file: "tests/test4.sysl"
+                start: <
                   line: 13
-                }
-              }
-            }
-          }
-          attr_defs {
+                  col: 14
+                >
+                end: <
+                  line: 13
+                  col: 14
+                >
+              >
+            >
+          >
+          attr_defs: <
             key: "note"
-            value {
+            value: <
               primitive: STRING
-              source_context {
-                start {
+              source_context: <
+                file: "tests/test4.sysl"
+                start: <
                   line: 14
-                }
-              }
-            }
-          }
-        }
-      }
-    }
-  }
-}
-apps {
+                  col: 16
+                >
+                end: <
+                  line: 14
+                  col: 16
+                >
+              >
+            >
+          >
+        >
+      >
+    >
+  >
+>
+apps: <
   key: "Sample::My Todo App"
-  value {
-    name {
+  value: <
+    name: <
       part: "Sample"
       part: "My Todo App"
-    }
-    types {
+    >
+    types: <
       key: "Todo"
-      value {
-        tuple {
-          attr_defs {
+      value: <
+        tuple: <
+          attr_defs: <
             key: "id"
-            value {
+            value: <
               primitive: INT
-              source_context {
-                start {
+              source_context: <
+                file: "tests/test4.sysl"
+                start: <
                   line: 8
-                }
-              }
-            }
-          }
-          attr_defs {
+                  col: 14
+                >
+                end: <
+                  line: 8
+                  col: 14
+                >
+              >
+            >
+          >
+          attr_defs: <
             key: "note"
-            value {
+            value: <
               primitive: STRING
-              source_context {
-                start {
+              source_context: <
+                file: "tests/test4.sysl"
+                start: <
                   line: 9
-                }
-              }
-            }
-          }
-        }
-      }
-    }
-  }
-}
+                  col: 16
+                >
+                end: <
+                  line: 9
+                  col: 16
+                >
+              >
+            >
+          >
+        >
+      >
+    >
+  >
+>

--- a/pkg/parse/tests/test4.sysl.golden.textpb
+++ b/pkg/parse/tests/test4.sysl.golden.textpb
@@ -98,8 +98,8 @@ apps {
                 }
                 ref {
                   appname {
-                    part: "GO "
-                    part: " Sample "
+                    part: "GO"
+                    part: "Sample"
                   }
                   path: "My Todo App"
                   path: "id"
@@ -124,7 +124,7 @@ apps {
                 }
                 ref {
                   appname {
-                    part: "Sample "
+                    part: "Sample"
                   }
                   path: "My Todo App"
                   path: "id"

--- a/pkg/parse/tests/test_rest_api.sysl.golden.textpb
+++ b/pkg/parse/tests/test_rest_api.sysl.golden.textpb
@@ -169,8 +169,14 @@ apps: <
                 >
               >
               source_context: <
+                file: "tests/test_rest_api.sysl"
                 start: <
                   line: 46
+                  col: 15
+                >
+                end: <
+                  line: 46
+                  col: 15
                 >
               >
             >
@@ -352,8 +358,14 @@ apps: <
                 >
               >
               source_context: <
+                file: "tests/test_rest_api.sysl"
                 start: <
                   line: 35
+                  col: 13
+                >
+                end: <
+                  line: 35
+                  col: 26
                 >
               >
             >
@@ -373,8 +385,14 @@ apps: <
                 >
               >
               source_context: <
+                file: "tests/test_rest_api.sysl"
                 start: <
                   line: 35
+                  col: 28
+                >
+                end: <
+                  line: 35
+                  col: 43
                 >
               >
             >
@@ -394,8 +412,14 @@ apps: <
                 >
               >
               source_context: <
+                file: "tests/test_rest_api.sysl"
                 start: <
                   line: 35
+                  col: 45
+                >
+                end: <
+                  line: 35
+                  col: 67
                 >
               >
             >
@@ -405,8 +429,14 @@ apps: <
             type: <
               primitive: INT
               source_context: <
+                file: "tests/test_rest_api.sysl"
                 start: <
                   line: 34
+                  col: 17
+                >
+                end: <
+                  line: 34
+                  col: 25
                 >
               >
             >
@@ -467,8 +497,14 @@ apps: <
             type: <
               primitive: INT
               source_context: <
+                file: "tests/test_rest_api.sysl"
                 start: <
                   line: 23
+                  col: 17
+                >
+                end: <
+                  line: 23
+                  col: 23
                 >
               >
             >
@@ -479,8 +515,14 @@ apps: <
               primitive: INT
               opt: true
               source_context: <
+                file: "tests/test_rest_api.sysl"
                 start: <
                   line: 23
+                  col: 27
+                >
+                end: <
+                  line: 23
+                  col: 36
                 >
               >
             >
@@ -491,8 +533,14 @@ apps: <
               primitive: INT
               opt: true
               source_context: <
+                file: "tests/test_rest_api.sysl"
                 start: <
                   line: 23
+                  col: 38
+                >
+                end: <
+                  line: 23
+                  col: 48
                 >
               >
             >
@@ -502,8 +550,14 @@ apps: <
             type: <
               primitive: INT
               source_context: <
+                file: "tests/test_rest_api.sysl"
                 start: <
                   line: 22
+                  col: 9
+                >
+                end: <
+                  line: 22
+                  col: 17
                 >
               >
             >
@@ -696,8 +750,14 @@ apps: <
             type: <
               primitive: INT
               source_context: <
+                file: "tests/test_rest_api.sysl"
                 start: <
                   line: 22
+                  col: 9
+                >
+                end: <
+                  line: 22
+                  col: 17
                 >
               >
             >
@@ -765,8 +825,14 @@ apps: <
             type: <
               primitive: INT
               source_context: <
+                file: "tests/test_rest_api.sysl"
                 start: <
                   line: 22
+                  col: 9
+                >
+                end: <
+                  line: 22
+                  col: 17
                 >
               >
             >
@@ -882,8 +948,14 @@ apps: <
             type: <
               primitive: INT
               source_context: <
+                file: "tests/test_rest_api.sysl"
                 start: <
                   line: 22
+                  col: 9
+                >
+                end: <
+                  line: 22
+                  col: 17
                 >
               >
             >

--- a/pkg/parse/tests/transform.sysl.golden.textpb
+++ b/pkg/parse/tests/transform.sysl.golden.textpb
@@ -1,769 +1,781 @@
-apps {
+apps: <
   key: "TransformApp"
-  value {
-    name {
+  value: <
+    name: <
       part: "TransformApp"
-    }
-    attrs {
+    >
+    attrs: <
       key: "package"
-      value {
+      value: <
         s: "io.sysl.demo.petshop.views"
-      }
-    }
-    types {
+      >
+    >
+    types: <
       key: "AnonType_0__"
-      value {
-        tuple {
-          attr_defs {
+      value: <
+        tuple: <
+          attr_defs: <
             key: "breed"
-            value {
-              type_ref {
-                context {
-                  appname {
+            value: <
+              type_ref: <
+                context: <
+                  appname: <
                     part: "TransformApp"
-                  }
+                  >
                   path: "AnonType_0__"
-                }
-                ref {
-                  appname {
+                >
+                ref: <
+                  appname: <
                     part: "PetShopModel"
-                  }
+                  >
                   path: "Breed"
-                }
-              }
-            }
-          }
-        }
-      }
-    }
-    types {
+                >
+              >
+            >
+          >
+        >
+      >
+    >
+    types: <
       key: "FooType"
-      value {
-        tuple {
-          attr_defs {
+      value: <
+        tuple: <
+          attr_defs: <
             key: "amount"
-            value {
+            value: <
               primitive: DECIMAL
-              constraint {
-                length {
+              constraint: <
+                length: <
                   max: 14
-                }
-              }
-              source_context {
-                start {
+                >
+              >
+              source_context: <
+                file: "tests/transform.sysl"
+                start: <
                   line: 59
-                }
-              }
-            }
-          }
-          attr_defs {
+                  col: 16
+                >
+                end: <
+                  line: 59
+                  col: 26
+                >
+              >
+            >
+          >
+          attr_defs: <
             key: "id"
-            value {
+            value: <
               primitive: INT
-              source_context {
-                start {
+              source_context: <
+                file: "tests/transform.sysl"
+                start: <
                   line: 58
-                }
-              }
-            }
-          }
-        }
-      }
-    }
-    views {
+                  col: 12
+                >
+                end: <
+                  line: 58
+                  col: 12
+                >
+              >
+            >
+          >
+        >
+      >
+    >
+    views: <
       key: "NoArgTransform"
-      value {
-        param {
+      value: <
+        param: <
           name: "number1"
-          type {
+          type: <
             primitive: INT
-          }
-        }
-        param {
+          >
+        >
+        param: <
           name: "foo"
-          type {
-            type_ref {
-              ref {
-                appname {
+          type: <
+            type_ref: <
+              ref: <
+                appname: <
                   part: "Some"
-                }
+                >
                 path: "Type"
-              }
-            }
-          }
-        }
-        ret_type {
-          type_ref {
-            ref {
-              appname {
+              >
+            >
+          >
+        >
+        ret_type: <
+          type_ref: <
+            ref: <
+              appname: <
                 part: "Model"
-              }
+              >
               path: "Type"
-            }
-          }
-        }
-        expr {
-          transform {
-            arg {
+            >
+          >
+        >
+        expr: <
+          transform: <
+            arg: <
               name: "."
-            }
+            >
             scopevar: "scopeVar"
-            stmt {
-              assign {
+            stmt: <
+              assign: <
                 name: "out"
-                expr {
-                  binexpr {
+                expr: <
+                  binexpr: <
                     op: SUB
-                    lhs {
-                      binexpr {
+                    lhs: <
+                      binexpr: <
                         op: ADD
-                        lhs {
+                        lhs: <
                           name: "number"
-                        }
-                        rhs {
-                          literal {
+                        >
+                        rhs: <
+                          literal: <
                             i: 1
-                          }
-                        }
-                      }
-                    }
-                    rhs {
+                          >
+                        >
+                      >
+                    >
+                    rhs: <
                       name: "scopeVar"
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
-        attrs {
+                    >
+                  >
+                >
+              >
+            >
+          >
+        >
+        attrs: <
           key: "patterns"
-          value {
-            a {
-              elt {
+          value: <
+            a: <
+              elt: <
                 s: "partial"
-              }
-            }
-          }
-        }
-      }
-    }
-    views {
+              >
+            >
+          >
+        >
+      >
+    >
+    views: <
       key: "WithArgTransform"
-      value {
-        param {
+      value: <
+        param: <
           name: "number"
-          type {
+          type: <
             primitive: INT
-          }
-        }
-        ret_type {
+          >
+        >
+        ret_type: <
           primitive: INT
-        }
-        expr {
-          transform {
-            arg {
+        >
+        expr: <
+          transform: <
+            arg: <
               name: "argName"
-            }
+            >
             scopevar: "scopeVar"
-            stmt {
-              assign {
+            stmt: <
+              assign: <
                 name: "out"
-                expr {
-                  binexpr {
+                expr: <
+                  binexpr: <
                     op: SUB
-                    lhs {
+                    lhs: <
                       name: "number"
-                    }
-                    rhs {
-                      literal {
+                    >
+                    rhs: <
+                      literal: <
                         i: 1
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
-        attrs {
+                      >
+                    >
+                  >
+                >
+              >
+            >
+          >
+        >
+        attrs: <
           key: "abc"
-          value {
+          value: <
             s: "foo"
-          }
-        }
-      }
-    }
-    views {
+          >
+        >
+      >
+    >
+    views: <
       key: "nestedTransformWithAnonymousType"
-      value {
-        param {
+      value: <
+        param: <
           name: "number"
-          type {
+          type: <
             primitive: INT
-          }
-        }
-        ret_type {
-          type_ref {
-            ref {
-              appname {
+          >
+        >
+        ret_type: <
+          type_ref: <
+            ref: <
+              appname: <
                 part: "Some1"
-              }
+              >
               path: "Type"
-            }
-          }
-        }
-        expr {
-          transform {
-            arg {
+            >
+          >
+        >
+        expr: <
+          transform: <
+            arg: <
               name: "argName"
-            }
+            >
             scopevar: "."
-            stmt {
-              let {
+            stmt: <
+              let: <
                 name: "_breedsAndPets"
-                expr {
-                  transform {
-                    arg {
-                      get_attr {
-                        arg {
+                expr: <
+                  transform: <
+                    arg: <
+                      get_attr: <
+                        arg: <
                           name: "."
-                        }
+                        >
                         attr: "breeds"
-                      }
-                    }
+                      >
+                    >
                     scopevar: "."
-                    stmt {
-                      let {
+                    stmt: <
+                      let: <
                         name: "breedId"
-                        expr {
-                          call {
+                        expr: <
+                          call: <
                             func: "autoinc"
-                          }
-                        }
-                      }
-                    }
-                    stmt {
-                      assign {
+                          >
+                        >
+                      >
+                    >
+                    stmt: <
+                      assign: <
                         name: "breed"
-                        expr {
-                          transform {
-                            arg {
+                        expr: <
+                          transform: <
+                            arg: <
                               name: "."
-                            }
+                            >
                             scopevar: "."
-                            stmt {
-                              assign {
+                            stmt: <
+                              assign: <
                                 name: "breedName"
-                                expr {
-                                  get_attr {
-                                    arg {
+                                expr: <
+                                  get_attr: <
+                                    arg: <
                                       name: "."
-                                    }
+                                    >
                                     attr: "name"
-                                  }
-                                }
-                              }
-                            }
-                          }
-                          type {
-                            type_ref {
-                              context {
-                                appname {
+                                  >
+                                >
+                              >
+                            >
+                          >
+                          type: <
+                            type_ref: <
+                              context: <
+                                appname: <
                                   part: "TransformApp"
-                                }
-                              }
-                              ref {
-                                appname {
+                                >
+                              >
+                              ref: <
+                                appname: <
                                   part: "PetShopModel"
-                                }
+                                >
                                 path: "Breed"
-                              }
-                            }
-                          }
-                        }
-                      }
-                    }
-                  }
-                  type {
-                    set {
-                      type_ref {
-                        context {
-                          appname {
+                              >
+                            >
+                          >
+                        >
+                      >
+                    >
+                  >
+                  type: <
+                    set: <
+                      type_ref: <
+                        context: <
+                          appname: <
                             part: "TransformApp"
-                          }
-                        }
-                        ref {
-                          appname {
+                          >
+                        >
+                        ref: <
+                          appname: <
                             part: "TransformApp"
-                          }
+                          >
                           path: "AnonType_0__"
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          }
-          type {
-            type_ref {
-              context {
-                appname {
+                        >
+                      >
+                    >
+                  >
+                >
+              >
+            >
+          >
+          type: <
+            type_ref: <
+              context: <
+                appname: <
                   part: "TransformApp"
-                }
-              }
-              ref {
-                appname {
+                >
+              >
+              ref: <
+                appname: <
                   part: "Some"
-                }
+                >
                 path: "Type"
-              }
-            }
-          }
-        }
-      }
-    }
-    views {
+              >
+            >
+          >
+        >
+      >
+    >
+    views: <
       key: "noReturnType"
-      value {
-        param {
+      value: <
+        param: <
           name: "number"
-          type {
+          type: <
             primitive: INT
-          }
-        }
-        ret_type {
-          type_ref {
-            context {
-              appname {
+          >
+        >
+        ret_type: <
+          type_ref: <
+            context: <
+              appname: <
                 part: "TransformApp"
-              }
-            }
-            ref {
-              appname {
+              >
+            >
+            ref: <
+              appname: <
                 part: "Some"
-              }
+              >
               path: "Type"
-            }
-          }
-        }
-        expr {
-          transform {
-            arg {
+            >
+          >
+        >
+        expr: <
+          transform: <
+            arg: <
               name: "argName"
-            }
+            >
             scopevar: "."
-            stmt {
-              assign {
+            stmt: <
+              assign: <
                 name: "out"
-                expr {
-                  binexpr {
+                expr: <
+                  binexpr: <
                     op: ADD
-                    lhs {
+                    lhs: <
                       name: "number"
-                    }
-                    rhs {
-                      literal {
+                    >
+                    rhs: <
+                      literal: <
                         s: "foo"
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          }
-          type {
-            type_ref {
-              context {
-                appname {
+                      >
+                    >
+                  >
+                >
+              >
+            >
+          >
+          type: <
+            type_ref: <
+              context: <
+                appname: <
                   part: "TransformApp"
-                }
-              }
-              ref {
-                appname {
+                >
+              >
+              ref: <
+                appname: <
                   part: "Some"
-                }
+                >
                 path: "Type"
-              }
-            }
-          }
-        }
-      }
-    }
-    views {
+              >
+            >
+          >
+        >
+      >
+    >
+    views: <
       key: "noScopeVar"
-      value {
-        param {
+      value: <
+        param: <
           name: "number"
-          type {
+          type: <
             primitive: INT
-          }
-        }
-        ret_type {
+          >
+        >
+        ret_type: <
           primitive: INT
-        }
-        expr {
-          transform {
-            arg {
+        >
+        expr: <
+          transform: <
+            arg: <
               name: "argName"
-            }
+            >
             scopevar: "."
-            stmt {
-              assign {
+            stmt: <
+              assign: <
                 name: "out"
-                expr {
-                  binexpr {
+                expr: <
+                  binexpr: <
                     op: ADD
-                    lhs {
-                      binexpr {
+                    lhs: <
+                      binexpr: <
                         op: MUL
-                        lhs {
+                        lhs: <
                           name: "number"
-                        }
-                        rhs {
-                          literal {
+                        >
+                        rhs: <
+                          literal: <
                             decimal: "1.5"
-                          }
-                        }
-                      }
-                    }
-                    rhs {
-                      literal {
+                          >
+                        >
+                      >
+                    >
+                    rhs: <
+                      literal: <
                         i: 2
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
-    }
-    views {
+                      >
+                    >
+                  >
+                >
+              >
+            >
+          >
+        >
+      >
+    >
+    views: <
       key: "withAnonymousSetOfReturnType"
-      value {
-        param {
+      value: <
+        param: <
           name: "number"
-          type {
+          type: <
             primitive: INT
-          }
-        }
-        ret_type {
+          >
+        >
+        ret_type: <
           primitive: INT
-        }
-        expr {
-          transform {
-            arg {
+        >
+        expr: <
+          transform: <
+            arg: <
               name: "argName"
-            }
+            >
             scopevar: "."
-            stmt {
-              assign {
+            stmt: <
+              assign: <
                 name: "out"
-                expr {
-                  binexpr {
+                expr: <
+                  binexpr: <
                     op: POW
-                    lhs {
+                    lhs: <
                       name: "number"
-                    }
-                    rhs {
-                      binexpr {
+                    >
+                    rhs: <
+                      binexpr: <
                         op: POW
-                        lhs {
-                          literal {
+                        lhs: <
+                          literal: <
                             i: 2
-                          }
-                        }
-                        rhs {
-                          literal {
+                          >
+                        >
+                        rhs: <
+                          literal: <
                             i: 3
-                          }
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
-    }
-    views {
+                          >
+                        >
+                      >
+                    >
+                  >
+                >
+              >
+            >
+          >
+        >
+      >
+    >
+    views: <
       key: "withSetOfReturnType"
-      value {
-        param {
+      value: <
+        param: <
           name: "number"
-          type {
+          type: <
             primitive: INT
-          }
-        }
-        ret_type {
-          set {
-            type_ref {
-              ref {
-                appname {
+          >
+        >
+        ret_type: <
+          set: <
+            type_ref: <
+              ref: <
+                appname: <
                   part: "Some1"
-                }
+                >
                 path: "Type"
-              }
-            }
-          }
-        }
-        expr {
-          transform {
-            arg {
+              >
+            >
+          >
+        >
+        expr: <
+          transform: <
+            arg: <
               name: "argName"
-            }
+            >
             scopevar: "."
-            stmt {
-              assign {
+            stmt: <
+              assign: <
                 name: "out"
-                expr {
-                  binexpr {
+                expr: <
+                  binexpr: <
                     op: DIV
-                    lhs {
+                    lhs: <
                       name: "number"
-                    }
-                    rhs {
+                    >
+                    rhs: <
                       name: "number"
-                    }
-                  }
-                }
-              }
-            }
-          }
-          type {
-            set {
-              type_ref {
-                context {
-                  appname {
+                    >
+                  >
+                >
+              >
+            >
+          >
+          type: <
+            set: <
+              type_ref: <
+                context: <
+                  appname: <
                     part: "TransformApp"
-                  }
-                }
-                ref {
-                  appname {
+                  >
+                >
+                ref: <
+                  appname: <
                     part: "Some"
-                  }
+                  >
                   path: "Type"
-                }
-              }
-            }
-          }
-        }
-      }
-    }
-    views {
+                >
+              >
+            >
+          >
+        >
+      >
+    >
+    views: <
       key: "withSomeReturnType"
-      value {
-        param {
+      value: <
+        param: <
           name: "number"
-          type {
+          type: <
             primitive: INT
-          }
-        }
-        ret_type {
-          type_ref {
-            ref {
-              appname {
+          >
+        >
+        ret_type: <
+          type_ref: <
+            ref: <
+              appname: <
                 part: "Some1"
-              }
+              >
               path: "Type"
-            }
-          }
-        }
-        expr {
-          transform {
-            arg {
+            >
+          >
+        >
+        expr: <
+          transform: <
+            arg: <
               name: "argName"
-            }
+            >
             scopevar: "."
-            stmt {
-              assign {
+            stmt: <
+              assign: <
                 name: "out"
-                expr {
-                  binexpr {
+                expr: <
+                  binexpr: <
                     op: ADD
-                    lhs {
+                    lhs: <
                       name: "number"
-                    }
-                    rhs {
-                      literal {
+                    >
+                    rhs: <
+                      literal: <
                         s: "foo"
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          }
-          type {
-            type_ref {
-              context {
-                appname {
+                      >
+                    >
+                  >
+                >
+              >
+            >
+          >
+          type: <
+            type_ref: <
+              context: <
+                appname: <
                   part: "TransformApp"
-                }
-              }
-              ref {
-                appname {
+                >
+              >
+              ref: <
+                appname: <
                   part: "Some"
-                }
+                >
                 path: "Type"
-              }
-            }
-          }
-        }
-      }
-    }
-    views {
+              >
+            >
+          >
+        >
+      >
+    >
+    views: <
       key: "withSomeReturnType2"
-      value {
-        param {
+      value: <
+        param: <
           name: "number"
-          type {
-            type_ref {
-              ref {
-                appname {
+          type: <
+            type_ref: <
+              ref: <
+                appname: <
                   part: "Sometype"
-                }
-              }
-            }
-          }
-        }
-        ret_type {
-          set {
-            type_ref {
-              ref {
-                appname {
+                >
+              >
+            >
+          >
+        >
+        ret_type: <
+          set: <
+            type_ref: <
+              ref: <
+                appname: <
                   part: "Sometype"
-                }
-              }
-            }
-          }
-        }
-        expr {
-          transform {
-            arg {
+                >
+              >
+            >
+          >
+        >
+        expr: <
+          transform: <
+            arg: <
               name: "argName"
-            }
+            >
             scopevar: "."
-            stmt {
-              assign {
+            stmt: <
+              assign: <
                 name: "out"
-                expr {
-                  binexpr {
+                expr: <
+                  binexpr: <
                     op: ADD
-                    lhs {
+                    lhs: <
                       name: "number"
-                    }
-                    rhs {
-                      literal {
+                    >
+                    rhs: <
+                      literal: <
                         s: "foo"
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          }
-          type {
-            type_ref {
-              context {
-                appname {
+                      >
+                    >
+                  >
+                >
+              >
+            >
+          >
+          type: <
+            type_ref: <
+              context: <
+                appname: <
                   part: "TransformApp"
-                }
-              }
-              ref {
-                appname {
+                >
+              >
+              ref: <
+                appname: <
                   part: "Sometype"
-                }
-              }
-            }
-          }
-        }
-      }
-    }
-    views {
+                >
+              >
+            >
+          >
+        >
+      >
+    >
+    views: <
       key: "withSomeReturnType3"
-      value {
-        param {
+      value: <
+        param: <
           name: "foo"
-          type {
-            set {
-              type_ref {
-                ref {
-                  appname {
+          type: <
+            set: <
+              type_ref: <
+                ref: <
+                  appname: <
                     part: "Model"
-                  }
+                  >
                   path: "SomeType"
-                }
-              }
-            }
-          }
-        }
-        ret_type {
-          set {
-            type_ref {
-              context {
-                appname {
+                >
+              >
+            >
+          >
+        >
+        ret_type: <
+          set: <
+            type_ref: <
+              context: <
+                appname: <
                   part: "TransformApp"
-                }
-              }
-              ref {
-                appname {
+                >
+              >
+              ref: <
+                appname: <
                   part: "Some"
-                }
+                >
                 path: "Type"
-              }
-            }
-          }
-        }
-        expr {
-          transform {
-            arg {
+              >
+            >
+          >
+        >
+        expr: <
+          transform: <
+            arg: <
               name: "argName"
-            }
+            >
             scopevar: "."
-            stmt {
-              assign {
+            stmt: <
+              assign: <
                 name: "out"
-                expr {
-                  binexpr {
+                expr: <
+                  binexpr: <
                     op: ADD
-                    lhs {
+                    lhs: <
                       name: "number"
-                    }
-                    rhs {
-                      literal {
+                    >
+                    rhs: <
+                      literal: <
                         s: "foo"
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          }
-          type {
-            set {
-              type_ref {
-                context {
-                  appname {
+                      >
+                    >
+                  >
+                >
+              >
+            >
+          >
+          type: <
+            set: <
+              type_ref: <
+                context: <
+                  appname: <
                     part: "TransformApp"
-                  }
-                }
-                ref {
-                  appname {
+                  >
+                >
+                ref: <
+                  appname: <
                     part: "Some"
-                  }
+                  >
                   path: "Type"
-                }
-              }
-            }
-          }
-        }
-      }
-    }
-  }
-}
+                >
+              >
+            >
+          >
+        >
+      >
+    >
+  >
+>

--- a/pkg/parse/tests/with_spaces.sysl.golden.textpb
+++ b/pkg/parse/tests/with_spaces.sysl.golden.textpb
@@ -1,172 +1,208 @@
-apps {
+apps: <
   key: "AnotherApp"
-  value {
-    name {
+  value: <
+    name: <
       part: "AnotherApp"
-    }
-    types {
+    >
+    types: <
       key: "SecondTable"
-      value {
-        tuple {
-          attr_defs {
+      value: <
+        tuple: <
+          attr_defs: <
             key: "Id"
-            value {
-              type_ref {
-                context {
-                  appname {
+            value: <
+              type_ref: <
+                context: <
+                  appname: <
                     part: "AnotherApp"
-                  }
+                  >
                   path: "SecondTable"
-                }
-                ref {
-                  appname {
+                >
+                ref: <
+                  appname: <
                     part: "App with"
-                  }
+                  >
                   path: "space"
                   path: "Id"
-                }
-              }
-              source_context {
-                start {
+                >
+              >
+              source_context: <
+                file: "tests/with_spaces.sysl"
+                start: <
                   line: 11
-                }
-              }
-            }
-          }
-          attr_defs {
+                  col: 14
+                >
+                end: <
+                  line: 11
+                  col: 32
+                >
+              >
+            >
+          >
+          attr_defs: <
             key: "Id2"
-            value {
-              type_ref {
-                context {
-                  appname {
+            value: <
+              type_ref: <
+                context: <
+                  appname: <
                     part: "AnotherApp"
-                  }
+                  >
                   path: "SecondTable"
-                }
-                ref {
-                  appname {
+                >
+                ref: <
+                  appname: <
                     part: "App with"
-                  }
+                  >
                   path: "space"
                   path: "Id"
-                }
-              }
-              source_context {
-                start {
+                >
+              >
+              source_context: <
+                file: "tests/with_spaces.sysl"
+                start: <
                   line: 12
-                }
-              }
-            }
-          }
-          attr_defs {
+                  col: 15
+                >
+                end: <
+                  line: 12
+                  col: 35
+                >
+              >
+            >
+          >
+          attr_defs: <
             key: "Id3"
-            value {
-              type_ref {
-                context {
-                  appname {
+            value: <
+              type_ref: <
+                context: <
+                  appname: <
                     part: "AnotherApp"
-                  }
+                  >
                   path: "SecondTable"
-                }
-                ref {
-                  appname {
+                >
+                ref: <
+                  appname: <
                     part: "My"
                     part: "App with"
-                  }
+                  >
                   path: "space"
                   path: "Id"
-                }
-              }
-              source_context {
-                start {
+                >
+              >
+              source_context: <
+                file: "tests/with_spaces.sysl"
+                start: <
                   line: 13
-                }
-              }
-            }
-          }
-          attr_defs {
+                  col: 15
+                >
+                end: <
+                  line: 13
+                  col: 41
+                >
+              >
+            >
+          >
+          attr_defs: <
             key: "Id4"
-            value {
-              type_ref {
-                context {
-                  appname {
+            value: <
+              type_ref: <
+                context: <
+                  appname: <
                     part: "AnotherApp"
-                  }
+                  >
                   path: "SecondTable"
-                }
-                ref {
-                  appname {
+                >
+                ref: <
+                  appname: <
                     part: "My"
                     part: "App with"
-                  }
+                  >
                   path: "space"
                   path: "Id"
-                }
-              }
-              source_context {
-                start {
+                >
+              >
+              source_context: <
+                file: "tests/with_spaces.sysl"
+                start: <
                   line: 14
-                }
-              }
-            }
-          }
-        }
-      }
-    }
-  }
-}
-apps {
+                  col: 15
+                >
+                end: <
+                  line: 14
+                  col: 44
+                >
+              >
+            >
+          >
+        >
+      >
+    >
+  >
+>
+apps: <
   key: "App with :: space"
-  value {
-    name {
+  value: <
+    name: <
       part: "App with"
       part: "space"
-    }
-    types {
+    >
+    types: <
       key: "SomeTable"
-      value {
-        tuple {
-          attr_defs {
+      value: <
+        tuple: <
+          attr_defs: <
             key: "Id"
-            value {
+            value: <
               primitive: INT
-              source_context {
-                start {
+              source_context: <
+                file: "tests/with_spaces.sysl"
+                start: <
                   line: 3
-                }
-              }
-            }
-          }
-        }
-      }
-    }
-  }
-}
-apps {
+                  col: 14
+                >
+                end: <
+                  line: 3
+                  col: 14
+                >
+              >
+            >
+          >
+        >
+      >
+    >
+  >
+>
+apps: <
   key: "My ::  App with :: space"
-  value {
-    name {
+  value: <
+    name: <
       part: "My"
       part: "App with"
       part: "space"
-    }
-    types {
+    >
+    types: <
       key: "SomeTable"
-      value {
-        tuple {
-          attr_defs {
+      value: <
+        tuple: <
+          attr_defs: <
             key: "Id"
-            value {
+            value: <
               primitive: INT
-              source_context {
-                start {
+              source_context: <
+                file: "tests/with_spaces.sysl"
+                start: <
                   line: 7
-                }
-              }
-            }
-          }
-        }
-      }
-    }
-  }
-}
+                  col: 14
+                >
+                end: <
+                  line: 7
+                  col: 14
+                >
+              >
+            >
+          >
+        >
+      >
+    >
+  >
+>

--- a/pkg/parse/tests/with_spaces.sysl.golden.textpb
+++ b/pkg/parse/tests/with_spaces.sysl.golden.textpb
@@ -20,7 +20,7 @@ apps {
                 }
                 ref {
                   appname {
-                    part: "App with "
+                    part: "App with"
                   }
                   path: "space"
                   path: "Id"
@@ -45,7 +45,7 @@ apps {
                 }
                 ref {
                   appname {
-                    part: "App with  "
+                    part: "App with"
                   }
                   path: "space"
                   path: "Id"
@@ -70,8 +70,8 @@ apps {
                 }
                 ref {
                   appname {
-                    part: "My "
-                    part: " App with  "
+                    part: "My"
+                    part: "App with"
                   }
                   path: "space"
                   path: "Id"
@@ -96,8 +96,8 @@ apps {
                 }
                 ref {
                   appname {
-                    part: "My   "
-                    part: "  App with  "
+                    part: "My"
+                    part: "App with"
                   }
                   path: "space"
                   path: "Id"

--- a/pkg/parse/utils.go
+++ b/pkg/parse/utils.go
@@ -100,7 +100,7 @@ func primitiveFromNativeDataType(native antlr.TerminalNode) (*sysl.Type_Primitiv
 	return &sysl.Type_Primitive_{Primitive: primitiveType}, constraint
 }
 
-type pathStack struct {
+type PathStack struct {
 	sep   string
 	parts []string
 
@@ -108,38 +108,40 @@ type pathStack struct {
 	prefix string
 }
 
-func NewPathStack(sep string) pathStack {
-	return pathStack{
+func NewPathStack(sep string) PathStack {
+	return PathStack{
 		sep:   sep,
 		parts: []string{},
 	}
 }
 
-func (p pathStack) Get() string {
+func (p PathStack) Get() string {
 	return p.path
 }
 
-func (p *pathStack) Push(items ...string) string {
+func (p *PathStack) Push(items ...string) string {
 	p.parts = append(p.parts, items...)
 	return p.update()
 }
 
-func (p *pathStack) Pop() string {
+func (p *PathStack) Pop() string {
 	p.parts = p.parts[:len(p.parts)-1]
 	return p.update()
 }
 
-func (p *pathStack) Reset() string {
+func (p *PathStack) Reset() string {
 	p.parts = []string{}
 	return p.update()
 }
 
-func (p *pathStack) update() string {
-	p.path = p.prefix + strings.Join(p.parts, p.sep)
-	return p.path
+// Parts() clones the path items into a new slice so that it is safe to store
+func (p PathStack) Parts() []string {
+	out := make([]string, len(p.parts))
+	copy(out, p.parts)
+	return out
 }
 
-func (p *pathStack) setPrefix(prefix string) string {
-	p.prefix = prefix
-	return p.update()
+func (p *PathStack) update() string {
+	p.path = p.prefix + strings.Join(p.parts, p.sep)
+	return p.path
 }

--- a/pkg/parse/utils.go
+++ b/pkg/parse/utils.go
@@ -138,9 +138,7 @@ func (p *PathStack) Reset() string {
 
 // Parts() clones the path items into a new slice so that it is safe to store
 func (p PathStack) Parts() []string {
-	out := make([]string, len(p.parts))
-	copy(out, p.parts)
-	return out
+	return append([]string{}, p.parts...)
 }
 
 func (p *PathStack) update() string {

--- a/pkg/parse/utils.go
+++ b/pkg/parse/utils.go
@@ -120,7 +120,9 @@ func (p PathStack) Get() string {
 }
 
 func (p *PathStack) Push(items ...string) string {
-	p.parts = append(p.parts, items...)
+	for _, i := range items {
+		p.parts = append(p.parts, strings.TrimSpace(i))
+	}
 	return p.update()
 }
 

--- a/pkg/parse/utils.go
+++ b/pkg/parse/utils.go
@@ -99,3 +99,47 @@ func primitiveFromNativeDataType(native antlr.TerminalNode) (*sysl.Type_Primitiv
 	}
 	return &sysl.Type_Primitive_{Primitive: primitiveType}, constraint
 }
+
+type pathStack struct {
+	sep   string
+	parts []string
+
+	path   string
+	prefix string
+}
+
+func NewPathStack(sep string) pathStack {
+	return pathStack{
+		sep:   sep,
+		parts: []string{},
+	}
+}
+
+func (p pathStack) Get() string {
+	return p.path
+}
+
+func (p *pathStack) Push(items ...string) string {
+	p.parts = append(p.parts, items...)
+	return p.update()
+}
+
+func (p *pathStack) Pop() string {
+	p.parts = p.parts[:len(p.parts)-1]
+	return p.update()
+}
+
+func (p *pathStack) Reset() string {
+	p.parts = []string{}
+	return p.update()
+}
+
+func (p *pathStack) update() string {
+	p.path = p.prefix + strings.Join(p.parts, p.sep)
+	return p.path
+}
+
+func (p *pathStack) setPrefix(prefix string) string {
+	p.prefix = prefix
+	return p.update()
+}


### PR DESCRIPTION
Some structural refactoring of the antlr parser listener to allow for parser simplification to follow...

BasicallyI noticed that the code was reusing struct fields in multiple places for different purposes which meant makes working in this codebase hell.

* Splits usages of `s.typename []string` into distinct fields for each of its uses (including:)
      1. keeping track of names used to build up references to types
      1. endpoint paths
      1. collector paths
      1. view names(!)
* Adds a simple stack type to replace the multiple ad-hock stacks that are used with the `typename` and `url_prefix` fields
* Replace the repeated map lookup to get the current modules app with a helper func

@anz-bank/sysl-developers


Reviewers: I would look at the commits indivually instead of the full diff, each is self contained.