### PR TITLE
Append newline to generated svg file

### DIFF
--- a/cmd/sysl/codegen.go
+++ b/cmd/sysl/codegen.go
@@ -330,7 +330,7 @@ func outputToFiles(output []*CodeGenOutput, fs afero.Fs) error {
 		if err != nil {
 			return errors.Wrapf(err, "unable to create %q", o.filename)
 		}
-		logrus.Warningln("Writing file: " + f.Name())
+		logrus.Infoln("Writing file: " + f.Name())
 		if err := Serialize(f, " ", o.output); err != nil {
 			return errors.Wrapf(err, "error writing to %q", o.filename)
 		}

--- a/cmd/sysl/diagutil.go
+++ b/cmd/sysl/diagutil.go
@@ -28,7 +28,7 @@ func OutputPlantuml(output, plantuml, umlInput string, fs afero.Fs) error {
 		if err != nil {
 			return err
 		}
-		return errors.Wrapf(afero.WriteFile(fs, output, out, os.ModePerm), "writing %q", output)
+		return errors.Wrapf(afero.WriteFile(fs, output, append(out, byte('\n')), os.ModePerm), "writing %q", output)
 
 	case "uml":
 		output := output[:l-3]


### PR DESCRIPTION
Fixes #511  .

Changes proposed in this pull request:
- append newline at the end of the generated svg file
- change the log level of writing file from WARN to INFO

@anz-bank/sysl-developers
