### PR TITLE
Remove spurious logging

### DIFF
--- a/pkg/transforms/templates.go
+++ b/pkg/transforms/templates.go
@@ -2,7 +2,6 @@ package transforms
 
 import (
 	"fmt"
-	"log"
 	"sort"
 
 	"github.com/anz-bank/sysl/pkg/eval"
@@ -70,7 +69,6 @@ func (t *templated) Apply(mod *sysl.Module, appNames ...string) map[string]*sysl
 	} else if fname, data, err := fn(evalRes); err == nil {
 		result[fname] = eval.MakeValueString(data)
 	}
-	log.Printf("%+v", result)
 	logrus.Tracef("Apply result: %+v", result)
 	return result
 }


### PR DESCRIPTION
The 'tmpl' subcommand had a `log.Printf` at the end as well as a
logrus.Tracef outputting the same data. The standard Go "log" package is
not used anywhere else, so get rid of it here. This cleans up the output
of the `sysl tmpl` subcommand.

cc: @anz-bank/sysl-developers