### PR TITLE
fix: release trigger event

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,14 @@
+Please attach **WIP** tag when this PR is still work in progress.
+Please attach **breaking-change** tag if this PR potentially causes other components to fail or changes previous sysl executable's behaviour.
+
+Fixes # .
+
+Changes proposed in this pull request:
+- 
+- 
+
+Checklist:
+- [ ] Added related tests
+- [ ] Made corresponding changes to the documentation
+
+@anz-bank/sysl-developers

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,8 +3,6 @@ name: Release
 
 on:
   push:
-    branches:
-      - master
     tags:
       - 'v*.*.*'
 
@@ -12,6 +10,7 @@ jobs:
   release-sysl:
     name: Release Sysl
     runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/master'
     steps:
       - name: Set up Go 1.13
         uses: actions/setup-go@v1


### PR DESCRIPTION
Changes proposed in this pull request:
- update release trigger condition
- put back default PR template because [GitHub doesn't support multiple PR templates at this moment](https://github.community/t5/How-to-use-Git-and-GitHub/Multiple-Pull-Request-Templates/td-p/20909)

@anz-bank/sysl-developers
