### PR TITLE
Diagram pkg #patch

### DIFF
--- a/cmd/sysl/cmd_datamodel.go
+++ b/cmd/sysl/cmd_datamodel.go
@@ -5,6 +5,7 @@ import (
 	"regexp"
 	"strings"
 
+	"github.com/anz-bank/sysl/pkg/diagrams"
 	"github.com/anz-bank/sysl/pkg/sequencediagram"
 
 	"github.com/anz-bank/sysl/pkg/cmdutils"
@@ -123,7 +124,7 @@ func generateDataModels(datagenParams *cmdutils.CmdContextParamDatagen,
 }
 
 type datamodelCmd struct {
-	plantumlmixin
+	diagrams.Plantumlmixin
 	cmdutils.CmdContextParamDatagen
 }
 

--- a/cmd/sysl/cmd_ints.go
+++ b/cmd/sysl/cmd_ints.go
@@ -4,6 +4,7 @@ import (
 	"regexp"
 
 	"github.com/anz-bank/sysl/pkg/cmdutils"
+	"github.com/anz-bank/sysl/pkg/diagrams"
 
 	sysl "github.com/anz-bank/sysl/pkg/sysl"
 	"github.com/anz-bank/sysl/pkg/syslutil"
@@ -55,7 +56,7 @@ func GenerateIntegrations(intgenParams *cmdutils.CmdContextParamIntgen,
 }
 
 type intsCmd struct {
-	plantumlmixin
+	diagrams.Plantumlmixin
 	cmdutils.CmdContextParamIntgen
 }
 

--- a/cmd/sysl/cmd_sequencediagram.go
+++ b/cmd/sysl/cmd_sequencediagram.go
@@ -2,12 +2,13 @@ package main
 
 import (
 	"github.com/anz-bank/sysl/pkg/cmdutils"
+	"github.com/anz-bank/sysl/pkg/diagrams"
 	"github.com/anz-bank/sysl/pkg/sequencediagram"
 	"gopkg.in/alecthomas/kingpin.v2"
 )
 
 type sequenceDiagramCmd struct {
-	plantumlmixin
+	diagrams.Plantumlmixin
 	endpointFormat string
 	appFormat      string
 	title          string
@@ -40,7 +41,7 @@ func (p *sequenceDiagramCmd) Configure(app *kingpin.Application) *kingpin.CmdCla
 
 	cmd.Flag("title", "diagram title").Short('t').StringVar(&p.title)
 
-	p.plantumlmixin.AddFlag(cmd)
+	p.Plantumlmixin.AddFlag(cmd)
 
 	cmd.Flag("output",
 		"output file (default: %(epname).png)",

--- a/cmd/sysl/plantuml.go
+++ b/cmd/sysl/plantuml.go
@@ -3,6 +3,8 @@ package main
 import (
 	"os"
 
+	"github.com/anz-bank/sysl/pkg/diagrams"
+
 	"github.com/spf13/afero"
 
 	"gopkg.in/alecthomas/kingpin.v2"
@@ -37,7 +39,7 @@ func (p *plantumlmixin) Value() string {
 
 func (p *plantumlmixin) GenerateFromMap(m map[string]string, fs afero.Fs) error {
 	for k, v := range m {
-		if err := OutputPlantuml(k, p.Value(), v, fs); err != nil {
+		if err := diagrams.OutputPlantuml(k, p.Value(), v, fs); err != nil {
 			return err
 		}
 	}

--- a/pkg/diagrams/diagutil.go
+++ b/pkg/diagrams/diagutil.go
@@ -1,4 +1,4 @@
-package main
+package diagrams
 
 import (
 	"bytes"

--- a/pkg/diagrams/diagutil_test.go
+++ b/pkg/diagrams/diagutil_test.go
@@ -1,4 +1,4 @@
-package main
+package diagrams
 
 import (
 	"testing"

--- a/pkg/diagrams/plantuml.go
+++ b/pkg/diagrams/plantuml.go
@@ -1,9 +1,7 @@
-package main
+package diagrams
 
 import (
 	"os"
-
-	"github.com/anz-bank/sysl/pkg/diagrams"
 
 	"github.com/spf13/afero"
 
@@ -15,11 +13,11 @@ const (
 	PlantUMLDefault = "http://localhost:8080/plantuml"
 )
 
-type plantumlmixin struct {
+type Plantumlmixin struct {
 	value string
 }
 
-func (p *plantumlmixin) AddFlag(cmd *kingpin.CmdClause) {
+func (p *Plantumlmixin) AddFlag(cmd *kingpin.CmdClause) {
 	cmd.Flag("plantuml",
 		"base url of plantuml server (default: "+PlantUMLEnvVar+" or "+
 			PlantUMLDefault+" see "+
@@ -27,7 +25,7 @@ func (p *plantumlmixin) AddFlag(cmd *kingpin.CmdClause) {
 	).Short('p').StringVar(&p.value)
 }
 
-func (p *plantumlmixin) Value() string {
+func (p *Plantumlmixin) Value() string {
 	if p.value == "" {
 		p.value = os.Getenv(PlantUMLEnvVar)
 		if p.value == "" {
@@ -37,9 +35,9 @@ func (p *plantumlmixin) Value() string {
 	return p.value
 }
 
-func (p *plantumlmixin) GenerateFromMap(m map[string]string, fs afero.Fs) error {
+func (p *Plantumlmixin) GenerateFromMap(m map[string]string, fs afero.Fs) error {
 	for k, v := range m {
-		if err := diagrams.OutputPlantuml(k, p.Value(), v, fs); err != nil {
+		if err := OutputPlantuml(k, p.Value(), v, fs); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
Continues #478 

Changes proposed in this pull request:
- Moves common diagram creation to `pkg/diagrams` this package is mainly used in cmd_sequencediagram and cmd_datamodel and needs to be available to other packages as well


@anz-bank/sysl-developers
