### PR TITLE
Sysl printer

### DIFF
--- a/pkg/printer/alphabetical.go
+++ b/pkg/printer/alphabetical.go
@@ -1,0 +1,49 @@
+// alphabetical.go are the functions to get a sorted list of keys from sysls map types
+// Unfortunately go doesn't allow generics and pointer types don't implement empty interfaces
+// so map[string]interface{} doesn't cut it
+
+package printer
+
+import (
+	"sort"
+
+	"github.com/anz-bank/sysl/pkg/sysl"
+)
+
+func alphabeticalAttributes(m map[string]*sysl.Attribute) []string {
+	keys := make([]string, 0, len(m))
+	for k, _ := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+func alphabeticalApplications(m map[string]*sysl.Application) []string {
+	keys := make([]string, 0, len(m))
+	for k, _ := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+func alphabeticalEndpoints(m map[string]*sysl.Endpoint) []string {
+	keys := make([]string, 0, len(m))
+	for k, _ := range m {
+		if k != "" {
+			keys = append(keys, k)
+		}
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+func alphabeticalTypes(m map[string]*sysl.Type) []string {
+	keys := make([]string, 0, len(m))
+	for k, _ := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}

--- a/pkg/printer/printer.go
+++ b/pkg/printer/printer.go
@@ -1,0 +1,141 @@
+// package printer prints out sysl datamodels back to source code using the Printer struct.
+// Source code does not have complete fidelity, and elements will be printed out in alphabetical order.
+package printer
+
+import (
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/anz-bank/sysl/pkg/sysl"
+	"github.com/anz-bank/sysl/pkg/syslutil"
+)
+
+// Printer prints sysl data structures out to source code
+type Printer struct {
+	io.Writer
+}
+
+// NewPrinter returns a printer that can be used to print out sysl source code from data structures
+func NewPrinter(buf io.Writer) *Printer {
+	return &Printer{Writer: buf}
+}
+
+// PrintModule Prints a whole module, calling
+func (p *Printer) PrintModule(mod *sysl.Module) {
+	for _, key := range alphabeticalApplications(mod.Apps) {
+		p.PrintApplication(mod.Apps[key])
+	}
+}
+
+// PrintApplication prints applications:
+// App:
+func (p *Printer) PrintApplication(A *sysl.Application) {
+	fmt.Fprintf(p.Writer, "%s:\n", strings.Join(A.Name.GetPart(), ""))
+	for _, key := range alphabeticalAttributes(A.Attrs) {
+		p.PrintAttrs(key, A.Attrs[key])
+	}
+	for _, key := range alphabeticalTypes(A.Types) {
+		p.PrintTypeDecl(key, A.Types[key])
+	}
+	for _, key := range alphabeticalEndpoints(A.Endpoints) {
+		p.PrintEndpoint(A.Endpoints[key])
+	}
+}
+
+// PrintTypeDecl prints Type declerations:
+// !type Foo:
+//     this <: string
+func (p *Printer) PrintTypeDecl(key string, t *sysl.Type) {
+	fmt.Fprintf(p.Writer, "    !type %s:\n", key)
+	if tuple := t.GetTuple(); tuple != nil {
+		for _, key := range alphabeticalTypes(tuple.AttrDefs) {
+			typeClass, typeIdent := syslutil.GetTypeDetail(tuple.AttrDefs[key])
+			if typeClass == "primitive" {
+				typeIdent = strings.ToLower(typeIdent)
+			}
+			fmt.Fprintf(p.Writer, "        %s <: %s\n", key, typeIdent)
+		}
+	}
+
+}
+
+// PrintEndpoint prints endpoints:
+// Endpoint:
+func (p *Printer) PrintEndpoint(E *sysl.Endpoint) {
+	fmt.Fprintf(p.Writer, "    %s", E.Name)
+
+	if len(E.Param) != 0 {
+		p.PrintParam(E.Param)
+	}
+	fmt.Fprintf(p.Writer, ":\n")
+	for _, stmnt := range E.Stmt {
+		p.PrintStatement(stmnt)
+	}
+}
+
+// PrintParam prints Parameters:
+// Endpoint(This <: ParamHere):
+func (p *Printer) PrintParam(params []*sysl.Param) {
+	ans := "("
+	for i, param := range params {
+		ans += param.Name + " <: " + p.ParamType(param)
+		if i != len(params)-1 {
+			ans += ","
+		}
+	}
+	ans += ")"
+	fmt.Fprint(p.Writer, ans)
+}
+
+// PrintAttrs prints different statements:
+// return string
+// My <- call
+// lookup db
+func (p *Printer) PrintStatement(S *sysl.Statement) {
+	if call := S.GetCall(); call != nil {
+		p.PrintCall(call)
+	}
+	if action := S.GetAction(); action != nil {
+		p.PrintAction(action)
+	}
+	if ret := S.GetRet(); ret != nil {
+		p.PrintReturn(ret)
+	}
+}
+
+// PrintReturn prints return statements:
+// return foo <: type
+func (p *Printer) PrintReturn(R *sysl.Return) {
+	fmt.Fprintf(p.Writer, "        return %s\n", R.Payload)
+}
+
+// PrintAction prints actions:
+// lookup data
+func (p *Printer) PrintAction(A *sysl.Action) {
+	fmt.Fprintf(p.Writer, "        %s\n", A.GetAction())
+}
+
+// PrintAttrs prints Attributes:
+// @owner="server"
+func (p *Printer) PrintAttrs(key string, A *sysl.Attribute) {
+	fmt.Fprintf(p.Writer, "    @%s=\"%s\"\n", key, A.GetS())
+}
+
+// ParamType prints:
+// foo(this <: <ParamType>):
+func (p *Printer) ParamType(P *sysl.Param) string {
+	if P.Type == nil {
+		return ""
+	}
+	if P.Type.GetTypeRef() == nil {
+		return ""
+	}
+	return strings.Join(P.Type.GetTypeRef().Ref.Appname.Part, "")
+}
+
+// PrintCall prints:
+// AnApp <- AnEndpoint
+func (p *Printer) PrintCall(c *sysl.Call) {
+	fmt.Fprintf(p.Writer, "        %s <- %s\n", strings.Join(c.Target.GetPart(), ""), c.GetEndpoint())
+}

--- a/pkg/printer/printer_test.go
+++ b/pkg/printer/printer_test.go
@@ -1,0 +1,28 @@
+package printer
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/alecthomas/assert"
+
+	"github.com/spf13/afero"
+
+	"github.com/anz-bank/sysl/pkg/loader"
+	"github.com/anz-bank/sysl/pkg/syslutil"
+	"github.com/sirupsen/logrus"
+)
+
+func TestPrinting(t *testing.T) {
+	_, fs := syslutil.WriteToMemOverlayFs("../../tests")
+	log := logrus.Logger{}
+
+	module, _, _ := loader.LoadSyslModule("/", "printer.sysl", fs, &log)
+
+	fileBytes, _ := afero.ReadFile(fs, "printer.sysl")
+
+	var buf bytes.Buffer
+	pr := NewPrinter(&buf)
+	pr.PrintModule(module)
+	assert.Equal(t, buf.String(), string(fileBytes))
+}

--- a/tests/printer.sysl
+++ b/tests/printer.sysl
@@ -1,0 +1,41 @@
+APIGateway:
+    @owner="client"
+    !type LoginResponse:
+        message <: string
+    Login:
+        Server <- Login
+        return ret <: APIGateway.LoginResponse
+DB:
+    @owner="server"
+    Query:
+        lookup data
+        return ret <: data
+    Save:
+        ...
+DBAAA:
+    @owner="server"
+    Query:
+        lookup data
+        return ret <: data
+    Save:
+        ...
+MobileApp:
+    @owner="client"
+    Login:
+        APIGateway <- Login
+Project:
+    @seqtitle="Diagram"
+    Seq:
+        MobileApp <- Login
+Server:
+    @owner="server"
+    !type LoginData:
+        password <: string
+        username <: string
+    !type LoginResponse:
+        message <: string
+    Login(data <: LoginData):
+        build query
+        DB <- Query
+        check result
+        return ret <: Server.LoginResponse


### PR DESCRIPTION
Starts on #640 

Changes proposed in this pull request:
- Add printer package that can print out sysl data models back into source code

This doesn't reach full fidelity, for example
- `[attribute= "foo"]` gets turned into `@attribute = "foo"`
- Order of applications and endpoints (anything stored into a map) is printed out alphabetically
- Doesn't yet support more complex sysl files like `Projects` or the weird :: syntax 

- REST syntax like:
```
  /moredep:
    /{id<:int}:
      GET:
        return Dep
      POST:
        return Dep
```

gets turned into (still valid)

```
GET /moredep/{id<:int}:
    return Dep
POST /moredep/{id<:int}:
    return Dep
```



Checklist:
- [x] Added related tests
- [x] Made corresponding changes to the documentation

@anz-bank/sysl-developers
