### PR TITLE
Test rig generation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,3 @@
-PKGS := $(shell go list ./... | grep -v /vendor)
-
 BIN_DIR := $(GOPATH)/bin
 
 # Try to detect current branch if not provided from environment

--- a/cmd/sysl/cmd_runner.go
+++ b/cmd/sysl/cmd_runner.go
@@ -72,6 +72,7 @@ func (r *cmdRunner) Configure(app *kingpin.Application) error {
 		&envCmd{},
 		&templateCmd{},
 		&modCmd{},
+		&testRigCmd{},
 	}
 	r.commands = map[string]cmdutils.Command{}
 

--- a/cmd/sysl/cmd_testrig.go
+++ b/cmd/sysl/cmd_testrig.go
@@ -42,7 +42,7 @@ func (p *testRigCmd) Configure(app *kingpin.Application) *kingpin.CmdClause {
 }
 
 func (p *testRigCmd) Execute(args cmdutils.ExecuteArgs) error {
-	err := testrig.GenerateRig(*p.TemplateFileName, *p.OutputDir, args.Modules)
+	err := testrig.GenerateRig(args.Filesystem, *p.TemplateFileName, *p.OutputDir, args.Modules)
 	if err != nil {
 		return err
 	}

--- a/cmd/sysl/cmd_testrig.go
+++ b/cmd/sysl/cmd_testrig.go
@@ -1,0 +1,51 @@
+package main
+
+import (
+	"github.com/anz-bank/sysl/pkg/cmdutils"
+	"github.com/anz-bank/sysl/pkg/testrig"
+	"gopkg.in/alecthomas/kingpin.v2"
+)
+
+type testRigCmd struct {
+	TemplateFileName *string
+	OutputDir        *string
+}
+
+func (p *testRigCmd) Name() string {
+	return "test-rig"
+}
+
+func (p *testRigCmd) MaxSyslModule() int {
+	return 1
+}
+
+func (p *testRigCmd) Configure(app *kingpin.Application) *kingpin.CmdClause {
+	cmd := app.Command(p.Name(), "Generate test rig")
+	templateFileHelp := `Variables file name (json format). Example content:
+	{
+		"dbfront": {
+			"name": "dbfront",
+			"url": "github.service.anz/eresova/test-rig/gen/dbfront",
+			"port": "8080",
+			"impl": {
+				"name": "dbfront_impl",
+				"url": "github.service.anz/eresova/test-rig/pkg/dbfront_impl",
+				"interface_factory": "GetServiceInterfaceImplementation",
+				"callback_factory": "GetCallback"
+			}
+		}
+	}`
+	p.TemplateFileName = cmd.Flag("template", templateFileHelp).Required().ExistingFile()
+	p.OutputDir = cmd.Flag("output-dir", "Directory name to put generated files in").Default(".").String()
+	EnsureFlagsNonEmpty(cmd)
+	return cmd
+}
+
+func (p *testRigCmd) Execute(args cmdutils.ExecuteArgs) error {
+	var err error
+	err = testrig.GenerateRig(*p.TemplateFileName, *p.OutputDir, args.Modules)
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/cmd/sysl/cmd_testrig.go
+++ b/cmd/sysl/cmd_testrig.go
@@ -42,8 +42,7 @@ func (p *testRigCmd) Configure(app *kingpin.Application) *kingpin.CmdClause {
 }
 
 func (p *testRigCmd) Execute(args cmdutils.ExecuteArgs) error {
-	var err error
-	err = testrig.GenerateRig(*p.TemplateFileName, *p.OutputDir, args.Modules)
+	err := testrig.GenerateRig(*p.TemplateFileName, *p.OutputDir, args.Modules)
 	if err != nil {
 		return err
 	}

--- a/go.mod
+++ b/go.mod
@@ -13,16 +13,19 @@ require (
 	github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d // indirect
 	github.com/antlr/antlr4 v0.0.0-20200124162019-2d7f727a00b7
 	github.com/arr-ai/wbnf v0.12.1
+	github.com/cbroglie/mustache v1.0.1
 	github.com/cornelk/hashmap v1.0.1
 	github.com/dchest/siphash v1.2.1 // indirect
 	github.com/dlclark/regexp2 v1.2.0 // indirect
 	github.com/getkin/kin-openapi v0.2.1-0.20191216082429-70fbea30aeb8
 	github.com/ghodss/yaml v1.0.0
+	github.com/go-chi/chi v4.0.3+incompatible
 	github.com/go-openapi/jsonreference v0.19.3 // indirect
 	github.com/go-openapi/spec v0.19.6
 	github.com/go-openapi/swag v0.19.7
 	github.com/golang/protobuf v1.3.3
 	github.com/hashicorp/hcl v1.0.0
+	github.com/lib/pq v1.3.0
 	github.com/mailru/easyjson v0.7.0 // indirect
 	github.com/mattn/go-isatty v0.0.10 // indirect
 	github.com/pkg/errors v0.9.1

--- a/go.sum
+++ b/go.sum
@@ -37,6 +37,8 @@ github.com/arr-ai/hash v0.4.0 h1:VPIDl5nkhq8qntxmsNd00bdj+UVs2vRKFzzM7HZkR7Q=
 github.com/arr-ai/hash v0.4.0/go.mod h1:2fLB6qpmZbH+dpvNooTW2m9o5z1pEsUQxfGmZs6Z8QQ=
 github.com/arr-ai/wbnf v0.12.1 h1:JkIrDEsKV6sUZJ+eoa+EkBIell4/X4+7ZmIdHH/ls+A=
 github.com/arr-ai/wbnf v0.12.1/go.mod h1:WRCWNNBAGJU3JwitK7FwbOA68f0/yr4m/Iq64/wyqCo=
+github.com/cbroglie/mustache v1.0.1 h1:ivMg8MguXq/rrz2eu3tw6g3b16+PQhoTn6EZAhst2mw=
+github.com/cbroglie/mustache v1.0.1/go.mod h1:R/RUa+SobQ14qkP4jtx5Vke5sDytONDQXNLPY/PO69g=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/coreos/etcd v3.3.10+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
@@ -67,6 +69,8 @@ github.com/getkin/kin-openapi v0.2.1-0.20191216082429-70fbea30aeb8 h1:PYAaNpYjjX
 github.com/getkin/kin-openapi v0.2.1-0.20191216082429-70fbea30aeb8/go.mod h1:8hr1ZT9XxXHCLcD+I0ow6wOKn6ljqk04N+xEMS2BILY=
 github.com/ghodss/yaml v1.0.0 h1:wQHKEahhL6wmXdzwWG11gIVCkOv05bNOh+Rxn0yngAk=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
+github.com/go-chi/chi v4.0.3+incompatible h1:gakN3pDJnzZN5jqFV2TEdF66rTfKeITyR8qu6ekICEY=
+github.com/go-chi/chi v4.0.3+incompatible/go.mod h1:eB3wogJHnLi3x/kFX2A+IbTBlXxmMeXJVKy9tTv1XzQ=
 github.com/go-openapi/jsonpointer v0.19.2/go.mod h1:3akKfEdA7DF1sugOqz1dVQHBcuDBPKZGEoHC/NkiQRg=
 github.com/go-openapi/jsonpointer v0.19.3 h1:gihV7YNZK1iK6Tgwwsxo2rJbD1GTbdm72325Bq8FI3w=
 github.com/go-openapi/jsonpointer v0.19.3/go.mod h1:Pl9vOtqEWErmShwVjC8pYs9cog34VGT37dQOVbmoatg=
@@ -116,6 +120,8 @@ github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORN
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
+github.com/lib/pq v1.3.0 h1:/qkRGz8zljWiDcFvgpwUpwIAPu3r07TDvs3Rws+o/pU=
+github.com/lib/pq v1.3.0/go.mod h1:5WUZQaWbwv1U+lTReE5YruASi9Al49XbQIvNi/34Woo=
 github.com/magiconair/properties v1.8.0/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
 github.com/mailru/easyjson v0.0.0-20190614124828-94de47d64c63/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
 github.com/mailru/easyjson v0.0.0-20190626092158-b2ccc519800e h1:hB2xlXdHp/pmPZq0y3QnmWAArdw9PqbmotexnWx/FU8=

--- a/pkg/testrig/embedded/dockerfile.go
+++ b/pkg/testrig/embedded/dockerfile.go
@@ -1,0 +1,27 @@
+package embedded
+
+func GetDockerfileStub() string {
+	return `
+FROM golang:latest as builder
+
+ARG GOPROXY
+ENV GOPROXY=${GOPROXY}
+
+WORKDIR /app
+
+# allow caching on source rebuilds
+COPY vendor ./vendor
+COPY go.mod go.sum ./
+RUN go mod download
+
+# main build
+COPY . ./
+RUN go build -o main {{.OutputDir}}/{{.Service.Name}}/main.go
+
+
+
+FROM scratch
+COPY --from=builder /app/main .
+CMD ["/main"]	
+`
+}

--- a/pkg/testrig/embedded/main.go
+++ b/pkg/testrig/embedded/main.go
@@ -1,0 +1,37 @@
+package embedded
+
+func GetMainStub() string {
+	return `package main
+
+import (
+	"context"
+	"log"
+	"net/http"
+
+	"github.com/go-chi/chi"
+
+	{{.Service.Name}} "{{.Service.URL}}"
+	{{.Service.Impl.Name}} "{{.Service.Impl.URL}}"
+)
+
+func LoadServices(ctx context.Context) error {
+	router := chi.NewRouter()
+
+	serviceInterface := {{.Service.Impl.Name}.{{.Service.Impl.InterfaceFactory}}()
+
+	genCallbacks := {{.Service.Impl.Name}}.{{.Service.Impl.CallbackFactory}}()
+
+	serviceHandler := {{.Service.Name}}.NewServiceHandler(genCallbacks, &serviceInterface)
+
+	serviceRouter := {{.Service.Name}}.NewServiceRouter(genCallbacks, serviceHandler)
+	serviceRouter.WireRoutes(ctx, router)
+
+	log.Println("starting {{.Service.Name}} on :{{.Service.Port}}")
+	return http.ListenAndServe(":{{.Service.Port}}", router)
+}
+
+func main() {
+	log.Fatal(LoadServices(context.Background()))
+}
+`
+}

--- a/pkg/testrig/embedded/maindb.go
+++ b/pkg/testrig/embedded/maindb.go
@@ -1,0 +1,64 @@
+package embedded
+
+func GetMainDbStub() string {
+	return `package main
+
+import (
+	"context"
+	"log"
+	"net/http"
+	"database/sql"
+	"time"
+
+	"github.com/go-chi/chi"
+	_ "github.com/lib/pq"
+
+	{{.Service.Name}} "{{.Service.URL}}"
+	{{.Service.Impl.Name}} "{{.Service.Impl.URL}}"
+)
+
+func initDb() (*sql.DB, error) {
+	psqlInfo := "host={{.Service.Name}}_db port=5432 user=someuser password=somepassword dbname=somedb sslmode=disable"
+	db, err := sql.Open("postgres", psqlInfo)
+	if err != nil {
+		return nil, err
+	}
+
+	time.Sleep(5 * time.Second)
+
+	err = db.Ping()
+	if err != nil {
+		log.Println(err)
+		return nil, err
+	}
+
+	return db, nil
+}
+
+func loadServices(ctx context.Context) error {
+	router := chi.NewRouter()
+
+	db, err := initDb()
+	if err != nil {
+		return err
+	}
+	defer db.Close()
+
+	serviceInterface := {{.Service.Impl.Name}}.{{.Service.Impl.InterfaceFactory}}()
+
+	genCallbacks := {{.Service.Impl.Name}}.{{.Service.Impl.CallbackFactory}}(db)
+
+	serviceHandler := {{.Service.Name}}.NewServiceHandler(genCallbacks, &serviceInterface)
+
+	serviceRouter := {{.Service.Name}}.NewServiceRouter(genCallbacks, serviceHandler)
+	serviceRouter.WireRoutes(ctx, router)
+
+	log.Println("starting {{.Service.Name}} on :{{.Service.Port}}")
+	return http.ListenAndServe(":{{.Service.Port}}", router)
+}
+
+func main() {
+	log.Fatal(loadServices(context.Background()))
+}
+`
+}

--- a/pkg/testrig/embedded/types.go
+++ b/pkg/testrig/embedded/types.go
@@ -1,0 +1,24 @@
+package embedded
+
+type Vars struct {
+	Service Service `json:"service"`
+}
+
+type ServiceMap map[string]Service
+
+type serviceBase struct {
+	Name string `json:"name"`
+	URL  string `json:"url"`
+}
+
+type Service struct {
+	serviceBase
+	Port string      `json:"port"`
+	Impl ServiceImpl `json:"impl"`
+}
+
+type ServiceImpl struct {
+	serviceBase
+	InterfaceFactory string `json:"interface_factory"`
+	CallbackFactory  string `json:"callback_factory"`
+}

--- a/pkg/testrig/template/dockerfile.go
+++ b/pkg/testrig/template/dockerfile.go
@@ -1,0 +1,66 @@
+package template
+
+func GetDockerfileStub() string {
+	return `
+FROM golang:latest as builder
+ENV http_proxy=http://docker.for.mac.host.internal:3128
+ENV https_proxy=http://docker.for.mac.host.internal:3128
+
+WORKDIR /app
+
+# allow insecure download for ANZ root CA certificates, we need them for golang
+RUN git config --global http.sslVerify false
+RUN git clone --depth 1 https://github.service.anz/ocp/ocp-cacerts.git
+RUN cp ocp-cacerts/global/*.crt /usr/local/share/ca-certificates/
+RUN update-ca-certificates
+
+# allow caching on source rebuilds
+COPY go.mod go.sum ./
+COPY vendor ./vendor
+RUN go mod download
+
+# main build
+COPY . ./
+RUN GOOS=linux go build -o main {{outputDir}}/{{name}}/main.go
+
+
+
+FROM scratch
+COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
+COPY --from=builder /app/main .
+# ENTRYPOINT [ "/main" ]
+CMD ["/main"]	
+`
+}
+
+func GetDockerfileStub2() string {
+	return `
+FROM golang:alpine as builder
+ENV http_proxy=http://docker.for.mac.host.internal:3128
+ENV https_proxy=http://docker.for.mac.host.internal:3128
+
+# certificates needed for golang downloads
+RUN apk --no-cache add ca-certificates
+COPY *.cer /usr/local/share/ca-certificates/
+RUN update-ca-certificates
+
+WORKDIR /app
+
+# dependencies as explicit step to allow caching
+COPY go.mod go.sum ./
+COPY vendor ./vendor
+RUN go mod download
+
+# main build
+COPY . ./
+RUN GOOS=linux go build -o main cmd/dbfront/main.go
+
+
+
+FROM scratch
+COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
+COPY --from=builder /app/main .
+# ENTRYPOINT [ "/main" ]
+CMD ["/main"]
+`
+}

--- a/pkg/testrig/template/main.go
+++ b/pkg/testrig/template/main.go
@@ -1,0 +1,40 @@
+package template
+
+func GetMainStub() string {
+	return `package main
+
+import (
+	"context"
+	"log"
+	"net/http"
+
+	"github.com/go-chi/chi"
+
+	{{name}} "{{url}}"
+	{{impl.name}} "{{impl.url}}"
+)
+
+func LoadServices(ctx context.Context) error {
+	router := chi.NewRouter()
+
+	serviceInterface := {{impl.name}}.{{impl.interface_factory}}()
+
+	genCallbacks := {{impl.name}}.{{impl.callback_factory}}()
+
+	// serviceHandler := simple.NewServiceHandler(genCallbacks, &serviceInterface, mydependency.NewClient(http.DefaultClient, "http://jsonplaceholder.typicode.com"))
+	serviceHandler := {{name}}.NewServiceHandler(genCallbacks, &serviceInterface)
+
+	// Service Router
+	serviceRouter := {{name}}.NewServiceRouter(genCallbacks, serviceHandler)
+	serviceRouter.WireRoutes(ctx, router)
+
+	log.Println("starting {{name}} on :{{port}}")
+	log.Fatal(http.ListenAndServe(":{{port}}", router))
+	return nil
+}
+
+func main() {
+	LoadServices(context.Background())
+}
+`
+}

--- a/pkg/testrig/template/main.go
+++ b/pkg/testrig/template/main.go
@@ -21,7 +21,6 @@ func LoadServices(ctx context.Context) error {
 
 	genCallbacks := {{impl.name}}.{{impl.callback_factory}}()
 
-	// serviceHandler := simple.NewServiceHandler(genCallbacks, &serviceInterface, mydependency.NewClient(http.DefaultClient, "http://jsonplaceholder.typicode.com"))
 	serviceHandler := {{name}}.NewServiceHandler(genCallbacks, &serviceInterface)
 
 	// Service Router

--- a/pkg/testrig/template/maindb.go
+++ b/pkg/testrig/template/maindb.go
@@ -1,12 +1,7 @@
 package template
 
-import (
-	_ "github.com/lib/pq"
-)
-
 func GetMainDbStub() string {
-	return `
-package main
+	return `package main
 
 import (
 	"context"
@@ -53,7 +48,6 @@ func loadServices(ctx context.Context) error {
 
 	genCallbacks := {{impl.name}}.{{impl.callback_factory}}(db)
 
-	// serviceHandler := simple.NewServiceHandler(genCallbacks, &serviceInterface, mydependency.NewClient(http.DefaultClient, "http://jsonplaceholder.typicode.com"))
 	serviceHandler := {{name}}.NewServiceHandler(genCallbacks, &serviceInterface)
 
 	// Service Router

--- a/pkg/testrig/template/maindb.go
+++ b/pkg/testrig/template/maindb.go
@@ -1,0 +1,72 @@
+package template
+
+import (
+	_ "github.com/lib/pq"
+)
+
+func GetMainDbStub() string {
+	return `
+package main
+
+import (
+	"context"
+	"log"
+	"net/http"
+	"database/sql"
+	"time"
+
+	"github.com/go-chi/chi"
+	_ "github.com/lib/pq"
+
+	{{name}} "{{url}}"
+	{{impl.name}} "{{impl.url}}"
+)
+
+func initDb() (*sql.DB, error) {
+	psqlInfo := "host={{name}}_db port=5432 user=someuser password=somepassword dbname=somedb sslmode=disable"
+	db, err := sql.Open("postgres", psqlInfo)
+	if err != nil {
+		return nil, err
+	}
+
+	time.Sleep(5 * time.Second)
+
+	err = db.Ping()
+	if err != nil {
+		log.Println(err)
+		return nil, err
+	}
+
+	return db, nil
+}
+
+func loadServices(ctx context.Context) error {
+	router := chi.NewRouter()
+
+	db, err := initDb()
+	if err != nil {
+		return err
+	}
+	defer db.Close()
+
+	serviceInterface := {{impl.name}}.{{impl.interface_factory}}()
+
+	genCallbacks := {{impl.name}}.{{impl.callback_factory}}(db)
+
+	// serviceHandler := simple.NewServiceHandler(genCallbacks, &serviceInterface, mydependency.NewClient(http.DefaultClient, "http://jsonplaceholder.typicode.com"))
+	serviceHandler := {{name}}.NewServiceHandler(genCallbacks, &serviceInterface)
+
+	// Service Router
+	serviceRouter := {{name}}.NewServiceRouter(genCallbacks, serviceHandler)
+	serviceRouter.WireRoutes(ctx, router)
+
+	log.Println("starting {{name}} on :{{port}}")
+	log.Fatal(http.ListenAndServe(":{{port}}", router))
+	return nil
+}
+
+func main() {
+	loadServices(context.Background())
+}
+`
+}

--- a/pkg/testrig/template/types.go
+++ b/pkg/testrig/template/types.go
@@ -8,7 +8,7 @@ type ServiceMap = map[string]Service
 
 type serviceBase struct {
 	Name string `json:"name"`
-	Url  string `json:"url"`
+	URL  string `json:"url"`
 }
 
 type Service struct {

--- a/pkg/testrig/template/types.go
+++ b/pkg/testrig/template/types.go
@@ -1,0 +1,24 @@
+package template
+
+type Vars struct {
+	Service Service `json:"service"`
+}
+
+type ServiceMap = map[string]Service
+
+type serviceBase struct {
+	Name string `json:"name"`
+	Url  string `json:"url"`
+}
+
+type Service struct {
+	serviceBase
+	Port string      `json:"port"`
+	Impl ServiceImpl `json:"impl"`
+}
+
+type ServiceImpl struct {
+	serviceBase
+	InterfaceFactory string `json:"interface_factory"`
+	CallbackFactory  string `json:"callback_factory"`
+}

--- a/pkg/testrig/testrig.go
+++ b/pkg/testrig/testrig.go
@@ -97,7 +97,7 @@ func readTemplate(templateFileName string) (template.ServiceMap, error) {
 		return nil, err
 	}
 	var vars template.ServiceMap
-	err = json.Unmarshal([]byte(byteValue), &vars)
+	err = json.Unmarshal(byteValue, &vars)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/testrig/testrig.go
+++ b/pkg/testrig/testrig.go
@@ -114,11 +114,11 @@ func generateDbService(serviceName string) map[string]interface{} {
 	block["ports"] = []string{"5432:5432"}
 	// piece of magic to make Postgres execute our script on startup
 	block["volumes"] = []string{fmt.Sprintf("../gen/%v/%v.sql:/docker-entrypoint-initdb.d/%v.sql", serviceName, serviceName, serviceName)}
-	environemnt := make(map[string]string)
-	environemnt["POSTGRES_USER"] = "someuser"
-	environemnt["POSTGRES_PASSWORD"] = "somepassword"
-	environemnt["POSTGRES_DB"] = "somedb"
-	block["environment"] = environemnt
+	environment := make(map[string]string)
+	environment["POSTGRES_USER"] = "someuser"
+	environment["POSTGRES_PASSWORD"] = "somepassword"
+	environment["POSTGRES_DB"] = "somedb"
+	block["environment"] = environment
 	return block
 }
 

--- a/pkg/testrig/testrig.go
+++ b/pkg/testrig/testrig.go
@@ -1,0 +1,194 @@
+// Package testrig provides tools for generating standalone test environment for sysl generated services
+package testrig
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/anz-bank/sysl/pkg/sysl"
+	"github.com/anz-bank/sysl/pkg/testrig/template"
+
+	"github.com/cbroglie/mustache"
+	"github.com/ghodss/yaml"
+)
+
+// GenerateRig creates full set of files required to start up a test rig
+// for every service, it creates main.go (optionally with DB connection) and a dockerfile to containerize it
+// if the service contains DB tables, it creates sidecar postgres container and creates a schema there
+// finally, it creates docker-compose.yml at the point of all (likely your project's root) that joins all containerized services
+func GenerateRig(templateFile string, outputDir string, modules []*sysl.Module) error {
+	serviceMap, err := readTemplate(templateFile)
+	if err != nil {
+		return err
+	}
+
+	applications := make(map[string]*sysl.Application)
+	for _, module := range modules {
+		for appName, app := range module.GetApps() {
+			applications[appName] = app
+		}
+	}
+	appsWhoNeedDb := make(map[string]bool)
+	for serviceName := range serviceMap {
+		appsWhoNeedDb[serviceName] = false
+		if applications[serviceName] != nil {
+			if appNeedsDb(applications[serviceName]) {
+				appsWhoNeedDb[serviceName] = true
+			}
+		}
+	}
+
+	composeServices := make(map[string]interface{})
+
+	for serviceName, serviceTmpl := range serviceMap {
+		os.MkdirAll(filepath.Join(outputDir, serviceName), os.ModePerm)
+
+		err = generateMain(serviceName, serviceTmpl, outputDir, appsWhoNeedDb[serviceName])
+		if err != nil {
+			return err
+		}
+
+		err = generateDockerfile(serviceName, serviceTmpl, outputDir)
+		if err != nil {
+			return err
+		}
+
+		block := generateAppService(serviceName, serviceTmpl, outputDir)
+		composeServices[serviceName] = block
+		if appsWhoNeedDb[serviceName] {
+			block := generateDbService(serviceName)
+			composeServices[serviceName+"_db"] = block
+		}
+	}
+
+	composeFile, err := os.Create("docker-compose.yml")
+	defer composeFile.Close()
+	if err != nil {
+		return err
+	}
+	return generateCompose(composeFile, composeMap)
+}
+
+func appNeedsDb(app *sysl.Application) bool {
+	patterns := app.GetAttrs()["patterns"]
+	if patterns == nil {
+		return false
+	}
+	return strings.Contains(patterns.String(), "DB")
+}
+
+func readTemplate(templateFileName string) (template.ServiceMap, error) {
+	templateFile, err := os.Open(templateFileName)
+	defer templateFile.Close()
+	if err != nil {
+		return nil, err
+	}
+
+	byteValue, _ := ioutil.ReadAll(templateFile)
+	var vars template.ServiceMap
+	err = json.Unmarshal([]byte(byteValue), &vars)
+	if err != nil {
+		return nil, err
+	}
+
+	return vars, nil
+}
+
+func generateAppService(serviceName string, serviceTmpl template.Service, outputDir string) map[string]interface{} {
+	build := make(map[string]interface{})
+	build["context"] = "."
+	build["dockerfile"] = filepath.Join(outputDir, serviceName, "Dockerfile")
+	block := make(map[string]interface{})
+	block["build"] = build
+	block["ports"] = []string{fmt.Sprintf("%v:%v", serviceTmpl.Port, serviceTmpl.Port)}
+	return block
+}
+
+func generateDbService(serviceName string) map[string]interface{} {
+	block := make(map[string]interface{})
+	block["image"] = "postgres:latest"
+	block["ports"] = []string{"5432:5432"}
+	// piece of magic to make Postgres execute our script on startup
+	block["volumes"] = []string{fmt.Sprintf("../gen/%v/%v.sql:/docker-entrypoint-initdb.d/%v.sql", serviceName, serviceName, serviceName)}
+	environemnt := make(map[string]string)
+	environemnt["POSTGRES_USER"] = "someuser"
+	environemnt["POSTGRES_PASSWORD"] = "somepassword"
+	environemnt["POSTGRES_DB"] = "somedb"
+	block["environment"] = environemnt
+	return block
+}
+
+func generateCompose(file *os.File, data map[string]interface{}) error {
+	data["version"] = "3.3"
+	data["services"] = composeServices
+
+	dataRaw, err := yaml.Marshal(data)
+	if err != nil {
+		return err
+	}
+
+	_, err = file.Write(dataRaw)
+	if err != nil {
+		return err
+	}
+	file.Sync()
+
+	return nil
+}
+
+func processMustacheTemplate(file *os.File, template string, data template.Service, outputDir string) error {
+	// mustache needs generic map
+	rawData, err := json.Marshal(&data)
+	if err != nil {
+		return err
+	}
+	var genericData map[string]interface{}
+	err = json.Unmarshal(rawData, &genericData)
+	if err != nil {
+		return err
+	}
+	genericData["outputDir"] = outputDir
+
+	renderedTemplate, err := mustache.Render(template, genericData)
+	if err != nil {
+		return err
+	}
+	_, err = file.WriteString(renderedTemplate)
+	if err != nil {
+		return err
+	}
+	file.Sync()
+
+	return nil
+}
+
+func generateMain(serviceName string, service template.Service, outputDir string, needDb bool) error {
+	output, err := os.Create(filepath.Join(outputDir, serviceName, "main.go"))
+	defer output.Close()
+	if err != nil {
+		return err
+	}
+
+	mainTemplate := template.GetMainStub()
+	if needDb {
+		mainTemplate = template.GetMainDbStub()
+	}
+
+	return processMustacheTemplate(output, mainTemplate, service, outputDir)
+}
+
+func generateDockerfile(serviceName string, service template.Service, outputDir string) error {
+	output, err := os.Create(filepath.Join(outputDir, serviceName, "Dockerfile"))
+	defer output.Close()
+	if err != nil {
+		return err
+	}
+
+	dockerTemplate := template.GetDockerfileStub()
+
+	return processMustacheTemplate(output, dockerTemplate, service, outputDir)
+}

--- a/pkg/testrig/testrig.go
+++ b/pkg/testrig/testrig.go
@@ -45,7 +45,10 @@ func GenerateRig(templateFile string, outputDir string, modules []*sysl.Module) 
 	composeServices := make(map[string]interface{})
 
 	for serviceName, serviceTmpl := range serviceMap {
-		os.MkdirAll(filepath.Join(outputDir, serviceName), os.ModePerm)
+		err = os.MkdirAll(filepath.Join(outputDir, serviceName), os.ModePerm)
+		if err != nil {
+			return err
+		}
 
 		err = generateMain(serviceName, serviceTmpl, outputDir, appsWhoNeedDb[serviceName])
 		if err != nil {
@@ -88,7 +91,10 @@ func readTemplate(templateFileName string) (template.ServiceMap, error) {
 		return nil, err
 	}
 
-	byteValue, _ := ioutil.ReadAll(templateFile)
+	byteValue, err := ioutil.ReadAll(templateFile)
+	if err != nil {
+		return nil, err
+	}
 	var vars template.ServiceMap
 	err = json.Unmarshal([]byte(byteValue), &vars)
 	if err != nil {
@@ -135,7 +141,10 @@ func generateCompose(file *os.File, data map[string]interface{}) error {
 	if err != nil {
 		return err
 	}
-	file.Sync()
+	err = file.Sync()
+	if err != nil {
+		return err
+	}
 
 	return nil
 }
@@ -161,7 +170,10 @@ func processMustacheTemplate(file *os.File, template string, data template.Servi
 	if err != nil {
 		return err
 	}
-	file.Sync()
+	err = file.Sync()
+	if err != nil {
+		return err
+	}
 
 	return nil
 }
@@ -178,7 +190,12 @@ func generateMain(serviceName string, service template.Service, outputDir string
 		mainTemplate = template.GetMainDbStub()
 	}
 
-	return processMustacheTemplate(output, mainTemplate, service, outputDir)
+	err = processMustacheTemplate(output, mainTemplate, service, outputDir)
+	if err != nil {
+		return err
+	}
+
+	return nil
 }
 
 func generateDockerfile(serviceName string, service template.Service, outputDir string) error {
@@ -190,5 +207,10 @@ func generateDockerfile(serviceName string, service template.Service, outputDir 
 
 	dockerTemplate := template.GetDockerfileStub()
 
-	return processMustacheTemplate(output, dockerTemplate, service, outputDir)
+	err = processMustacheTemplate(output, dockerTemplate, service, outputDir)
+	if err != nil {
+		return err
+	}
+
+	return nil
 }

--- a/pkg/testrig/testrig.go
+++ b/pkg/testrig/testrig.go
@@ -19,7 +19,8 @@ import (
 // GenerateRig creates full set of files required to start up a test rig
 // for every service, it creates main.go (optionally with DB connection) and a dockerfile to containerize it
 // if the service contains DB tables, it creates sidecar postgres container and creates a schema there
-// finally, it creates docker-compose.yml at the point of all (likely your project's root) that joins all containerized services
+// finally, it creates docker-compose.yml at the point of all (likely your project's root)
+// that joins all containerized services
 func GenerateRig(templateFile string, outputDir string, modules []*sysl.Module) error {
 	serviceMap, err := readTemplate(templateFile)
 	if err != nil {
@@ -119,7 +120,10 @@ func generateDbService(serviceName string) map[string]interface{} {
 	block["image"] = "postgres:latest"
 	block["ports"] = []string{"5432:5432"}
 	// piece of magic to make Postgres execute our script on startup
-	block["volumes"] = []string{fmt.Sprintf("../gen/%v/%v.sql:/docker-entrypoint-initdb.d/%v.sql", serviceName, serviceName, serviceName)}
+	block["volumes"] = []string{
+		fmt.Sprintf("../gen/%v/%v.sql:/docker-entrypoint-initdb.d/%v.sql",
+			serviceName, serviceName, serviceName),
+	}
 	environment := make(map[string]string)
 	environment["POSTGRES_USER"] = "someuser"
 	environment["POSTGRES_PASSWORD"] = "somepassword"

--- a/pkg/testrig/testrig.go
+++ b/pkg/testrig/testrig.go
@@ -8,12 +8,13 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"text/template"
 
 	"github.com/anz-bank/sysl/pkg/sysl"
-	"github.com/anz-bank/sysl/pkg/testrig/template"
+	"github.com/anz-bank/sysl/pkg/testrig/embedded"
 
-	"github.com/cbroglie/mustache"
 	"github.com/ghodss/yaml"
+	"github.com/spf13/afero"
 )
 
 // GenerateRig creates full set of files required to start up a test rig
@@ -21,8 +22,8 @@ import (
 // if the service contains DB tables, it creates sidecar postgres container and creates a schema there
 // finally, it creates docker-compose.yml at the point of all (likely your project's root)
 // that joins all containerized services
-func GenerateRig(templateFile string, outputDir string, modules []*sysl.Module) error {
-	serviceMap, err := readTemplate(templateFile)
+func GenerateRig(fs afero.Fs, templateFile string, outputDir string, modules []*sysl.Module) error {
+	serviceMap, err := readUserData(fs, templateFile)
 	if err != nil {
 		return err
 	}
@@ -46,18 +47,15 @@ func GenerateRig(templateFile string, outputDir string, modules []*sysl.Module) 
 	composeServices := make(map[string]interface{})
 
 	for serviceName, serviceTmpl := range serviceMap {
-		err = os.MkdirAll(filepath.Join(outputDir, serviceName), os.ModePerm)
-		if err != nil {
+		if err := fs.MkdirAll(filepath.Join(outputDir, serviceName), os.ModePerm); err != nil {
 			return err
 		}
 
-		err = generateMain(serviceName, serviceTmpl, outputDir, appsWhoNeedDb[serviceName])
-		if err != nil {
+		if err := generateMain(fs, serviceName, serviceTmpl, outputDir, appsWhoNeedDb[serviceName]); err != nil {
 			return err
 		}
 
-		err = generateDockerfile(serviceName, serviceTmpl, outputDir)
-		if err != nil {
+		if err := generateDockerfile(fs, serviceName, serviceTmpl, outputDir); err != nil {
 			return err
 		}
 
@@ -69,12 +67,7 @@ func GenerateRig(templateFile string, outputDir string, modules []*sysl.Module) 
 		}
 	}
 
-	composeFile, err := os.Create("docker-compose.yml")
-	defer composeFile.Close()
-	if err != nil {
-		return err
-	}
-	return generateCompose(composeFile, composeMap)
+	return generateCompose(fs, composeServices)
 }
 
 func appNeedsDb(app *sysl.Application) bool {
@@ -85,116 +78,107 @@ func appNeedsDb(app *sysl.Application) bool {
 	return strings.Contains(patterns.String(), "DB")
 }
 
-func readTemplate(templateFileName string) (template.ServiceMap, error) {
-	templateFile, err := os.Open(templateFileName)
-	defer templateFile.Close()
+func readUserData(fs afero.Fs, templateFileName string) (embedded.ServiceMap, error) {
+	templateFile, err := fs.Open(templateFileName)
 	if err != nil {
 		return nil, err
 	}
+	defer templateFile.Close()
 
 	byteValue, err := ioutil.ReadAll(templateFile)
 	if err != nil {
 		return nil, err
 	}
-	var vars template.ServiceMap
-	err = json.Unmarshal(byteValue, &vars)
-	if err != nil {
+	var vars embedded.ServiceMap
+	if err := json.Unmarshal(byteValue, &vars); err != nil {
 		return nil, err
 	}
-
 	return vars, nil
 }
 
-func generateAppService(serviceName string, serviceTmpl template.Service, outputDir string) map[string]interface{} {
-	build := make(map[string]interface{})
-	build["context"] = "."
-	build["dockerfile"] = filepath.Join(outputDir, serviceName, "Dockerfile")
-	block := make(map[string]interface{})
-	block["build"] = build
-	block["ports"] = []string{fmt.Sprintf("%v:%v", serviceTmpl.Port, serviceTmpl.Port)}
-	return block
+func generateAppService(serviceName string, serviceTmpl embedded.Service, outputDir string) map[string]interface{} {
+	return map[string]interface{}{
+		"build": map[string]interface{}{
+			"context":    ".",
+			"dockerfile": filepath.Join(outputDir, serviceName, "Dockerfile"),
+		},
+		"ports": []string{fmt.Sprintf("%v:%v", serviceTmpl.Port, serviceTmpl.Port)},
+	}
 }
 
 func generateDbService(serviceName string) map[string]interface{} {
-	block := make(map[string]interface{})
-	block["image"] = "postgres:latest"
-	block["ports"] = []string{"5432:5432"}
-	// piece of magic to make Postgres execute our script on startup
-	block["volumes"] = []string{
-		fmt.Sprintf("../gen/%v/%v.sql:/docker-entrypoint-initdb.d/%v.sql",
-			serviceName, serviceName, serviceName),
+	return map[string]interface{}{
+		"image": "postgres:latest",
+		"ports": []string{"5432:5432"},
+		"volumes": []string{
+			fmt.Sprintf("../gen/%v/%v.sql:/docker-entrypoint-initdb.d/%v.sql", serviceName, serviceName, serviceName),
+		},
+		"environment": map[string]string{
+			"POSTGRES_USER":     "someuser",
+			"POSTGRES_PASSWORD": "somepassword",
+			"POSTGRES_DB":       "somedb",
+		},
 	}
-	environment := make(map[string]string)
-	environment["POSTGRES_USER"] = "someuser"
-	environment["POSTGRES_PASSWORD"] = "somepassword"
-	environment["POSTGRES_DB"] = "somedb"
-	block["environment"] = environment
-	return block
 }
 
-func generateCompose(file *os.File, data map[string]interface{}) error {
-	data["version"] = "3.3"
-	data["services"] = composeServices
+func generateCompose(fs afero.Fs, composeServices map[string]interface{}) error {
+	output, err := fs.Create("docker-compose.yml")
+	if err != nil {
+		return err
+	}
+	defer output.Close()
+
+	data := map[string]interface{}{
+		"version":  "3.3",
+		"services": composeServices,
+	}
 
 	dataRaw, err := yaml.Marshal(data)
 	if err != nil {
 		return err
 	}
 
-	_, err = file.Write(dataRaw)
-	if err != nil {
+	if _, err := output.Write(dataRaw); err != nil {
 		return err
 	}
-	err = file.Sync()
-	if err != nil {
-		return err
-	}
-
-	return nil
-}
-
-func processMustacheTemplate(file *os.File, template string, data template.Service, outputDir string) error {
-	// mustache needs generic map
-	rawData, err := json.Marshal(&data)
-	if err != nil {
-		return err
-	}
-	var genericData map[string]interface{}
-	err = json.Unmarshal(rawData, &genericData)
-	if err != nil {
-		return err
-	}
-	genericData["outputDir"] = outputDir
-
-	renderedTemplate, err := mustache.Render(template, genericData)
-	if err != nil {
-		return err
-	}
-	_, err = file.WriteString(renderedTemplate)
-	if err != nil {
-		return err
-	}
-	err = file.Sync()
-	if err != nil {
+	if err := output.Sync(); err != nil {
 		return err
 	}
 
 	return nil
 }
 
-func generateMain(serviceName string, service template.Service, outputDir string, needDb bool) error {
-	output, err := os.Create(filepath.Join(outputDir, serviceName, "main.go"))
+func processTemplate(file afero.File, resource string, data embedded.Service, outputDir string) error {
+	tmpl, err := template.New("servicesData").Parse(resource)
+	if err != nil {
+		return err
+	}
+	userData := struct {
+		OutputDir string
+		Service   embedded.Service
+	}{
+		OutputDir: outputDir,
+		Service:   data,
+	}
+	if err := tmpl.Execute(file, userData); err != nil {
+		return err
+	}
+	return file.Sync()
+}
+
+func generateMain(fs afero.Fs, serviceName string, service embedded.Service, outputDir string, needDb bool) error {
+	output, err := fs.Create(filepath.Join(outputDir, serviceName, "main.go"))
+	if err != nil {
+		return err
+	}
 	defer output.Close()
-	if err != nil {
-		return err
-	}
 
-	mainTemplate := template.GetMainStub()
+	mainTemplate := embedded.GetMainStub()
 	if needDb {
-		mainTemplate = template.GetMainDbStub()
+		mainTemplate = embedded.GetMainDbStub()
 	}
 
-	err = processMustacheTemplate(output, mainTemplate, service, outputDir)
+	err = processTemplate(output, mainTemplate, service, outputDir)
 	if err != nil {
 		return err
 	}
@@ -202,16 +186,16 @@ func generateMain(serviceName string, service template.Service, outputDir string
 	return nil
 }
 
-func generateDockerfile(serviceName string, service template.Service, outputDir string) error {
-	output, err := os.Create(filepath.Join(outputDir, serviceName, "Dockerfile"))
-	defer output.Close()
+func generateDockerfile(fs afero.Fs, serviceName string, service embedded.Service, outputDir string) error {
+	output, err := fs.Create(filepath.Join(outputDir, serviceName, "Dockerfile"))
 	if err != nil {
 		return err
 	}
+	defer output.Close()
 
-	dockerTemplate := template.GetDockerfileStub()
+	dockerTemplate := embedded.GetDockerfileStub()
 
-	err = processMustacheTemplate(output, dockerTemplate, service, outputDir)
+	err = processTemplate(output, dockerTemplate, service, outputDir)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Changes proposed in this pull request:
-  test rig generation command for Sysl service, that creates docker compose suite including databases if needed. Example setup is added to CLI help.

Fully operational test project is located here:
https://github.service.anz/eresova/test-rig