### PR TITLE
build: Remove PKGS from Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,3 @@
-PKGS := $(shell go list ./... | grep -v /vendor)
-
 BIN_DIR := $(GOPATH)/bin
 
 # Try to detect current branch if not provided from environment


### PR DESCRIPTION
This is an unused variable that is a simply expanded variable, which
means it is evaluated even if not used. As it is a `$(shell ...)`
command, that command is run every time you run `make`. The command is a
`go list` command which causes the go compiler to fetch dependencies.
This means if you make something simple, the makefile still does a lot
of work.

STOP IT!!! It's driving me nuts.

@anz-bank/sysl-developers