### PR TITLE
first scratchy version of test rig generation

### DIFF
--- a/cmd/sysl/cmd_runner.go
+++ b/cmd/sysl/cmd_runner.go
@@ -72,6 +72,7 @@ func (r *cmdRunner) Configure(app *kingpin.Application) error {
 		&envCmd{},
 		&templateCmd{},
 		&modCmd{},
+		&testRigCmd{},
 	}
 	r.commands = map[string]cmdutils.Command{}
 

--- a/cmd/sysl/cmd_testrig.go
+++ b/cmd/sysl/cmd_testrig.go
@@ -1,0 +1,50 @@
+package main
+
+import (
+	"github.com/anz-bank/sysl/pkg/cmdutils"
+	"github.com/anz-bank/sysl/pkg/testrig"
+	"gopkg.in/alecthomas/kingpin.v2"
+)
+
+type testRigCmd struct {
+	TemplateFileName *string
+	OutputDir        *string
+}
+
+func (p *testRigCmd) Name() string {
+	return "test-rig"
+}
+
+func (p *testRigCmd) MaxSyslModule() int {
+	return 1
+}
+
+func (p *testRigCmd) Configure(app *kingpin.Application) *kingpin.CmdClause {
+	cmd := app.Command(p.Name(), "Generate test rig")
+	templateFileHelp := `Variables file name (json format). Example content:
+	{
+		"dbfront": {
+			"name": "dbfront",
+			"import": "< golang import path to generated code >",
+			"port": "8080",
+			"impl": {
+				"name": "dbfront_impl",
+				"import": "< golang import path to your implementation >",
+				"interface_factory": "GetServiceInterfaceImplementation",
+				"callback_factory": "GetCallback"
+			}
+		}
+	}`
+	p.TemplateFileName = cmd.Flag("template", templateFileHelp).Required().ExistingFile()
+	p.OutputDir = cmd.Flag("output-dir", "Directory name to put generated files in").Default(".").String()
+	EnsureFlagsNonEmpty(cmd)
+	return cmd
+}
+
+func (p *testRigCmd) Execute(args cmdutils.ExecuteArgs) error {
+	err := testrig.GenerateRig(args.Filesystem, *p.TemplateFileName, *p.OutputDir, args.Modules)
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/go.mod
+++ b/go.mod
@@ -13,16 +13,19 @@ require (
 	github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d // indirect
 	github.com/antlr/antlr4 v0.0.0-20200124162019-2d7f727a00b7
 	github.com/arr-ai/wbnf v0.12.1
+	github.com/cbroglie/mustache v1.0.1
 	github.com/cornelk/hashmap v1.0.1
 	github.com/dchest/siphash v1.2.1 // indirect
 	github.com/dlclark/regexp2 v1.2.0 // indirect
 	github.com/getkin/kin-openapi v0.2.1-0.20191216082429-70fbea30aeb8
 	github.com/ghodss/yaml v1.0.0
+	github.com/go-chi/chi v4.0.3+incompatible
 	github.com/go-openapi/jsonreference v0.19.3 // indirect
 	github.com/go-openapi/spec v0.19.6
 	github.com/go-openapi/swag v0.19.7
 	github.com/golang/protobuf v1.3.3
 	github.com/hashicorp/hcl v1.0.0
+	github.com/lib/pq v1.3.0
 	github.com/mailru/easyjson v0.7.0 // indirect
 	github.com/mattn/go-isatty v0.0.10 // indirect
 	github.com/pkg/errors v0.9.1

--- a/go.sum
+++ b/go.sum
@@ -37,6 +37,8 @@ github.com/arr-ai/hash v0.4.0 h1:VPIDl5nkhq8qntxmsNd00bdj+UVs2vRKFzzM7HZkR7Q=
 github.com/arr-ai/hash v0.4.0/go.mod h1:2fLB6qpmZbH+dpvNooTW2m9o5z1pEsUQxfGmZs6Z8QQ=
 github.com/arr-ai/wbnf v0.12.1 h1:JkIrDEsKV6sUZJ+eoa+EkBIell4/X4+7ZmIdHH/ls+A=
 github.com/arr-ai/wbnf v0.12.1/go.mod h1:WRCWNNBAGJU3JwitK7FwbOA68f0/yr4m/Iq64/wyqCo=
+github.com/cbroglie/mustache v1.0.1 h1:ivMg8MguXq/rrz2eu3tw6g3b16+PQhoTn6EZAhst2mw=
+github.com/cbroglie/mustache v1.0.1/go.mod h1:R/RUa+SobQ14qkP4jtx5Vke5sDytONDQXNLPY/PO69g=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/coreos/etcd v3.3.10+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
@@ -67,6 +69,8 @@ github.com/getkin/kin-openapi v0.2.1-0.20191216082429-70fbea30aeb8 h1:PYAaNpYjjX
 github.com/getkin/kin-openapi v0.2.1-0.20191216082429-70fbea30aeb8/go.mod h1:8hr1ZT9XxXHCLcD+I0ow6wOKn6ljqk04N+xEMS2BILY=
 github.com/ghodss/yaml v1.0.0 h1:wQHKEahhL6wmXdzwWG11gIVCkOv05bNOh+Rxn0yngAk=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
+github.com/go-chi/chi v4.0.3+incompatible h1:gakN3pDJnzZN5jqFV2TEdF66rTfKeITyR8qu6ekICEY=
+github.com/go-chi/chi v4.0.3+incompatible/go.mod h1:eB3wogJHnLi3x/kFX2A+IbTBlXxmMeXJVKy9tTv1XzQ=
 github.com/go-openapi/jsonpointer v0.19.2/go.mod h1:3akKfEdA7DF1sugOqz1dVQHBcuDBPKZGEoHC/NkiQRg=
 github.com/go-openapi/jsonpointer v0.19.3 h1:gihV7YNZK1iK6Tgwwsxo2rJbD1GTbdm72325Bq8FI3w=
 github.com/go-openapi/jsonpointer v0.19.3/go.mod h1:Pl9vOtqEWErmShwVjC8pYs9cog34VGT37dQOVbmoatg=
@@ -116,6 +120,8 @@ github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORN
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
+github.com/lib/pq v1.3.0 h1:/qkRGz8zljWiDcFvgpwUpwIAPu3r07TDvs3Rws+o/pU=
+github.com/lib/pq v1.3.0/go.mod h1:5WUZQaWbwv1U+lTReE5YruASi9Al49XbQIvNi/34Woo=
 github.com/magiconair/properties v1.8.0/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
 github.com/mailru/easyjson v0.0.0-20190614124828-94de47d64c63/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
 github.com/mailru/easyjson v0.0.0-20190626092158-b2ccc519800e h1:hB2xlXdHp/pmPZq0y3QnmWAArdw9PqbmotexnWx/FU8=

--- a/pkg/testrig/dockerfile.go
+++ b/pkg/testrig/dockerfile.go
@@ -1,0 +1,27 @@
+package testrig
+
+func GetDockerfileStub() string {
+	return `
+FROM golang:latest as builder
+
+ARG GOPROXY
+ENV GOPROXY=${GOPROXY}
+
+WORKDIR /app
+
+# allow caching on source rebuilds
+COPY vendor ./vendor
+COPY go.mod go.sum ./
+RUN go mod download
+
+# main build
+COPY . ./
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -o main {{.OutputDir}}/{{.Service.Name}}/main.go
+
+
+
+FROM scratch
+COPY --from=builder /app/main /main
+CMD ["/main"]	
+`
+}

--- a/pkg/testrig/main.go
+++ b/pkg/testrig/main.go
@@ -1,0 +1,37 @@
+package testrig
+
+func GetMainStub() string {
+	return `package main
+
+import (
+	"context"
+	"log"
+	"net/http"
+
+	"github.com/go-chi/chi"
+
+	{{.Service.Name}} "{{.Service.URL}}"
+	{{.Service.Impl.Name}} "{{.Service.Impl.URL}}"
+)
+
+func LoadServices(ctx context.Context) error {
+	router := chi.NewRouter()
+
+	serviceInterface := {{.Service.Impl.Name}.{{.Service.Impl.InterfaceFactory}}()
+
+	genCallbacks := {{.Service.Impl.Name}}.{{.Service.Impl.CallbackFactory}}()
+
+	serviceHandler := {{.Service.Name}}.NewServiceHandler(genCallbacks, &serviceInterface)
+
+	serviceRouter := {{.Service.Name}}.NewServiceRouter(genCallbacks, serviceHandler)
+	serviceRouter.WireRoutes(ctx, router)
+
+	log.Println("starting {{.Service.Name}} on :{{.Service.Port}}")
+	return http.ListenAndServe(":{{.Service.Port}}", router)
+}
+
+func main() {
+	log.Fatal(LoadServices(context.Background()))
+}
+`
+}

--- a/pkg/testrig/maindb.go
+++ b/pkg/testrig/maindb.go
@@ -1,0 +1,64 @@
+package testrig
+
+func GetMainDbStub() string {
+	return `package main
+
+import (
+	"context"
+	"log"
+	"net/http"
+	"database/sql"
+	"time"
+
+	"github.com/go-chi/chi"
+	_ "github.com/lib/pq"
+
+	{{.Service.Name}} "{{.Service.URL}}"
+	{{.Service.Impl.Name}} "{{.Service.Impl.URL}}"
+)
+
+func initDb() (*sql.DB, error) {
+	psqlInfo := "host={{.Service.Name}}_db port=5432 user=someuser password=somepassword dbname=somedb sslmode=disable"
+	db, err := sql.Open("postgres", psqlInfo)
+	if err != nil {
+		return nil, err
+	}
+
+	time.Sleep(5 * time.Second)
+
+	err = db.Ping()
+	if err != nil {
+		log.Println(err)
+		return nil, err
+	}
+
+	return db, nil
+}
+
+func loadServices(ctx context.Context) error {
+	router := chi.NewRouter()
+
+	db, err := initDb()
+	if err != nil {
+		return err
+	}
+	defer db.Close()
+
+	serviceInterface := {{.Service.Impl.Name}}.{{.Service.Impl.InterfaceFactory}}()
+
+	genCallbacks := {{.Service.Impl.Name}}.{{.Service.Impl.CallbackFactory}}(db)
+
+	serviceHandler := {{.Service.Name}}.NewServiceHandler(genCallbacks, &serviceInterface)
+
+	serviceRouter := {{.Service.Name}}.NewServiceRouter(genCallbacks, serviceHandler)
+	serviceRouter.WireRoutes(ctx, router)
+
+	log.Println("starting {{.Service.Name}} on :{{.Service.Port}}")
+	return http.ListenAndServe(":{{.Service.Port}}", router)
+}
+
+func main() {
+	log.Fatal(loadServices(context.Background()))
+}
+`
+}

--- a/pkg/testrig/testrig.go
+++ b/pkg/testrig/testrig.go
@@ -1,0 +1,194 @@
+// Package testrig provides tools for generating standalone test environment for sysl generated services
+package testrig
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"text/template"
+
+	"github.com/anz-bank/sysl/pkg/sysl"
+	"github.com/anz-bank/sysl/pkg/syslutil"
+
+	"github.com/ghodss/yaml"
+	"github.com/spf13/afero"
+)
+
+// GenerateRig creates full set of files required to start up a test rig
+// for every service, it creates main.go (optionally with DB connection) and a dockerfile to containerize it
+// if the service contains DB tables, it creates sidecar postgres container and creates a schema there
+// finally, it creates docker-compose.yml at the point of all (likely your project's root)
+// that joins all containerized services
+func GenerateRig(fs afero.Fs, templateFile string, outputDir string, modules []*sysl.Module) error {
+	serviceMap, err := readUserData(fs, templateFile)
+	if err != nil {
+		return err
+	}
+
+	applications := make(map[string]*sysl.Application)
+	for _, module := range modules {
+		for appName, app := range module.GetApps() {
+			applications[appName] = app
+		}
+	}
+
+	composeServices := make(map[string]interface{})
+
+	for serviceName, serviceTmpl := range serviceMap {
+		if err := fs.MkdirAll(filepath.Join(outputDir, serviceName), os.ModePerm); err != nil {
+			return err
+		}
+
+		if err := generateMain(fs, serviceName, serviceTmpl, outputDir, appNeedsDb(applications[serviceName])); err != nil {
+			return err
+		}
+
+		if err := generateDockerfile(fs, serviceName, serviceTmpl, outputDir); err != nil {
+			return err
+		}
+
+		var dependencies []string
+		if appNeedsDb(applications[serviceName]) {
+			dbServiceName := serviceName + "_db"
+			composeServices[dbServiceName] = generateDbService(serviceName)
+			dependencies = []string{dbServiceName}
+		}
+		composeServices[serviceName] = generateAppService(&generateAppServiceInput{
+			ServiceName: serviceName,
+			Vars:        serviceTmpl,
+			OutputDir:   outputDir,
+			DependsOn:   dependencies,
+		})
+	}
+
+	return generateCompose(fs, composeServices)
+}
+
+func appNeedsDb(app *sysl.Application) bool {
+	if app == nil {
+		return false
+	}
+	patterns := syslutil.MakeStrSetFromAttr("patterns", app.Attrs)
+	return patterns.Contains("DB")
+}
+
+func readUserData(fs afero.Fs, templateFileName string) (ServiceVarsMap, error) {
+	templateFile, err := fs.Open(templateFileName)
+	if err != nil {
+		return nil, err
+	}
+	defer templateFile.Close()
+
+	byteValue, err := ioutil.ReadAll(templateFile)
+	if err != nil {
+		return nil, err
+	}
+	var vars ServiceVarsMap
+	if err := json.Unmarshal(byteValue, &vars); err != nil {
+		return nil, err
+	}
+	return vars, nil
+}
+
+type generateAppServiceInput struct {
+	ServiceName string
+	Vars        ServiceVars
+	OutputDir   string
+	DependsOn   []string
+}
+
+func generateAppService(input *generateAppServiceInput) map[string]interface{} {
+	return map[string]interface{}{
+		"build": map[string]interface{}{
+			"context":    ".",
+			"dockerfile": filepath.Join(input.OutputDir, input.ServiceName, "Dockerfile"),
+		},
+		"ports":      []string{fmt.Sprintf("%v:%v", input.Vars.Port, input.Vars.Port)},
+		"depends_on": input.DependsOn,
+	}
+}
+
+func generateDbService(serviceName string) map[string]interface{} {
+	return map[string]interface{}{
+		"image": "postgres:latest",
+		"ports": []string{"5432:5432"},
+		"volumes": []string{
+			fmt.Sprintf("../gen/%v/%v.sql:/docker-entrypoint-initdb.d/%v.sql", serviceName, serviceName, serviceName),
+		},
+		"environment": map[string]string{
+			"POSTGRES_USER":     "someuser",
+			"POSTGRES_PASSWORD": "somepassword",
+			"POSTGRES_DB":       "somedb",
+		},
+	}
+}
+
+func generateCompose(fs afero.Fs, composeServices map[string]interface{}) error {
+	output, err := fs.Create("docker-compose.yml")
+	if err != nil {
+		return err
+	}
+	defer output.Close()
+
+	data := map[string]interface{}{
+		"version":  "3.3",
+		"services": composeServices,
+	}
+
+	dataRaw, err := yaml.Marshal(data)
+	if err != nil {
+		return err
+	}
+
+	if _, err := output.Write(dataRaw); err != nil {
+		return err
+	}
+	return output.Sync()
+}
+
+func processTemplate(file afero.File, resource string, data ServiceVars, outputDir string) error {
+	tmpl, err := template.New("servicesData").Parse(resource)
+	if err != nil {
+		return err
+	}
+	userData := struct {
+		OutputDir string
+		Service   ServiceVars
+	}{
+		OutputDir: outputDir,
+		Service:   data,
+	}
+	if err := tmpl.Execute(file, userData); err != nil {
+		return err
+	}
+	return file.Sync()
+}
+
+func generateMain(fs afero.Fs, serviceName string, serviceVars ServiceVars, outputDir string, needDb bool) error {
+	output, err := fs.Create(filepath.Join(outputDir, serviceName, "main.go"))
+	if err != nil {
+		return err
+	}
+	defer output.Close()
+
+	mainTemplate := GetMainStub()
+	if needDb {
+		mainTemplate = GetMainDbStub()
+	}
+
+	return processTemplate(output, mainTemplate, serviceVars, outputDir)
+}
+
+func generateDockerfile(fs afero.Fs, serviceName string, serviceVars ServiceVars, outputDir string) error {
+	output, err := fs.Create(filepath.Join(outputDir, serviceName, "Dockerfile"))
+	if err != nil {
+		return err
+	}
+	defer output.Close()
+
+	dockerTemplate := GetDockerfileStub()
+
+	return processTemplate(output, dockerTemplate, serviceVars, outputDir)
+}

--- a/pkg/testrig/types.go
+++ b/pkg/testrig/types.go
@@ -1,0 +1,20 @@
+package testrig
+
+type ServiceVarsMap map[string]ServiceVars
+
+type serviceVarsBase struct {
+	Name   string `json:"name"`
+	Import string `json:"import"`
+}
+
+type ServiceVars struct {
+	serviceVarsBase
+	Port string          `json:"port"`
+	Impl ServiceImplVars `json:"impl"`
+}
+
+type ServiceImplVars struct {
+	serviceVarsBase
+	InterfaceFactory string `json:"interface_factory"`
+	CallbackFactory  string `json:"callback_factory"`
+}


### PR DESCRIPTION
Test rig generation for Sysl.
Currently supports single services with sidecar DB.

Command syntax lives in console help,.
Full test project lives here:
https://github.service.anz/eresova/test-rig
