### PR TITLE
Bugfix/fix linter issues

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,5 +1,5 @@
 service:
-  golangci-lint-version: 1.19.1
+  golangci-lint-version: 1.23.3
 run:
   skip-files:
     - pkg/grammar/sysl_lexer.go

--- a/pkg/ui/spa_test.go
+++ b/pkg/ui/spa_test.go
@@ -16,8 +16,9 @@ func TestSpaHandlerNonExistent(t *testing.T) {
 	w := httptest.NewRecorder()
 	handler := spaHandler{staticPath: "/ui/build", indexPath: "/ui/build/index.html", fileSystem: pkgerFS{}}
 	handler.ServeHTTP(w, req)
-	defer w.Result().Body.Close()
-	assert.Equal(t, 500, w.Result().StatusCode, "expected status code to be 500 but got %d", w.Result().StatusCode)
+	result := w.Result()
+	defer result.Body.Close()
+	assert.Equal(t, 500, result.StatusCode, "expected status code to be 500 but got %d", result.StatusCode)
 }
 
 func TestSpaHandlerInvalidPath(t *testing.T) {
@@ -26,8 +27,9 @@ func TestSpaHandlerInvalidPath(t *testing.T) {
 	w := httptest.NewRecorder()
 	handler := spaHandler{staticPath: "/ui/build", indexPath: "/ui/build/index.html", fileSystem: pkgerFS{}}
 	handler.ServeHTTP(w, req)
-	defer w.Result().Body.Close()
-	assert.Equal(t, 500, w.Result().StatusCode, "expected status code to be 500 but got %d", w.Result().StatusCode)
+	result := w.Result()
+	defer result.Body.Close()
+	assert.Equal(t, 500, result.StatusCode, "expected status code to be 500 but got %d", result.StatusCode)
 }
 
 type mockFileSystem struct {
@@ -37,22 +39,34 @@ func (m *mockFileSystem) Stat(name string) (os.FileInfo, error) {
 	return nil, nil
 }
 
-type mockHttpFileSystem struct{}
+type mockHTTPFileSystem struct{}
 
-func (f mockHttpFileSystem) Open(name string) (http.File, error) {
+func (f mockHTTPFileSystem) Open(name string) (http.File, error) {
 	appFS := afero.NewMemMapFs()
-	appFS.MkdirAll("/ui/build", 0755)
-	appFS.MkdirAll("/ui/build/data/", 0755)
-	afero.WriteFile(appFS, "/ui/build/data/services.json", []byte("file a"), 0644)
-	afero.WriteFile(appFS, "/ui/build/index.html", []byte("file b"), 0644)
+	if err := appFS.MkdirAll("/ui/build", 0755); err != nil {
+		return nil, err
+	}
+	if err := appFS.MkdirAll("/ui/build/data/", 0755); err != nil {
+		return nil, err
+	}
+	if err := afero.WriteFile(appFS, "/ui/build/data/services.json", []byte("file a"), 0644); err != nil {
+		return nil, err
+	}
+	if err := afero.WriteFile(appFS, "/ui/build/index.html", []byte("file b"), 0644); err != nil {
+		return nil, err
+	}
 	return appFS.Open(name)
 }
 
 func (m *mockFileSystem) Dir(name string) http.FileSystem {
 	appFS := afero.NewMemMapFs()
-	appFS.MkdirAll("/ui/build", 0755)
-	afero.WriteFile(appFS, "/ui/build/index.html", []byte("file b"), 0644)
-	return mockHttpFileSystem{}
+	if err := appFS.MkdirAll("/ui/build", 0755); err != nil {
+		return nil
+	}
+	if err := afero.WriteFile(appFS, "/ui/build/index.html", []byte("file b"), 0644); err != nil {
+		return nil
+	}
+	return mockHTTPFileSystem{}
 }
 func TestSpaHandlerValidPath(t *testing.T) {
 	// Test we can handle spa
@@ -61,8 +75,9 @@ func TestSpaHandlerValidPath(t *testing.T) {
 	mockFileSystem := new(mockFileSystem)
 	handler := spaHandler{staticPath: "/ui/build", indexPath: "/ui/build/index.html", fileSystem: mockFileSystem}
 	handler.ServeHTTP(w, req)
-	defer w.Result().Body.Close()
-	assert.Equal(t, 200, w.Result().StatusCode, "expected status code to be 200 but got %d", w.Result().StatusCode)
+	result := w.Result()
+	defer result.Body.Close()
+	assert.Equal(t, 200, result.StatusCode, "expected status code to be 200 but got %d", result.StatusCode)
 }
 
 func TestSpaHandlerFolderPath(t *testing.T) {
@@ -72,8 +87,9 @@ func TestSpaHandlerFolderPath(t *testing.T) {
 	mockFileSystem := new(mockFileSystem)
 	handler := spaHandler{staticPath: "/ui/build", indexPath: "/ui/build/index.html", fileSystem: mockFileSystem}
 	handler.ServeHTTP(w, req)
-	defer w.Result().Body.Close()
-	assert.Equal(t, 200, w.Result().StatusCode, "expected status code to be 200 but got %d", w.Result().StatusCode)
+	result := w.Result()
+	defer result.Body.Close()
+	assert.Equal(t, 200, result.StatusCode, "expected status code to be 200 but got %d", result.StatusCode)
 }
 
 // This test currently fails when it runs on windows. Uncomment when pkger has been fixed or replaced


### PR DESCRIPTION
- Fixes linter issues which are picked up by golangci-lint 1.23.8 but not by older versions e.g 1.19 which was run by the CI
- Bump version of golangci-lint to 1.23.3. Ideally we would bump to 1.23.8 but currently, this isn't supported by golangci. More details in https://github.com/anz-bank/sysl/commit/fbec3436d097d55b6d7aedcef88d4316c0677392  



```
golangci-lint run
WARN [runner/nolint] Found unknown linters in //nolint directives: bodycloser
pkg/ui/spa_test.go:40:6: type `mockHttpFileSystem` should be `mockHTTPFileSystem` (golint)
type mockHttpFileSystem struct{}
     ^
pkg/ui/spa_test.go:44:16: Error return value of `appFS.MkdirAll` is not checked (errcheck)
        appFS.MkdirAll("/ui/build", 0755)
                      ^
pkg/ui/spa_test.go:45:16: Error return value of `appFS.MkdirAll` is not checked (errcheck)
        appFS.MkdirAll("/ui/build/data/", 0755)
                      ^
pkg/ui/spa_test.go:46:17: Error return value of `afero.WriteFile` is not checked (errcheck)
        afero.WriteFile(appFS, "/ui/build/data/services.json", []byte("file a"), 0644)
                       ^
pkg/ui/spa_test.go:47:17: Error return value of `afero.WriteFile` is not checked (errcheck)
        afero.WriteFile(appFS, "/ui/build/index.html", []byte("file b"), 0644)
                       ^
pkg/ui/spa_test.go:53:16: Error return value of `appFS.MkdirAll` is not checked (errcheck)
        appFS.MkdirAll("/ui/build", 0755)
                      ^
pkg/ui/spa_test.go:54:17: Error return value of `afero.WriteFile` is not checked (errcheck)
        afero.WriteFile(appFS, "/ui/build/index.html", []byte("file b"), 0644)
                       ^
pkg/ui/server_test.go:56:13: response body must be closed (bodyclose)
        if w.Result().StatusCode != 200 {
                   ^
pkg/ui/server_test.go:111:31: response body must be closed (bodyclose)
        assert.Equal(t, 200, w.Result().StatusCode, "Expected return status code of 200")
                                     ^
pkg/ui/server_test.go:187:26: response body must be closed (bodyclose)
        assert.Equal(t, w.Result().StatusCode, 200)
                                ^
make: *** [lint] Error 1
```