### PR TITLE
Fix goreleaser version to version: v0.126.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,8 +38,9 @@ jobs:
           SYSL_PLANTUML: http://www.plantuml.com/plantuml
 
       - name: Validate goreleaser config
-        uses: goreleaser/goreleaser-action@master
+        uses: goreleaser/goreleaser-action@v1.3.1
         with:
+          version: v0.126.0
           args: check -f .github/goreleaser_configs/.goreleaser.yml
 
       # GoReleaser requires Docker Hub access to push image
@@ -54,8 +55,9 @@ jobs:
 
       # GoReleaser release process is customized in `.goreleaser.yml` file
       - name: Release binaries and docker images via goreleaser
-        uses: goreleaser/goreleaser-action@master
+        uses: goreleaser/goreleaser-action@v1.3.1
         with:
+          version: v0.126.0
           args: release --rm-dist --debug -f .github/goreleaser_configs/.goreleaser.yml
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Attempt to fix issues with Release action not working.

Examples of failed releases:
https://github.com/anz-bank/sysl/runs/510101515?check_suite_focus=true
https://github.com/anz-bank/sysl/actions/runs/45279915

Key error message
```
 ⨯ release failed after 462.85s error=GitHub/GitLab/Gitea Releases: failed to publish artifacts: failed to upload ***_0.8.0_checksums.txt after 10 retries: POST https://uploads.github.com/repos/***/***/releases/24545312/assets?name=***_0.8.0_checksums.txt: 422 Validation Failed [{Resource:ReleaseAsset Field:name Code:already_exists Message:}]
```
An issue has been raised on this, so until this is fixed, we should use an older version, `v0.126.0`
https://github.com/goreleaser/goreleaser/issues/1382

Tested on my fork https://github.com/cuminandpaprika/sysl/actions/runs/56635451