### PR TITLE
Move datamodel to own package

### DIFF
--- a/cmd/sysl/cmd_datamodel.go
+++ b/cmd/sysl/cmd_datamodel.go
@@ -1,127 +1,13 @@
 package main
 
 import (
-	"fmt"
-	"regexp"
-	"strings"
-
-	"github.com/anz-bank/sysl/pkg/diagrams"
-	"github.com/anz-bank/sysl/pkg/sequencediagram"
+	"github.com/anz-bank/sysl/pkg/datamodeldiagram"
 
 	"github.com/anz-bank/sysl/pkg/cmdutils"
+	"github.com/anz-bank/sysl/pkg/diagrams"
 
 	"gopkg.in/alecthomas/kingpin.v2"
-
-	sysl "github.com/anz-bank/sysl/pkg/sysl"
-	"github.com/sirupsen/logrus"
 )
-
-func generateDataModelsWithProjectMannerModule(datagenParams *cmdutils.CmdContextParamDatagen,
-	model *sysl.Module, logger *logrus.Logger) (map[string]string, error) {
-	outmap := make(map[string]string)
-
-	logger.Debugf("project: %v\n", datagenParams.Project)
-	logger.Debugf("title: %s\n", datagenParams.Title)
-	logger.Debugf("filter: %s\n", datagenParams.Filter)
-	logger.Debugf("output: %s\n", datagenParams.Output)
-
-	spclass := sequencediagram.ConstructFormatParser("", datagenParams.ClassFormat)
-
-	// The "project" app that specifies the data models to be built
-	var app *sysl.Application
-	var exists bool
-	if app, exists = model.GetApps()[datagenParams.Project]; !exists {
-		return nil, fmt.Errorf("project not found in sysl")
-	}
-
-	// Iterate over each endpoint within the selected project
-	for epname, endpt := range app.GetEndpoints() {
-		outputDir := datagenParams.Output
-		if strings.Contains(outputDir, "%(epname)") {
-			of := cmdutils.MakeFormatParser(datagenParams.Output)
-			outputDir = of.FmtOutput(datagenParams.Project, epname, endpt.GetLongName(), endpt.GetAttrs())
-		}
-		if datagenParams.Filter != "" {
-			re := regexp.MustCompile(datagenParams.Filter)
-			if !re.MatchString(outputDir) {
-				continue
-			}
-		}
-		generateDataModel(spclass, outmap, model, endpt.GetStmt(), datagenParams.Title, datagenParams.Project, outputDir)
-	}
-	return outmap, nil
-}
-
-/**
- * It is added to help reviewing generated data model with sysl
- * file produced by command import. Generate data model diagrams using the following command:
- * sysl data      -d --root=/Users/guest/data -t Test -o Test.png Test
- * sysl datamodel -d --root=/Users/guest/data -t Test -o Test.png Test.sysl
- */
-func generateDataModelsWithPureModule(datagenParams *cmdutils.CmdContextParamDatagen,
-	model *sysl.Module, logger *logrus.Logger) (map[string]string, error) {
-	outmap := make(map[string]string)
-
-	logger.Debugf("title: %s\n", datagenParams.Title)
-	logger.Debugf("output: %s\n", datagenParams.Output)
-
-	spclass := sequencediagram.ConstructFormatParser("", datagenParams.ClassFormat)
-
-	apps := model.GetApps()
-	for appName := range apps {
-		app := apps[appName]
-		outputDir := datagenParams.Output
-		if strings.Contains(outputDir, "%(epname)") {
-			of := cmdutils.MakeFormatParser(datagenParams.Output)
-			outputDir = of.FmtOutput(appName, appName, app.GetLongName(), app.GetAttrs())
-		}
-		var stringBuilder strings.Builder
-		if app != nil {
-			dataParam := &DataModelParam{
-				Mod:   model,
-				App:   app,
-				Title: datagenParams.Title,
-			}
-			v := MakeDataModelView(spclass, dataParam.Mod, &stringBuilder, dataParam.Title, "")
-			outmap[outputDir] = v.GenerateDataView(dataParam)
-		}
-	}
-
-	return outmap, nil
-}
-
-func generateDataModel(pclass cmdutils.ClassLabeler, outmap map[string]string, mod *sysl.Module,
-	stmts []*sysl.Statement, title, project, outDir string) {
-	apps := mod.GetApps()
-
-	// Parse all the applications in the project
-	for _, stmt := range stmts {
-		if a, ok := stmt.Stmt.(*sysl.Statement_Action); ok {
-			var stringBuilder strings.Builder
-			app := apps[a.Action.Action]
-			if app != nil {
-				dataParam := &DataModelParam{
-					Mod:     mod,
-					App:     app,
-					Title:   title,
-					Project: project,
-				}
-				v := MakeDataModelView(pclass, dataParam.Mod, &stringBuilder, dataParam.Title, dataParam.Project)
-				outmap[outDir] = v.GenerateDataView(dataParam)
-			}
-		}
-	}
-}
-
-func generateDataModels(datagenParams *cmdutils.CmdContextParamDatagen,
-	model *sysl.Module, logger *logrus.Logger) (map[string]string, error) {
-	if datagenParams.Direct {
-		// The sysl file is not project manner
-		return generateDataModelsWithPureModule(datagenParams, model, logger)
-	}
-	// Sysl file is project manner
-	return generateDataModelsWithProjectMannerModule(datagenParams, model, logger)
-}
 
 type datamodelCmd struct {
 	diagrams.Plantumlmixin
@@ -154,7 +40,7 @@ func (p *datamodelCmd) Configure(app *kingpin.Application) *kingpin.CmdClause {
 }
 
 func (p *datamodelCmd) Execute(args cmdutils.ExecuteArgs) error {
-	outmap, err := generateDataModels(&p.CmdContextParamDatagen, args.Modules[0], args.Logger)
+	outmap, err := datamodeldiagram.GenerateDataModels(&p.CmdContextParamDatagen, args.Modules[0], args.Logger)
 	if err != nil {
 		return err
 	}

--- a/cmd/sysl/deps.go
+++ b/cmd/sysl/deps.go
@@ -1,1 +1,0 @@
-package main

--- a/pkg/datamodeldiagram/datamodel.go
+++ b/pkg/datamodeldiagram/datamodel.go
@@ -1,0 +1,119 @@
+package datamodeldiagram
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/anz-bank/sysl/pkg/cmdutils"
+	"github.com/anz-bank/sysl/pkg/sequencediagram"
+	"github.com/anz-bank/sysl/pkg/sysl"
+	"github.com/sirupsen/logrus"
+)
+
+func GenerateDataModelsWithProjectMannerModule(datagenParams *cmdutils.CmdContextParamDatagen,
+	model *sysl.Module, logger *logrus.Logger) (map[string]string, error) {
+	outmap := make(map[string]string)
+
+	logger.Debugf("project: %v\n", datagenParams.Project)
+	logger.Debugf("title: %s\n", datagenParams.Title)
+	logger.Debugf("filter: %s\n", datagenParams.Filter)
+	logger.Debugf("output: %s\n", datagenParams.Output)
+
+	spclass := sequencediagram.ConstructFormatParser("", datagenParams.ClassFormat)
+
+	// The "project" app that specifies the data models to be built
+	var app *sysl.Application
+	var exists bool
+	if app, exists = model.GetApps()[datagenParams.Project]; !exists {
+		return nil, fmt.Errorf("project not found in sysl")
+	}
+
+	// Iterate over each endpoint within the selected project
+	for epname, endpt := range app.GetEndpoints() {
+		outputDir := datagenParams.Output
+		if strings.Contains(outputDir, "%(epname)") {
+			of := cmdutils.MakeFormatParser(datagenParams.Output)
+			outputDir = of.FmtOutput(datagenParams.Project, epname, endpt.GetLongName(), endpt.GetAttrs())
+		}
+		if datagenParams.Filter != "" {
+			re := regexp.MustCompile(datagenParams.Filter)
+			if !re.MatchString(outputDir) {
+				continue
+			}
+		}
+		GenerateDataModel(spclass, outmap, model, endpt.GetStmt(), datagenParams.Title, datagenParams.Project, outputDir)
+	}
+	return outmap, nil
+}
+
+/**
+ * It is added to help reviewing generated data model with sysl
+ * file produced by command import. Generate data model diagrams using the following command:
+ * sysl data      -d --root=/Users/guest/data -t Test -o Test.png Test
+ * sysl datamodel -d --root=/Users/guest/data -t Test -o Test.png Test.sysl
+ */
+func GenerateDataModelsWithPureModule(datagenParams *cmdutils.CmdContextParamDatagen,
+	model *sysl.Module, logger *logrus.Logger) (map[string]string, error) {
+	outmap := make(map[string]string)
+
+	logger.Debugf("title: %s\n", datagenParams.Title)
+	logger.Debugf("output: %s\n", datagenParams.Output)
+
+	spclass := sequencediagram.ConstructFormatParser("", datagenParams.ClassFormat)
+
+	apps := model.GetApps()
+	for appName := range apps {
+		app := apps[appName]
+		outputDir := datagenParams.Output
+		if strings.Contains(outputDir, "%(epname)") {
+			of := cmdutils.MakeFormatParser(datagenParams.Output)
+			outputDir = of.FmtOutput(appName, appName, app.GetLongName(), app.GetAttrs())
+		}
+		var stringBuilder strings.Builder
+		if app != nil {
+			dataParam := &DataModelParam{
+				Mod:   model,
+				App:   app,
+				Title: datagenParams.Title,
+			}
+			v := MakeDataModelView(spclass, dataParam.Mod, &stringBuilder, dataParam.Title, "")
+			outmap[outputDir] = v.GenerateDataView(dataParam)
+		}
+	}
+
+	return outmap, nil
+}
+
+func GenerateDataModel(pclass cmdutils.ClassLabeler, outmap map[string]string, mod *sysl.Module,
+	stmts []*sysl.Statement, title, project, outDir string) {
+	apps := mod.GetApps()
+
+	// Parse all the applications in the project
+	for _, stmt := range stmts {
+		if a, ok := stmt.Stmt.(*sysl.Statement_Action); ok {
+			var stringBuilder strings.Builder
+			app := apps[a.Action.Action]
+			if app != nil {
+				dataParam := &DataModelParam{
+					Mod:     mod,
+					App:     app,
+					Title:   title,
+					Project: project,
+				}
+				v := MakeDataModelView(pclass, dataParam.Mod, &stringBuilder, dataParam.Title, dataParam.Project)
+				outmap[outDir] = v.GenerateDataView(dataParam)
+			}
+		}
+	}
+}
+
+func GenerateDataModels(datagenParams *cmdutils.CmdContextParamDatagen,
+	model *sysl.Module, logger *logrus.Logger) (map[string]string, error) {
+	if datagenParams.Direct {
+		// The sysl file is not project manner
+		return GenerateDataModelsWithPureModule(datagenParams, model, logger)
+	}
+	// Sysl file is project manner
+	return GenerateDataModelsWithProjectMannerModule(datagenParams, model, logger)
+}

--- a/pkg/datamodeldiagram/datamodel_test.go
+++ b/pkg/datamodeldiagram/datamodel_test.go
@@ -1,0 +1,89 @@
+package datamodeldiagram
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/anz-bank/sysl/pkg/cmdutils"
+	"github.com/anz-bank/sysl/pkg/diagrams"
+	"github.com/anz-bank/sysl/pkg/loader"
+	"github.com/anz-bank/sysl/pkg/parse"
+	"github.com/anz-bank/sysl/pkg/syslutil"
+	"github.com/sirupsen/logrus/hooks/test"
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGenerateDataDiagFail(t *testing.T) {
+	t.Parallel()
+	_, err := parse.NewParser().Parse("doesn't-exist.sysl", syslutil.NewChrootFs(afero.NewOsFs(), ""))
+	require.Error(t, err)
+}
+
+func TestDoConstructDataDiagramsWithProjectMannerModule(t *testing.T) {
+	args := &DataArgs{
+		Root:    testDir,
+		Modules: "data.sysl",
+		Output:  "%(epname).png",
+		Project: "Project",
+		Title:   "empdata",
+		Expected: map[string]string{
+			"Relational-Model.png":      filepath.Join(testDir, "relational-model-golden.puml"),
+			"Object-Model.png":          filepath.Join(testDir, "object-model-golden.puml"),
+			"Primitive-Alias-Model.png": filepath.Join(testDir, "primitive-alias-model-golden.puml"),
+		},
+	}
+	result, err := DoConstructDataDiagramsWithParams(args.Root, "", args.Title, args.Output, args.Project,
+		args.Modules)
+	assert.Nil(t, err, "Generating the data diagrams failed")
+	diagrams.ComparePUML(t, args.Expected, result)
+}
+
+func DoConstructDataDiagramsWithParams(
+	rootModel, filter, title, output, project, modules string,
+) (map[string]string, error) {
+	classFormat := "%(classname)"
+	cmdContextParamDatagen := &cmdutils.CmdContextParamDatagen{
+		Filter:      filter,
+		Title:       title,
+		Output:      output,
+		Project:     project,
+		ClassFormat: classFormat,
+	}
+
+	logger, _ := test.NewNullLogger()
+	mod, _, err := loader.LoadSyslModule(rootModel, modules, afero.NewOsFs(), logger)
+	if err != nil {
+		return nil, err
+	}
+	return GenerateDataModels(cmdContextParamDatagen, mod, logger)
+}
+
+func TestDoConstructDataDiagramsWithPureModule(t *testing.T) {
+	args := &DataArgs{
+		Root:    testDir,
+		Modules: "reviewdatamodelcmd.sysl",
+		Output:  "%(epname).png",
+		Title:   "testdata",
+		Expected: map[string]string{
+			"Test.png": filepath.Join(testDir, "review-data-model-cmd.puml"),
+		},
+	}
+
+	var result map[string]string
+	logger, _ := test.NewNullLogger()
+	mod, _, err := loader.LoadSyslModule(args.Root, args.Modules, afero.NewOsFs(), logger)
+	if err != nil {
+		result = nil
+	} else {
+		result, err = GenerateDataModels(&cmdutils.CmdContextParamDatagen{
+			Title:  args.Title,
+			Output: args.Output,
+			Direct: true,
+		}, mod, logger)
+	}
+
+	assert.Nil(t, err, "Generating the data diagrams failed")
+	diagrams.ComparePUML(t, args.Expected, result)
+}

--- a/pkg/datamodeldiagram/datamodelview_test.go
+++ b/pkg/datamodeldiagram/datamodelview_test.go
@@ -1,11 +1,12 @@
-package main
+package datamodeldiagram
 
 import (
 	"strings"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+
+	"github.com/stretchr/testify/assert"
 )
 
 type ClassLabelerMock struct {
@@ -24,13 +25,13 @@ func TestDrawPrimitive(t *testing.T) {
 	var stringBuilder strings.Builder
 	v := MakeDataModelView(clMock, nil, &stringBuilder, "title", "project")
 	viewParam := EntityViewParam{
-		entityColor:  "orchid",
-		entityHeader: "D",
-		entityName:   "uuid",
+		EntityColor:  "orchid",
+		EntityHeader: "D",
+		EntityName:   "uuid",
 	}
 	relationshipMap := map[string]map[string]RelationshipParam{}
-	v.drawPrimitive(viewParam, "INT", relationshipMap)
-	actual := v.stringBuilder.String()
+	v.DrawPrimitive(viewParam, "INT", relationshipMap)
+	actual := v.StringBuilder.String()
 
 	expected := "class \"uuid\" as _0 << (D,orchid) >> {\n" +
 		"+ id : int\n}\n"

--- a/pkg/datamodeldiagram/sysl_const.go
+++ b/pkg/datamodeldiagram/sysl_const.go
@@ -1,0 +1,3 @@
+package datamodeldiagram
+
+const testDir = "../../tests/"

--- a/pkg/datamodeldiagram/testutil.go
+++ b/pkg/datamodeldiagram/testutil.go
@@ -1,0 +1,10 @@
+package datamodeldiagram
+
+type DataArgs struct {
+	Root     string
+	Title    string
+	Output   string
+	Project  string
+	Modules  string
+	Expected map[string]string
+}

--- a/pkg/integrationdiagram/sysl_const.go
+++ b/pkg/integrationdiagram/sysl_const.go
@@ -1,5 +1,4 @@
 package integrationdiagram
 
-const syslDir = "../../pkg/"
 const projDir = "../../"
 const testDir = "../../tests/"


### PR DESCRIPTION
continues on #478 

Moves all data model code to `pkg/datamodeldiagram`

this is the final installment in the "diagram trilogy" that included #645 #696 and this

Hopefully a continuation of this trilogy will be made one day, as I hope this stunning example of pure excitement has inspired those who really want to stand up to the authoritarian rule of the `main` empire.

Let's continue our revolt against this beast, spreading it's resources among smaller and more diverse groups among the small and often overlooked far reaches of the `pkg` directory. 

The `main` empire is crumbling at the forces of the `pkg` resistance, down from it's peak of 8832 lines of code, now down to 2783 lines of code. 

But I say NOT ENOUGH. 
We can go further.
We can have the smallest possible `main` empire. 
Stand with me.
We can do this!
