### PR TITLE
Wbnf grammar fixes

### DIFF
--- a/pkg/parser/endpoints.wbnf
+++ b/pkg/parser/endpoints.wbnf
@@ -7,7 +7,9 @@ rest_endpoint -> http_path attribs? ":" %!Indented(method_def | rest_endpoint);
 
 method_def -> method=(HTTP_VERBS) params? query_param? attribs? ":" %!Indented(stmt);
 
-params -> "(" (field | reference):"," ")";
+params -> "(" (field | reference):"," ")" {
+    .wrapRE -> /{\s*()\s*};
+};
 
 query_param -> "?" (ident=(NAME) "=" (NativeDataTypes| NAME | "{" NAME "}") optional="?"?):"&";
 

--- a/pkg/parser/sysl.wbnf
+++ b/pkg/parser/sysl.wbnf
@@ -106,7 +106,7 @@ NativeDataTypes -> "int32" | "int64" | "int" |
                 "float" | "string" | "datetime" | "date" |
                 "bool" | "decimal";
 
-reference ->  \s* pkg=(NAME:"::" ".")? APPNAME;
+reference ->  pkg=(NAME:"::" ".")? APPNAME;
 
 COMMENT_NO_NL -> "#" [^\n]*;
 COMMENT -> COMMENT_NO_NL "\n";

--- a/pkg/parser/sysl.wbnf
+++ b/pkg/parser/sysl.wbnf
@@ -13,7 +13,7 @@ import  -> "import"  prefix=("//"|"/")? PATH ( "as"  reference)? ("~" mode=NAME)
 
 // -------------- Events --------------- //
 
-event  ->  "<->" NAME params? attribs? ":" COMMENT*
+event  ->  "<->" APPNAME params? attribs? ":" COMMENT*
         ( SHORTCUT | %!Indented(stmt));
 subscribe  ->  APPNAME "->" NAME params? attribs? ":" COMMENT*
         ( SHORTCUT | %!Indented(stmt));

--- a/pkg/parser/sysl.wbnf
+++ b/pkg/parser/sysl.wbnf
@@ -58,8 +58,14 @@ facade -> "!wrap" NAME  ":" COMMENT*
         };
 
 alias -> "!alias" NAME attribs?  ":" COMMENT*
-        (%!Indented(alias_line) | alias_line);
-alias_line -> annotation* (collection_type | type_spec);
+        (indented_alias_def | inline_alias_def) {
+        inline_alias_def -> annotation* (collection_type | type_spec);
+
+        indented_alias_def -> (annotations INDENT_SEP | \n+ INDENT)
+                          (collection_type | type_spec)
+                          (INDENT_SEP annotation:INDENT_SEP)?;
+};
+
 union -> "!union" NAME attribs?  ":"
     ( SHORTCUT |
          %!Indented(COMMENT_NO_NL | user_defined_type=NAME | annotation | SHORTCUT )

--- a/pkg/parser/sysl.wbnf
+++ b/pkg/parser/sysl.wbnf
@@ -83,7 +83,7 @@ array_of_array   -> "[" (array_of_strings:",")? "]";
 
 array_size -> "(" min=("0"|DIGITS) ".." max=DIGITS? ")";
 
-annotation -> "@" var_name=(NAME) "=" value=(QSTRING | array_of_strings | multi_line_docstring);
+annotation -> "@" var_name=([a-zA-Z_][-\w.]*) "=" value=(QSTRING | array_of_strings | multi_line_docstring);
 
 annotations -> %!Indented(annotation);
 

--- a/pkg/parser/sysl.wbnf
+++ b/pkg/parser/sysl.wbnf
@@ -62,7 +62,7 @@ alias -> "!alias" NAME attribs?  ":" COMMENT*
 alias_line -> annotation* (collection_type | type_spec);
 union -> "!union" NAME attribs?  ":"
     ( SHORTCUT |
-         %!Indented(COMMENT | type_spec | annotation | SHORTCUT )
+         %!Indented(COMMENT_NO_NL | user_defined_type=NAME | annotation | SHORTCUT )
     );
 
 collection_type -> ("set"|"sequence") "of" type_spec;

--- a/scripts/grammar-out.txt
+++ b/scripts/grammar-out.txt
@@ -169,7 +169,7 @@
 ./pkg/parse/tests/docstrings.sysl success
 ./pkg/parse/tests/with_spaces.sysl success
 ./pkg/parse/tests/rank.sysl success
-./pkg/parse/tests/alias.sysl fail
+./pkg/parse/tests/alias.sysl success
 ./pkg/parse/tests/matching.sysl fail
 ./pkg/parse/tests/test2.sysl success
 ./pkg/parse/tests/tableof.sysl success
@@ -233,4 +233,4 @@
 ./pkg/exporter/test-data/SWAGGER_ENSURE_HEADER_FIELDS_IN_INSERTION_ORDER.sysl success
 ./pkg/exporter/test-data/REST_ENDPOINT_DOT.sysl success
 ./pkg/exporter/test-data/SWAGGER_QUERY_PARAM_EXAMPLE.sysl success
-Passes:194 Fails:41
+Passes:195 Fails:40

--- a/scripts/grammar-out.txt
+++ b/scripts/grammar-out.txt
@@ -1,6 +1,6 @@
 ./demo/bank/project.sysl success
 ./demo/bank/bank.sysl success
-./demo/grocerystore/grocerystore.sysl fail
+./demo/grocerystore/grocerystore.sysl success
 ./demo/simple/reljam-xsd.sysl success
 ./demo/simple/sysl-sd.sysl success
 ./demo/simple/example2.sysl success
@@ -81,7 +81,7 @@
 ./tests/blackbox.sysl success
 ./tests/reviewdatamodelcmd.sysl fail
 ./tests/args.sysl success
-./tests/ui_grpc.sysl fail
+./tests/ui_grpc.sysl success
 ./tests/groupby.sysl success
 ./docs/website/static/assets/if-else.sysl success
 ./docs/website/static/assets/data.sysl success
@@ -233,4 +233,4 @@
 ./pkg/exporter/test-data/SWAGGER_ENSURE_HEADER_FIELDS_IN_INSERTION_ORDER.sysl success
 ./pkg/exporter/test-data/REST_ENDPOINT_DOT.sysl success
 ./pkg/exporter/test-data/SWAGGER_QUERY_PARAM_EXAMPLE.sysl success
-Passes:195 Fails:40
+Passes:197 Fails:38

--- a/scripts/grammar-out.txt
+++ b/scripts/grammar-out.txt
@@ -92,7 +92,7 @@
 ./docs/website/static/assets/for-loop.sysl success
 ./docs/website/static/assets/api.sysl success
 ./docs/website/static/assets/events.sysl success
-./docs/website/static/assets/nested.sysl fail
+./docs/website/static/assets/nested.sysl success
 ./docs/website/static/assets/args.sysl success
 ./unsorted/examples/grammars/go/go.gen.sysl fail
 ./unsorted/examples/grammars/java/java.gen.sysl fail
@@ -169,7 +169,7 @@
 ./pkg/parse/tests/docstrings.sysl success
 ./pkg/parse/tests/with_spaces.sysl success
 ./pkg/parse/tests/rank.sysl success
-./pkg/parse/tests/alias.sysl success
+./pkg/parse/tests/alias.sysl fail
 ./pkg/parse/tests/matching.sysl fail
 ./pkg/parse/tests/test2.sysl success
 ./pkg/parse/tests/tableof.sysl success

--- a/scripts/grammar-out.txt
+++ b/scripts/grammar-out.txt
@@ -75,7 +75,7 @@
 ./tests/multiple-app-datamodel.sysl success
 ./tests/ui_rest.sysl fail
 ./tests/integration_immediate_predecessors_test.sysl success
-./tests/test1.sysl fail
+./tests/test1.sysl success
 ./tests/comments.sysl fail
 ./tests/model.sysl success
 ./tests/blackbox.sysl success
@@ -203,7 +203,7 @@
 ./pkg/parse/tests/test_rest_api.sysl success
 ./pkg/parse/tests/project.sysl success
 ./pkg/parse/tests/absolute_import.sysl success
-./pkg/parse/tests/test1.sysl fail
+./pkg/parse/tests/test1.sysl success
 ./pkg/parse/tests/for_loop.sysl success
 ./pkg/parse/tests/duplicate_import_single.sysl success
 ./pkg/parse/tests/args.sysl success
@@ -233,4 +233,4 @@
 ./pkg/exporter/test-data/SWAGGER_ENSURE_HEADER_FIELDS_IN_INSERTION_ORDER.sysl success
 ./pkg/exporter/test-data/REST_ENDPOINT_DOT.sysl success
 ./pkg/exporter/test-data/SWAGGER_QUERY_PARAM_EXAMPLE.sysl success
-Passes:197 Fails:38
+Passes:199 Fails:36

--- a/tests/table.sysl
+++ b/tests/table.sysl
@@ -8,3 +8,9 @@ Table:
         !table inline_shortcut: ...
 
     !table inline_shortcut_again: ...
+
+    !table multiple_field_attributes:
+        multiline_field <:
+            a <: string
+            b <: int
+            c <: reference


### PR DESCRIPTION
Multiple small fixes on the grammar. I have divided them into multiple commits for easier review. I can divide them into multiple PRs but the fixes are very small.

Changes proposed in this pull request:
- `union` rule has working `COMMENT` statement.
- `union` rule for `user_defined_type` is changed to `NAME`. `type_spec` allows sized types which isn't allowed in the original grammar.
- `param` rule now allows newline inside parameters. Current `sysl validate` doesn't allow this, but this needs to be allowed as one of the allowed argument is an field with multiple attributes. For example:
```
field <:
      attribute1 <: int
      attribute2 <: string
```
- `field` multiple attributes now work like the example above.
- `alias` restricts to one `type` line (it allowed multiple `type` line before)
- `annotation` now allows full stop.


@anz-bank/sysl-developers
