### PR TITLE
handles lines with random spaces between indented statements

### DIFF
--- a/pkg/parser/sysl.wbnf
+++ b/pkg/parser/sysl.wbnf
@@ -121,9 +121,9 @@ QSTRING -> /{ " (?: \\. | [^\\"] )* "
            | ' (?: \\. | [^\\'] )* '
            };
 
-.wrapRE -> \n+ | \s+ | /{[\_]*()[\_]*};
+.wrapRE -> /{(\n (?:[\_\t]+ \n)?)+} | \n+ | \s+ | /{[\_]*()[\_]*};
 
 INDENT      -> %level="" \s+;
-INDENT_SEP  -> \n+ %level;
+INDENT_SEP  -> /{(\n (?:[\_\t]+ \n)?)+} %level;
 
-.macro Indented(child) {\n+ level=INDENT child:INDENT_SEP}
+.macro Indented(child) {/{(\n (?:[\_\t]+ \n)?)+} level=INDENT child:INDENT_SEP}

--- a/scripts/grammar-out.txt
+++ b/scripts/grammar-out.txt
@@ -4,16 +4,19 @@
 ./demo/simple/reljam-xsd.sysl success
 ./demo/simple/sysl-sd.sysl success
 ./demo/simple/example2.sysl success
+./demo/simple/sysl-app-hyperlink.sysl success
 ./demo/simple/hello.sysl success
+./demo/simple/sysl-endpoint-hyperlink.sysl success
+./demo/simple/sysl-endpoint-app-hyperlink.sysl success
 ./demo/simple/reljam-model.sysl success
 ./demo/simple/reljam-facade.sysl success
 ./demo/simple/sysl-data.sysl success
 ./demo/simple/sysl-ints.sysl success
 ./demo/simple/sysl-sd2.sysl success
 ./demo/codegen/GRPCProtoGeneration/grpc.sysl fail
-./demo/codegen/GRPCProtoGeneration/hello.sysl fail
+./demo/codegen/GRPCProtoGeneration/hello.sysl success
 ./demo/codegen/AuthorisationAPI/grpc.sysl fail
-./demo/codegen/AuthorisationAPI/authorisation.sysl fail
+./demo/codegen/AuthorisationAPI/authorisation.sysl success
 ./demo/examples/Rest-and-HTTP/1_project.sysl fail
 ./demo/examples/GRPC/grpc.sysl fail
 ./demo/examples/Data-types/project.sysl success
@@ -79,7 +82,7 @@
 ./tests/comments.sysl fail
 ./tests/model.sysl success
 ./tests/blackbox.sysl success
-./tests/reviewdatamodelcmd.sysl fail
+./tests/reviewdatamodelcmd.sysl success
 ./tests/args.sysl success
 ./tests/ui_grpc.sysl success
 ./tests/groupby.sysl success
@@ -233,4 +236,4 @@
 ./pkg/exporter/test-data/SWAGGER_ENSURE_HEADER_FIELDS_IN_INSERTION_ORDER.sysl success
 ./pkg/exporter/test-data/REST_ENDPOINT_DOT.sysl success
 ./pkg/exporter/test-data/SWAGGER_QUERY_PARAM_EXAMPLE.sysl success
-Passes:199 Fails:36
+Passes:205 Fails:33

--- a/scripts/grammar-out.txt
+++ b/scripts/grammar-out.txt
@@ -60,7 +60,7 @@
 ./tests/indirect_2.sysl success
 ./tests/ints_stmts.sysl success
 ./tests/transform1.sysl fail
-./tests/transform2.sysl fail
+./tests/transform2.sysl success
 ./tests/integration_excludes_test.sysl success
 ./tests/test.gen_multiple_annotations.sysl fail
 ./tests/integration_test.sysl success
@@ -236,4 +236,4 @@
 ./pkg/exporter/test-data/SWAGGER_ENSURE_HEADER_FIELDS_IN_INSERTION_ORDER.sysl success
 ./pkg/exporter/test-data/REST_ENDPOINT_DOT.sysl success
 ./pkg/exporter/test-data/SWAGGER_QUERY_PARAM_EXAMPLE.sysl success
-Passes:205 Fails:33
+Passes:206 Fails:32


### PR DESCRIPTION
current indentation rule does not anticipate lines with random spaces. For example (with underscores replacing spaces)

```
____statement1
___

____statement2
```

The newly added regex rule `/{(\n (?:[\_\t]+ \n)?)+}` will handle lines with random spaces.
It is also added to the global `.wrapRE` rule so that it does not ignore the random spaces as sometimes it is parsed as the `level` rule which consumes spaces before a statement is necessary to determine the level of indentation of the statement.

Parse result is also updated along with the newly added sysl files.

@anz-bank/sysl-developers
