### PR TITLE
[WIP] Introduce --parser command-line argument to enable wbnf parsing

### DIFF
--- a/cmd/sysl/cmd_codegen.go
+++ b/cmd/sysl/cmd_codegen.go
@@ -54,6 +54,7 @@ func (p *codegenCmd) Execute(args cmdutils.ExecuteArgs) error {
 			Start:         p.Start,
 			DepPath:       p.DepPath,
 			BasePath:      p.BasePath,
+			ParserType:    args.ParserType,
 			Filesystem:    args.Filesystem,
 			Logger:        args.Logger,
 		})
@@ -66,7 +67,7 @@ func (p *codegenCmd) Execute(args cmdutils.ExecuteArgs) error {
 		p.appName = args.DefaultAppName
 	}
 	eval.EnableDebugger = p.enableDebugger
-	output, err := GenerateCode(&p.CmdContextParamCodegen, args.Modules[0], p.appName, args.Filesystem, args.Logger)
+	output, err := GenerateCode(&p.CmdContextParamCodegen, args.Modules[0], p.appName, args.Filesystem, args.Logger, args.ParserType)
 	if err != nil {
 		return err
 	}

--- a/cmd/sysl/cmd_template.go
+++ b/cmd/sysl/cmd_template.go
@@ -45,7 +45,7 @@ func (p *templateCmd) Configure(app *kingpin.Application) *kingpin.CmdClause {
 
 func (p *templateCmd) Execute(args cmdutils.ExecuteArgs) error {
 	tmplFs := syslutil.NewChrootFs(args.Filesystem, p.rootTemplate)
-	tfmParser := parse.NewParser()
+	tfmParser := parse.NewParserWithParserType(args.ParserType)
 	tx, transformAppName, err := parse.LoadAndGetDefaultApp(p.template, tmplFs, tfmParser)
 	if err != nil {
 		return err

--- a/cmd/sysl/codegen.go
+++ b/cmd/sysl/codegen.go
@@ -117,7 +117,7 @@ func Serialize(w io.Writer, delim string, node Node) error {
 func GenerateCode(
 	codegenParams *cmdutils.CmdContextParamCodegen,
 	model *sysl.Module, modelAppName string,
-	fs afero.Fs, logger *logrus.Logger) ([]*CodeGenOutput, error) {
+	fs afero.Fs, logger *logrus.Logger, parserType parse.ParserType) ([]*CodeGenOutput, error) {
 	var codeOutput []*CodeGenOutput
 	depPath := codegenParams.DepPath
 	basePath := codegenParams.BasePath
@@ -134,7 +134,7 @@ func GenerateCode(
 	if mod.SyslModules {
 		transformFs = mod.NewFs(transformFs)
 	}
-	tfmParser := parse.NewParser()
+	tfmParser := parse.NewParserWithParserType(parserType)
 	tx, transformAppName, err := parse.LoadAndGetDefaultApp(codegenParams.Transform, transformFs, tfmParser)
 	if err != nil {
 		return nil, err
@@ -149,7 +149,7 @@ func GenerateCode(
 	}
 
 	if !codegenParams.DisableValidator {
-		grammarSysl, err := validate.LoadGrammar(codegenParams.Grammar, fs)
+		grammarSysl, err := validate.LoadGrammarWithParserType(codegenParams.Grammar, fs, parserType)
 		if err != nil {
 			msg.NewMsg(msg.WarnValidationSkipped, []string{err.Error()}).LogMsg()
 		} else {

--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,6 @@ require (
 	github.com/cornelk/hashmap v1.0.1
 	github.com/dchest/siphash v1.2.1 // indirect
 	github.com/dlclark/regexp2 v1.2.0 // indirect
-	github.com/envoyproxy/protoc-gen-validate v0.3.0 // indirect
 	github.com/fullstorydev/grpcui v0.2.1
 	github.com/fullstorydev/grpcurl v1.5.0
 	github.com/getkin/kin-openapi v0.3.0

--- a/pkg/cmdutils/types.go
+++ b/pkg/cmdutils/types.go
@@ -1,6 +1,7 @@
 package cmdutils
 
 import (
+	"github.com/anz-bank/sysl/pkg/parse"
 	sysl "github.com/anz-bank/sysl/pkg/sysl"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/afero"
@@ -96,6 +97,7 @@ type ExecuteArgs struct {
 	Filesystem     afero.Fs
 	Logger         *logrus.Logger
 	DefaultAppName string
+	ParserType     parse.ParserType
 }
 
 type Command interface {

--- a/pkg/loader/loader.go
+++ b/pkg/loader/loader.go
@@ -22,13 +22,17 @@ type ProjectConfiguration struct {
 }
 
 func LoadSyslModule(root, filename string, fs afero.Fs, logger *logrus.Logger) (*sysl.Module, string, error) {
+	return LoadSyslModuleWithParserType(root, filename, fs, logger, parse.DefaultParserType)
+}
+
+func LoadSyslModuleWithParserType(root, filename string, fs afero.Fs, logger *logrus.Logger, parserType parse.ParserType) (*sysl.Module, string, error) {
 	logger.Debugf("Attempting to load module:%s (root:%s)", filename, root)
 	projectConfig := NewProjectConfiguration()
 	if err := projectConfig.ConfigureProject(root, filename, fs, logger); err != nil {
 		return nil, "", err
 	}
 
-	modelParser := parse.NewParser()
+	modelParser := parse.NewParserWithParserType(parserType)
 	if !projectConfig.RootIsFound {
 		modelParser.RestrictToLocalImport()
 	}

--- a/pkg/parse/parse.go
+++ b/pkg/parse/parse.go
@@ -142,7 +142,7 @@ func (p *Parser) Parse(filename string, fs afero.Fs) (*sysl.Module, error) {
 			imports = imports[1:]
 			if _, has := imported[source.filename]; !has {
 				if !p.allowAbsoluteImport && strings.HasPrefix(source.filename, "/") {
-					return nil, Exitf(2,
+					return nil, Exitf(ParseError,
 						"error importing: importing outside current directory is only allowed when root is defined")
 				}
 				break

--- a/pkg/parse/wbnf_parser.go
+++ b/pkg/parse/wbnf_parser.go
@@ -1,0 +1,12 @@
+package parse
+
+import (
+	"github.com/anz-bank/sysl/pkg/sysl"
+	"github.com/spf13/afero"
+)
+
+// Parse the given source definition, modifying the app contents in the process.
+// Return the list of import definitions declared in the source but not parsed.
+func parseWbnf(source importDef, fs afero.Fs, apps map[string]*sysl.Application) ([]importDef, error) {
+	return nil, Exitf(ParseError, "wbnf parser unimplemented")
+}


### PR DESCRIPTION
Proposal:
Introduce --parser command-line argument to enable wbnf parsing

To simplify the testing and transition to wbnf, the --parser flag can
switch between the existing Antlr parser and the under-development
wbnf parser.

Usage:
sysl validate example.sysl --parser wbnf

@anz-bank/sysl-developers