### PR TITLE
Configure goreleaser to publish homebrew formula on release

### DIFF
--- a/.github/goreleaser_configs/.goreleaser.yml
+++ b/.github/goreleaser_configs/.goreleaser.yml
@@ -68,3 +68,104 @@ changelog:
       - '^test:'
       - '^chore:'
       - typo
+
+brews:
+  -
+    # Name template of the recipe
+    # Default to project name
+    name: Sysl
+
+    # IDs of the archives to use.
+    # Defaults to all.
+    ids:
+    - sysl
+
+    # GOARM to specify which 32-bit arm version to use if there are multiple versions
+    # from the build section. Brew formulas support atm only one 32-bit version.
+    # Default is 6 for all artifacts or each id if there a multiple versions.
+    goarm: 6
+
+
+    # NOTE: make sure the url_template, the token and given repo (github or gitlab) owner and name are from the
+    # same kind. We will probably unify this in the next major version like it is done with scoop.
+
+    # Github repository to push the tap to.
+    github:
+      owner: anz-bank
+      name: homebrew-sysl
+
+    # Template for the url which is determined by the given Token (github or gitlab)
+    # Default for github is "https://github.com/<repo_owner>/<repo_name>/releases/download/{{ .Tag }}/{{ .ArtifactName }}"
+    url_template: "https://github.com/anz-bank/sysl/releases/download/{{ .Tag }}/{{ .ArtifactName }}"
+
+    # Allows you to set a custom download strategy. Note that you'll need
+    # to implement the strategy and add it to your tap repository.
+    # Example: https://docs.brew.sh/Formula-Cookbook#specifying-the-download-strategy-explicitly
+    # Default is empty.
+    download_strategy: CurlDownloadStrategy
+
+    # Allows you to add a custom require_relative at the top of the formula template
+    # Default is empty
+    custom_require:
+
+    # Git author used to commit to the repository.
+    # Defaults are shown.
+    commit_author:
+      name: goreleaserbot
+      email: goreleaser@carlosbecker.com
+
+    # Folder inside the repository to put the formula.
+    # Default is the root folder.
+    folder: Formula
+
+    # Caveats for the user of your binary.
+    # Default is empty.
+    # caveats: "How to use this binary"
+
+    # Your app's homepage.
+    # Default is empty.
+    homepage: "https://sysl.io/"
+
+    # Your app's description.
+    # Default is empty.
+    description: "Sysl generates code and documentation from system specifications"
+
+    # Setting this will prevent goreleaser to actually try to commit the updated
+    # formula - instead, the formula file will be stored on the dist folder only,
+    # leaving the responsibility of publishing it to the user.
+    # If set to auto, the release will not be uploaded to the homebrew tap
+    # in case there is an indicator for prerelease in the tag e.g. v1.0.0-rc1
+    # Default is false.
+    # skip_upload: true
+
+    # Custom block for brew.
+    # Can be used to specify alternate downloads for devel or head releases.
+    # Default is empty.
+    # custom_block: |
+    #   head "https://github.com/some/package.git"
+    #   ...
+
+    # Packages your package depends on.
+    dependencies:
+      - go
+
+    # Packages that conflict with your package.
+    # conflicts:
+    #   - svn
+    #   - bash
+
+    # Specify for packages that run as a service.
+    # Default is empty.
+    # plist: |
+    #   <?xml version="1.0" encoding="UTF-8"?>
+    #   ...
+
+    # So you can `brew test` your formula.
+    # Default is empty.
+    test: |
+      system "#{bin}/sysl --version"
+
+    # Custom install script for brew.
+    # Default is 'bin.install "program"'.
+    install: |
+      bin.install "sysl"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,7 +60,7 @@ jobs:
           version: v0.126.0
           args: release --rm-dist --debug -f .github/goreleaser_configs/.goreleaser.yml
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.REPO_ACCESS_TOKEN }}
 
       # FIXME: sysl_js hasn't been rebuilt for months and it is out of date.
       # If sysl_js works again, please add NPM_PUBLISH_TOKEN to GitHub secrets 

--- a/docs/website/content/docs/install.md
+++ b/docs/website/content/docs/install.md
@@ -20,6 +20,15 @@ Sysl is a CLI (Command Line Interface) that executes with the `sysl` command.
 
 Here are several approaches to get start using Sysl:
 
+## Install with Homebrew
+
+If you have [homebrew](https://brew.sh/) installed, you can simply run the following commands in your terminal:
+
+```sh
+brew tap anz-bank/homebrew-sysl
+brew install anz-bank/homebrew-sysl/sysl
+```
+
 ## Install the pre-compiled binary
 
 1. Download the pre-compiled binaries matching your OS from the [releases page](https://github.com/anz-bank/sysl/releases).


### PR DESCRIPTION
Closes https://github.com/anz-bank/sysl/issues/656

- Configures goreleaser to update the homebrew formula at https://github.com/anz-bank/homebrew-sysl for every release
- Also updates the Release workflow to use REPO_ACCESS_TOKEN so that goreleaser can push to a different repo. The default GITHUB_TOKEN is scoped only to this repository.
- Updates docs on sysl.io/install with instructions for installing with homebrew

@anz-bank/sysl-developers
