### PR TITLE
Removes invalid protoc-gen-validate dependency

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,6 @@ require (
 	github.com/cornelk/hashmap v1.0.1
 	github.com/dchest/siphash v1.2.1 // indirect
 	github.com/dlclark/regexp2 v1.2.0 // indirect
-	github.com/envoyproxy/protoc-gen-validate v0.3.0 // indirect
 	github.com/fullstorydev/grpcui v0.2.1
 	github.com/fullstorydev/grpcurl v1.5.0
 	github.com/getkin/kin-openapi v0.3.0


### PR DESCRIPTION
No tagged version of protoc-gen-validate:0.3.0 exists. The closest valid
version: protoc-gen-validate:0.3.0-java appears unrequired:

go mod why github.com/envoyproxy/protoc-gen-validate
main module does not need package github.com/envoyproxy/protoc-gen-validate

Closes: #722