### PR TITLE
Fix openapi import when colon is in URL path

### DIFF
--- a/pkg/importer/tests-openapi/simple_with_special_char_endpoint.sysl
+++ b/pkg/importer/tests-openapi/simple_with_special_char_endpoint.sysl
@@ -13,7 +13,17 @@ testapp "Simple" [package="package_foo"]:
             | No description.
             return ok <: SimpleObj
 
+    /test%2Bplus:
+        GET:
+            | No description.
+            return ok <: SimpleObj
+
     /test%2Estuff:
+        GET:
+            | No description.
+            return ok <: SimpleObj
+
+    /test%3Acolon:
         GET:
             | No description.
             return ok <: SimpleObj

--- a/pkg/importer/tests-openapi/simple_with_special_char_endpoint.yaml
+++ b/pkg/importer/tests-openapi/simple_with_special_char_endpoint.yaml
@@ -11,6 +11,24 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/SimpleObj"
+  /test:colon:
+    get:
+      responses:
+        200:
+          description: "200 OK"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SimpleObj"
+  /test+plus:
+    get:
+      responses:
+        200:
+          description: "200 OK"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SimpleObj"
   /deep/deeeeeeep/test.stuff:
     get:
       responses:

--- a/pkg/importer/utils.go
+++ b/pkg/importer/utils.go
@@ -72,7 +72,7 @@ func spaceSeparate(items ...string) string {
 }
 
 func getSyslSafeEndpoint(endpoint string) string {
-	// url.PathEscape does not escape '.'
+	// url.PathEscape does not escape '. :'
 	charsToKeep := map[string]string{
 		`%2F`: "/",
 		`%7B`: "{",
@@ -81,8 +81,15 @@ func getSyslSafeEndpoint(endpoint string) string {
 		`%3F`: "?",
 		`%26`: "&",
 	}
+	charsToReplace := map[string]string{
+		".": `%2E`,
+		":": `%3A`,
+		"+": `%2B`,
+	}
 	endpoint = url.PathEscape(endpoint)
-	endpoint = strings.ReplaceAll(endpoint, ".", `%2E`)
+	for realChar, hex := range charsToReplace {
+		endpoint = strings.ReplaceAll(endpoint, realChar, hex)
+	}
 	for hex, realChar := range charsToKeep {
 		endpoint = strings.ReplaceAll(endpoint, hex, realChar)
 	}

--- a/tests/with_encoded_url.sysl
+++ b/tests/with_encoded_url.sysl
@@ -14,3 +14,11 @@ testapp "Simple" [package="package_foo"]:
     /tests%7Eagain:
         GET:
             return ok <: 200
+
+    /tests%3Aagain:
+        GET:
+            return ok <: 200
+
+    /tests%2Bagain:
+        GET:
+            return ok <: 200


### PR DESCRIPTION
- Adds escaping of ":" and "+" in URL paths when importing from OpenAPI or Swagger.

e.g
`/api:pay` in the OpenAPI yaml will be imported as '/api%3A' in sysl

Fixes https://github.com/anzx/acceleration/issues/58