### PR TITLE
Change modules to make the more usable for codegen

### DIFF
--- a/cmd/sysl/codegen.go
+++ b/cmd/sysl/codegen.go
@@ -132,7 +132,7 @@ func GenerateCode(
 	var transformFs afero.Fs
 	transformFs = syslutil.NewChrootFs(fs, codegenParams.RootTransform)
 	if mod.SyslModules {
-		transformFs = mod.NewFs(transformFs)
+		transformFs = mod.NewFs(transformFs, codegenParams.RootTransform)
 	}
 
 	tfmParser := parse.NewParser()

--- a/cmd/sysl/codegen.go
+++ b/cmd/sysl/codegen.go
@@ -141,16 +141,13 @@ func GenerateCode(
 		return nil, err
 	}
 
-	if mod.SyslModules {
-		fs = mod.NewFs(fs)
-	}
-	g, err := ebnfparser.ReadGrammar(fs, codegenParams.Grammar, codegenParams.Start)
+	g, err := ebnfparser.ReadGrammar(transformFs, codegenParams.Grammar, codegenParams.Start)
 	if err != nil {
 		return nil, err
 	}
 
 	if !codegenParams.DisableValidator {
-		grammarSysl, err := validate.LoadGrammar(codegenParams.Grammar, fs)
+		grammarSysl, err := validate.LoadGrammar(codegenParams.Grammar, transformFs)
 		if err != nil {
 			msg.NewMsg(msg.WarnValidationSkipped, []string{err.Error()}).LogMsg()
 		} else {

--- a/pkg/loader/loader.go
+++ b/pkg/loader/loader.go
@@ -96,7 +96,7 @@ func (pc *ProjectConfiguration) ConfigureProject(root, module string, fs afero.F
 
 	pc.Fs = syslutil.NewChrootFs(fs, pc.Root)
 	if mod.SyslModules {
-		pc.Fs = mod.NewFs(pc.Fs)
+		pc.Fs = mod.NewFs(pc.Fs, pc.Root)
 	}
 
 	return nil

--- a/pkg/mod/fs.go
+++ b/pkg/mod/fs.go
@@ -11,10 +11,11 @@ import (
 
 type Fs struct {
 	source afero.Fs
+	root   string
 }
 
-func NewFs(fs afero.Fs) *Fs {
-	return &Fs{source: fs}
+func NewFs(fs afero.Fs, root string) *Fs {
+	return &Fs{source: fs, root: root}
 }
 
 func (fs *Fs) Open(name string) (afero.File, error) {
@@ -23,6 +24,9 @@ func (fs *Fs) Open(name string) (afero.File, error) {
 		return f, nil
 	}
 
+	// filepath.Join will strip path elements of ".", so if the root is "."
+	// it will still work as a go module path when prepended with "."
+	name = filepath.Join(fs.root, name)
 	mod, err := Find(name)
 	if err != nil {
 		return nil, err
@@ -53,6 +57,9 @@ func (fs *Fs) OpenFile(name string, flag int, perm os.FileMode) (afero.File, err
 		return f, nil
 	}
 
+	// filepath.Join will strip path elements of ".", so if the root is "."
+	// it will still work as a go module path when prepended with "."
+	name = filepath.Join(fs.root, name)
 	mod, err := Find(name)
 	if err != nil {
 		return nil, err

--- a/pkg/mod/fs_test.go
+++ b/pkg/mod/fs_test.go
@@ -13,7 +13,7 @@ func TestNewFs(t *testing.T) {
 	t.Parallel()
 
 	_, backendFs := syslutil.WriteToMemOverlayFs("/")
-	fs := NewFs(backendFs)
+	fs := NewFs(backendFs, "")
 	assert.Equal(t, backendFs, fs.source)
 }
 
@@ -22,7 +22,7 @@ func TestOpenLocalFile(t *testing.T) {
 
 	filename := "deps.sysl"
 	_, memfs := syslutil.WriteToMemOverlayFs("../../tests/")
-	fs := NewFs(memfs)
+	fs := NewFs(memfs, "")
 	f, err := fs.Open(filename)
 	assert.Nil(t, err)
 	assert.Equal(t, "deps.sysl", filepath.Base(f.Name()))
@@ -33,7 +33,7 @@ func TestOpenRemoteFile(t *testing.T) {
 
 	filename := "github.com/anz-bank/sysl/demo/examples/Modules/deps.sysl"
 	_, memfs := syslutil.WriteToMemOverlayFs("/")
-	fs := NewFs(memfs)
+	fs := NewFs(memfs, "")
 	f, err := fs.Open(filename)
 	assert.Nil(t, err)
 	assert.Equal(t, "deps.sysl", filepath.Base(f.Name()))
@@ -44,8 +44,20 @@ func TestOpenRemoteFileFailed(t *testing.T) {
 
 	filename := "github.com/wrong/repo/deps.sysl"
 	_, memfs := syslutil.WriteToMemOverlayFs("/")
-	fs := NewFs(memfs)
+	fs := NewFs(memfs, "")
 	f, err := fs.Open(filename)
 	assert.Nil(t, f)
-	assert.Equal(t, fmt.Sprintf("%s not found", filename), err.Error())
+	assert.Equal(t, fmt.Sprintf("%s not found", filepath.FromSlash(filename)), err.Error())
+}
+
+func TestOpenRemoteFileWithRoot(t *testing.T) {
+	t.Parallel()
+
+	root := "github.com/anz-bank/sysl"
+	path := "demo/examples/Modules/deps.sysl"
+	_, memfs := syslutil.WriteToMemOverlayFs("/")
+	fs := NewFs(memfs, root)
+	f, err := fs.Open(path)
+	assert.Nil(t, err)
+	assert.Equal(t, "deps.sysl", filepath.Base(f.Name()))
 }

--- a/pkg/validate/validate.go
+++ b/pkg/validate/validate.go
@@ -367,18 +367,21 @@ func loadTransform(transformFile string, fs afero.Fs, p *parse.Parser) (*sysl.Ap
 // eg: if grammarFile is ./foo/bar.g, this tries to load ./foo/bar.sysl
 func LoadGrammar(grammarFile string, fs afero.Fs) (*sysl.Application, error) {
 	tokens := strings.Split(grammarFile, string(os.PathSeparator))
-	rootGrammar := strings.Join(tokens[:len(tokens)-1], string(os.PathSeparator))
-	grammarFileName := tokens[len(tokens)-1]
+	tokens[len(tokens)-1] = changeFileExtension(tokens[len(tokens)-1], "sysl")
+	syslFile := strings.Join(tokens, string(os.PathSeparator))
 
-	tokens = strings.Split(grammarFileName, ".")
-	tokens[len(tokens)-1] = "sysl"
-	grammarSyslFile := strings.Join(tokens, ".")
-	p := parse.NewParser()
-
-	grammar, name, err := parse.LoadAndGetDefaultApp(grammarSyslFile,
-		syslutil.NewChrootFs(fs, rootGrammar), p)
+	grammar, name, err := parse.LoadAndGetDefaultApp(syslFile, fs, parse.NewParser())
 	if err != nil {
 		return nil, err
 	}
 	return grammar.GetApps()[name], nil
+}
+
+func changeFileExtension(filename, extension string) string {
+	parts := strings.Split(filename, ".")
+	if len(parts) == 1 {
+		parts = append(parts, "") // add empty extension to be replaced.
+	}
+	parts[len(parts)-1] = extension
+	return strings.Join(parts, ".")
 }

--- a/pkg/validate/validate_test.go
+++ b/pkg/validate/validate_test.go
@@ -273,11 +273,12 @@ func TestValidatorValidateViews(t *testing.T) {
 	t.Parallel()
 
 	p := parse.NewParser()
-	transform, err := loadTransform("transform1.sysl", syslutil.NewChrootFs(afero.NewOsFs(), testDir), p)
+	fs := syslutil.NewChrootFs(afero.NewOsFs(), testDir)
+	transform, err := loadTransform("transform1.sysl", fs, p)
 	require.NoError(t, err)
 	require.NotNil(t, transform)
 
-	grammar, err := LoadGrammar(filepath.Join(testDir, "grammar.sysl"), afero.NewOsFs())
+	grammar, err := LoadGrammar("grammar.sysl", fs)
 	require.NoError(t, err)
 	require.NotNil(t, grammar)
 
@@ -359,11 +360,12 @@ func TestValidatorValidateViewsInnerTypes(t *testing.T) {
 	t.Parallel()
 
 	p := parse.NewParser()
-	transform, err := loadTransform("transform1.sysl", syslutil.NewChrootFs(afero.NewOsFs(), testDir), p)
+	fs := syslutil.NewChrootFs(afero.NewOsFs(), testDir)
+	transform, err := loadTransform("transform1.sysl", fs, p)
 	require.NoError(t, err)
 	require.NotNil(t, transform)
 
-	grammar, err := LoadGrammar(filepath.Join(testDir, "grammar.sysl"), afero.NewOsFs())
+	grammar, err := LoadGrammar("grammar.sysl", fs)
 	require.NoError(t, err)
 	require.NotNil(t, grammar)
 
@@ -401,11 +403,12 @@ func TestValidatorValidateViewsChoiceTypes(t *testing.T) {
 	t.Parallel()
 
 	p := parse.NewParser()
-	transform, err := loadTransform("transform1.sysl", syslutil.NewChrootFs(afero.NewOsFs(), testDir), p)
+	fs := syslutil.NewChrootFs(afero.NewOsFs(), testDir)
+	transform, err := loadTransform("transform1.sysl", fs, p)
 	require.NoError(t, err)
 	require.NotNil(t, transform)
 
-	grammar, err := LoadGrammar(filepath.Join(testDir, "grammar.sysl"), afero.NewOsFs())
+	grammar, err := LoadGrammar("grammar.sysl", fs)
 	require.NoError(t, err)
 	require.NotNil(t, grammar)
 
@@ -481,11 +484,12 @@ func TestValidatorValidate(t *testing.T) {
 	t.Parallel()
 
 	p := parse.NewParser()
-	transform, err := loadTransform("transform2.sysl", syslutil.NewChrootFs(afero.NewOsFs(), testDir), p)
+	fs := syslutil.NewChrootFs(afero.NewOsFs(), testDir)
+	transform, err := loadTransform("transform2.sysl", fs, p)
 	require.NoError(t, err)
 	require.NotNil(t, transform)
 
-	grammar, err := LoadGrammar(filepath.Join(testDir, "grammar.sysl"), afero.NewOsFs())
+	grammar, err := LoadGrammar("grammar.sysl", fs)
 	require.NoError(t, err)
 	require.NotNil(t, grammar)
 
@@ -516,7 +520,7 @@ func TestValidatorLoadTransformError(t *testing.T) {
 func TestValidatorLoadGrammarSuccess(t *testing.T) {
 	t.Parallel()
 
-	grammar, err := LoadGrammar(filepath.Join(testDir, "grammar.sysl"), afero.NewOsFs())
+	grammar, err := LoadGrammar("grammar.sysl", syslutil.NewChrootFs(afero.NewOsFs(), testDir))
 	assert.NotNil(t, grammar, "Unexpected result")
 	assert.Nil(t, err, "Unexpected result")
 }
@@ -602,6 +606,27 @@ func TestValidatorValidateTfmReturn(t *testing.T) {
 			validator.validateTfmReturn(input, view.GetExpr(), view.GetRetType())
 			actual := validator.GetMessages()
 			assert.Equal(t, expected, actual, "Unexpected result")
+		})
+	}
+}
+
+func TestChangeFileExtension(t *testing.T) {
+	cases := map[string]struct {
+		input     string
+		extension string
+		expected  string
+	}{
+		"simple":  {"filename.ext", "sysl", "filename.sysl"},
+		"path":    {"/tmp/filename.ext", "sysl", "/tmp/filename.sysl"},
+		"multi":   {"filename.foo.ext", "sysl", "filename.foo.sysl"},
+		"none":    {"filename", "sysl", "filename.sysl"},
+		"nonsysl": {"filename.old", "new", "filename.new"},
+	}
+	for name, test := range cases {
+		test := test
+		t.Run(name, func(t *testing.T) {
+			actual := changeFileExtension(test.input, test.extension)
+			assert.Equal(t, test.expected, actual)
 		})
 	}
 }


### PR DESCRIPTION
Add a `root` parameter to `mod.Fs` so that when a root is specified, it can
be a module.

When the `codegen` subcommand loads a grammar (from the `--grammar` flag),
look for it relative to `--root-transform` instead of `--root`.

The grammar is closely tied to the transform so the transform root is the
more correct place to look for it.

This allows the following invocation:

    sysl codegen --root-transform github.com/anz-bank/sysl-go/codegen \
    --grammar grammar/go.gen.g --transform transform/svc_types.sysl \
    ...

@anz-bank/sysl-developers