### PR TITLE
Run go mod tidy

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -106,8 +106,6 @@ github.com/envoyproxy/go-control-plane v0.9.4 h1:rEvIZUSZ3fx39WIi3JkQqQBitGwpELB
 github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1mIlRU8Am5FuJP05cCM98=
 github.com/envoyproxy/protoc-gen-validate v0.1.0 h1:EQciDnbrYxy13PgWoY8AqoxGiPrpgBZ1R8UNe3ddc+A=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
-github.com/envoyproxy/protoc-gen-validate v0.3.0 h1:Y2J74o+yAfcD8jpqtkLnUqRo+yshLr4eR1WPYGX0cic=
-github.com/envoyproxy/protoc-gen-validate v0.3.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/fullstorydev/grpcui v0.2.1 h1:8JTcnTTWEZgSM/oipTfX4f2zl/jCtabA4sgI4n6XUdw=
 github.com/fullstorydev/grpcui v0.2.1/go.mod h1:GmjekePsrhFLIB6j2t3ih4u/88Q8IU6JhVlAFUWMP8E=


### PR DESCRIPTION
Cleans up an error in https://github.com/anz-bank/sysl/pull/742 which removes protoc-gen-validate:0.3.0 from go.mod but not from go.sum

# Context
Currently, releases on sysl are failing due to git being in a dirty state (due to the go mod tidy not being run on a previous commit) https://github.com/anz-bank/sysl/actions/runs/64357603

This means we don't get to use our shiny new sysl docker image, as it isn't currently getting published to https://hub.docker.com/r/anzbank/sysl/tags 😢 