### PR TITLE
Handle the bytes sysl type

### DIFF
--- a/pkg/importer/swagger.go
+++ b/pkg/importer/swagger.go
@@ -44,13 +44,13 @@ func convertToOpenapiv3(data []byte) (*openapi3.Swagger, string, error) {
 }
 
 // nolint:gochecknoglobals
-var swaggerFormats = []string{"int32", "int64", "float", "double", "date", "date-time", "byte"}
+var swaggerFormats = []string{"int32", "int64", "float", "double", "date", "date-time", "byte", "binary"}
 
 func mapSwaggerTypeAndFormatToType(typeName, format string, logger *logrus.Logger) string {
 	typeName = strings.ToLower(typeName)
 	format = strings.ToLower(format)
 	if format != "" && !contains(format, swaggerFormats) {
-		logger.Errorf("unknown format '%s' being used, ignoring...\n", format)
+		logger.Warnf("unknown format '%s' being used, ignoring...\n", format)
 		format = ""
 	}
 
@@ -60,6 +60,7 @@ func mapSwaggerTypeAndFormatToType(typeName, format string, logger *logrus.Logge
 			"date":      "date",
 			"date-time": "datetime",
 			"byte":      StringTypeName,
+			"binary":    "bytes",
 		},
 		"integer": {
 			"":      "int",

--- a/pkg/importer/tests-openapi/multiple-return-values.sysl
+++ b/pkg/importer/tests-openapi/multiple-return-values.sysl
@@ -28,5 +28,5 @@ testapp "Simple" [package="package_foo"]:
     !type _test_ok:
         SimpleObj <: SimpleObj [mediatype="application/json"]:
             @json_tag = "SimpleObj"
-        string_ <: string [mediatype="application/pdf"]:
-            @json_tag = "string"
+        bytes_ <: bytes [mediatype="application/pdf"]:
+            @json_tag = "bytes"

--- a/pkg/importer/types.go
+++ b/pkg/importer/types.go
@@ -124,7 +124,9 @@ func (t TypeList) Sort() {
 type FieldList []Field
 
 // nolint:gochecknoglobals
-var builtIns = []string{"int32", "int64", "int", "float", "string", "date", "bool", "decimal", "datetime", "xml"}
+var builtIns = []string{"int32", "int64", "int",
+	"float", "string", "date", "bool", "decimal",
+	"datetime", "xml", "bytes"}
 
 func IsBuiltIn(name string) bool {
 	for _, kw := range builtIns {


### PR DESCRIPTION
required changes to allow the swagger importer to use the bytes internal sysl type

fix #718 

@anz-bank/sysl-developers
