### PR TITLE
Update codecov to use a 2% threshold

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -4,3 +4,14 @@ ignore:
   - pkg/sysl_js/SyslParserListener.js
   - pkg/ui/pkged.go
   - pkg/lspimpl/lspframework
+
+coverage:
+  status:
+    project:
+      default:
+        target: 80%
+        threshold: 2%
+    patch: off
+
+comment:
+  layout: "diff, flags, files"


### PR DESCRIPTION
Previously, codecov only uses a comparison against a static threshold rather than allowing for some amount of change. This PR enables a slight drop in coverage as well as cleaning up the status checks. From my knowledge, the Patch status was offering very little benefit to developers, (and it wasn't an enforced check anyways, so it was being mostly ignored).

Proposed Changes
- Updates codecov to allow for drops of up to 2% when above 80%
- Removes graph in PR comment to reduce noise
- Removes patch status, to reduce number of CI Checks (seemed to just be generating noise)


Related docs: https://docs.codecov.io/docs/commit-status

@anz-bank/sysl-developers
