### PR TITLE
Build docker image with workflow step

### DIFF
--- a/.github/goreleaser_configs/.goreleaser.yml
+++ b/.github/goreleaser_configs/.goreleaser.yml
@@ -30,11 +30,6 @@ build:
   goarm:
     - 7
 
-dockers:
-  - image_templates:
-    - "docker.io/anzbank/sysl:latest"
-    - "docker.io/anzbank/sysl:{{ .Version }}"
-
 archives:
 - id: "sysl"
   builds: ['sysl']

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -124,3 +124,27 @@ jobs:
           npm test --prefix unsorted/sysl_js
         env:
           NPM_AUTH_TOKEN: "SOME-RANDOM-KEY"
+
+  build-docker:
+    name: Builds the sysl docker image
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up Go 1.13
+        uses: actions/setup-go@v1
+        with:
+          go-version: 1.13
+
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@master
+
+      - name: Build and push docker image
+        uses: docker/build-push-action@v1
+        with:
+          username: ${{ secrets.DOCKER_USER }}
+          password: ${{ secrets.DOCKER_PASS }}
+          repository: docker.io/anzbank/sysl
+          tag_with_ref: true
+          add_git_labels: true
+          tags: latest
+          push: false
+          labels: org.opencontainers.image.revision=${{ github.sha }},org.opencontainers.image.url=https://sysl.io

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,24 +43,28 @@ jobs:
           version: v0.126.0
           args: check -f .github/goreleaser_configs/.goreleaser.yml
 
-      # GoReleaser requires Docker Hub access to push image
-      - name: Login to Docker Hub
-        uses: azure/docker-login@v1
-        with:
-          username: ${{ secrets.DOCKER_USER }}
-          password: ${{ secrets.DOCKER_PASS }}
-
       - name: Set env
         run: echo ::set-env name=GOVERSION::$(go version | awk '{print $3, $4;}')
 
       # GoReleaser release process is customized in `.goreleaser.yml` file
-      - name: Release binaries and docker images via goreleaser
+      - name: Release binaries via goreleaser
         uses: goreleaser/goreleaser-action@v1.3.1
         with:
           version: v0.126.0
           args: release --rm-dist --debug -f .github/goreleaser_configs/.goreleaser.yml
         env:
           GITHUB_TOKEN: ${{ secrets.REPO_ACCESS_TOKEN }}
+
+      - name: Build and push docker image
+        uses: docker/build-push-action@v1
+        with:
+          username: ${{ secrets.DOCKER_USER }}
+          password: ${{ secrets.DOCKER_PASS }}
+          repository: docker.io/anzbank/sysl
+          tag_with_ref: true
+          add_git_labels: true
+          tags: latest
+          labels: org.opencontainers.image.revision=${{ github.sha }},org.opencontainers.image.url=https://sysl.io
 
       # FIXME: sysl_js hasn't been rebuilt for months and it is out of date.
       # If sysl_js works again, please add NPM_PUBLISH_TOKEN to GitHub secrets 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,9 @@ on:
     tags:
       - 'v*.*.*'
 
+env:
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
 jobs:
   release-sysl:
     name: Release Sysl
@@ -15,9 +18,6 @@ jobs:
         uses: actions/setup-go@v1
         with:
           go-version: 1.13
-        id: go
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Check out code into the Go module directory
         uses: actions/checkout@master
@@ -27,14 +27,11 @@ jobs:
 
       - name: Get dependencies
         run: make deps
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Test
         run: make coverage
         timeout-minutes: 5
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SYSL_PLANTUML: http://www.plantuml.com/plantuml
 
       - name: Validate goreleaser config

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -11,7 +11,9 @@ Sysl is using [GitHub Actions](https://help.github.com/en/actions/getting-starte
 
 2. The version tag push event then triggers the [Release workflow](https://github.com/anz-bank/sysl/blob/master/.github/workflows/release.yml) to publish release to [Sysl's GitHub releases page](https://github.com/anz-bank/sysl/releases) (with changelog) and [Docker Hub](https://hub.docker.com/r/anzbank/sysl).
 
-   > Releasing is automated via [GoReleaser](https://goreleaser.com/). GoReleaser creates and deploys `sysl-X.Y.Z-Os-Arch.tar.gz` and `sysl-X.Y.Z-Windows-Arch.zip` to the [Sysl Github Release page](https://github.com/anz-bank/sysl/releases). It also pushes Sysl's Docker Images `anzbank/sysl:latest` and `anzbank/sysl:X.Y.Z` to [Docker Hub](https://hub.docker.com/r/anzbank/sysl). See [GoReleaser config file](https://github.com/anz-bank/sysl/blob/master/.github/workflows/.goreleaser.yml) for further details.
+   > Most of the release process is automated via [GoReleaser](https://goreleaser.com/). GoReleaser creates and deploys `sysl-X.Y.Z-Os-Arch.tar.gz` and `sysl-X.Y.Z-Windows-Arch.zip` to the [Sysl Github Release page](https://github.com/anz-bank/sysl/releases). It also updates [sysl-homebrew](https://github.com/anz-bank/homebrew-sysl) with the latest release. See [GoReleaser config file](https://github.com/anz-bank/sysl/blob/master/.github/workflows/.goreleaser.yml) for further details.
+
+   > The release workflow also pushes Sysl's Docker Images `anzbank/sysl:latest` and `anzbank/sysl:X.Y.Z` to [Docker Hub](https://hub.docker.com/r/anzbank/sysl).
 
 
 ### A tested example


### PR DESCRIPTION
Removes the docker image build step from goreleaser and executes it using the offical docker github action

Fixes https://github.com/anz-bank/sysl/issues/755

To view a test run, I've run it on my fork, pushing a docker image to https://hub.docker.com/repository/registry-1.docker.io/zhengj9/test-sysl/tags?page=1
Here is the execution of the github action https://github.com/cuminandpaprika/sysl/runs/563566184

The docker image can be tested using
`docker run zhengj9/test-sysl:latest info`

Changes proposed in this pull request:
- Add build step in the release workflow
- Add docker build job to the build and test workflow

Checklist:
- [x] Added related tests
- [x] Made corresponding changes to the documentation

@anz-bank/sysl-developers
