### PR TITLE
Remove release pr instruction from pr template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,6 +1,5 @@
 * Please attach **WIP** tag when this PR is still work in progress.
 * Please attach **breaking-change** tag if this PR potentially causes other components to fail or changes previous sysl executable's behaviour.
-* If you want to create a new release PR, please follow the [releasing documentation](https://github.com/anz-bank/sysl/blob/master/docs/releasing.md)
 
 Fixes # .
 
@@ -11,5 +10,3 @@ Changes proposed in this pull request:
 Checklist:
 - [ ] Added related tests
 - [ ] Made corresponding changes to the documentation
-
-@anz-bank/sysl-developers

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -7,7 +7,7 @@ Sysl is using [GitHub Actions](https://help.github.com/en/actions/getting-starte
 
 ### Steps to publish new release
 
-1. Any merged PR on master will trigger the [Generate-Tag workflow](https://github.com/anz-bank/sysl/blob/master/.github/workflows/generate-tag.yml). It will generate and push the respective version tag according to the commit message. We follow [Semver](https://semver.org/) for versioning.
+1. Any merged PR on master will trigger the [Generate-Tag workflow](https://github.com/anz-bank/sysl/blob/master/.github/workflows/generate-tag.yml). It will generate and push the respective minor version tag. We follow [Semver](https://semver.org/) for versioning.
 
 2. The version tag push event then triggers the [Release workflow](https://github.com/anz-bank/sysl/blob/master/.github/workflows/release.yml) to publish release to [Sysl's GitHub releases page](https://github.com/anz-bank/sysl/releases) (with changelog) and [Docker Hub](https://hub.docker.com/r/anzbank/sysl).
 


### PR DESCRIPTION
Changes proposed in this pull request:
- Remove release pr instruction from pr template
- Update releasing.md docs