### PR TITLE
Add correct exit code for failed code coverage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ lint: ## Run golangci-lint
 	golangci-lint run
 
 coverage: ## Run tests and verify the test coverage remains high
-	./scripts/test-with-coverage.sh 85
+	./scripts/test-with-coverage.sh 80
 
 test: ## Run tests without coverage
 	$(TESTEXE)

--- a/scripts/test-with-coverage.sh
+++ b/scripts/test-with-coverage.sh
@@ -22,6 +22,7 @@ EXIT_CODE=$(echo $?)
 COVERAGE_LEVEL="$(coverage_level)"
 if [ "$COVERAGE_LEVEL" -lt "$MIN_COVERAGE" ]; then
     printf "\e[1;31m✘\e[0m Coverage %d%% < %d%% required\n" ${COVERAGE_LEVEL} ${MIN_COVERAGE}
+    exit 1
 else
     printf "\e[1;32m✔\e[0m Coverage %d%% >= %d%% required\n" ${COVERAGE_LEVEL} ${MIN_COVERAGE}
 fi


### PR DESCRIPTION
Fixes an issue introduced in https://github.com/anz-bank/sysl/pull/565 which fixed test failures not being checked in the exit code.
Also drops codecoverage down to 80% so that it will pass CI.

Fixes https://github.com/anz-bank/sysl/issues/771

Changes proposed in this pull request:
- Add exit code for test coverage below threshold
- Drops test coverage to 80% for now

To test this, a few steps are needed:
- Checkout the branch

Test that it passes, with coverage above threshold
- run `make coverage` 
- view the exit code using `echo $?`
- It should return an exit code of 0

Test that it fails with coverage below threshold
- Set the coverage threshold so that it fails (L36 of the makefile, change `./scripts/test-with-coverage.sh 80` to ./scripts/test-with-coverage.sh 85)
- run `make coverage` 
- view the exit code using `echo $?`
- It should return an exit code of 2



