### PR TITLE
Add openapi3 support in import statements

### DIFF
--- a/pkg/parse/Parser_test.go
+++ b/pkg/parse/Parser_test.go
@@ -590,6 +590,12 @@ func TestEnum(t *testing.T) {
 	testParseAgainstGoldenWithSourceContext(t, "tests/enum.sysl")
 }
 
+func TestOpenAPI3(t *testing.T) {
+	t.Parallel()
+
+	testParseAgainstGoldenWithSourceContext(t, "tests/openapi3.sysl")
+}
+
 func TestUndefinedRootAbsoluteImport(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/parse/parse.go
+++ b/pkg/parse/parse.go
@@ -81,6 +81,8 @@ func importForeign(def importDef, input antlr.CharStream) (antlr.CharStream, err
 		return input, nil
 	case "~swagger":
 		text, err = importer.LoadSwaggerText(od, input.GetText(0, input.Size()), logger)
+	case "~openapi3":
+		text, err = importer.LoadOpenAPIText(od, input.GetText(0, input.Size()), logger)
 	default:
 		return nil, Exitf(ParseError, fmt.Sprintf("%s has unknown format - (%s)\n", def.filename, def.mode))
 	}

--- a/pkg/parse/tests/openapi3.sysl
+++ b/pkg/parse/tests/openapi3.sysl
@@ -1,0 +1,12 @@
+import preference.yaml as preference ~openapi3
+
+Simple "Simple Server" [package="simple"]:
+    @basePath = "simple"
+
+    /stuff:
+        GET:
+            return ok <: Stuff
+
+    !type Stuff:
+        innerStuff <: string:
+            @json_tag = "innerStuff"

--- a/pkg/parse/tests/openapi3.sysl.golden.textpb
+++ b/pkg/parse/tests/openapi3.sysl.golden.textpb
@@ -1,0 +1,352 @@
+apps: <
+  key: "Simple"
+  value: <
+    name: <
+      part: "Simple"
+    >
+    long_name: "Simple Server"
+    attrs: <
+      key: "basePath"
+      value: <
+        s: "simple"
+      >
+    >
+    attrs: <
+      key: "package"
+      value: <
+        s: "simple"
+      >
+    >
+    endpoints: <
+      key: "GET /stuff"
+      value: <
+        name: "GET /stuff"
+        attrs: <
+          key: "patterns"
+          value: <
+            a: <
+              elt: <
+                s: "rest"
+              >
+            >
+          >
+        >
+        stmt: <
+          ret: <
+            payload: "ok <: Stuff"
+          >
+        >
+        rest_params: <
+          method: GET
+          path: "/stuff"
+        >
+        source_context: <
+          file: "tests/openapi3.sysl"
+          start: <
+            line: 7
+            col: 8
+          >
+          end: <
+            line: 10
+            col: 4
+          >
+        >
+      >
+    >
+    types: <
+      key: "Stuff"
+      value: <
+        tuple: <
+          attr_defs: <
+            key: "innerStuff"
+            value: <
+              primitive: STRING
+              attrs: <
+                key: "json_tag"
+                value: <
+                  s: "innerStuff"
+                >
+              >
+              source_context: <
+                file: "tests/openapi3.sysl"
+                start: <
+                  line: 12
+                  col: 22
+                >
+                end: <
+                  line: 13
+                >
+              >
+            >
+          >
+        >
+        source_context: <
+          file: "tests/openapi3.sysl"
+          start: <
+            line: 10
+            col: 4
+          >
+          end: <
+            line: 13
+          >
+        >
+      >
+    >
+    source_context: <
+      file: "tests/openapi3.sysl"
+      start: <
+        line: 3
+        col: 1
+      >
+      end: <
+        line: 3
+        col: 40
+      >
+    >
+  >
+>
+apps: <
+  key: "preference"
+  value: <
+    name: <
+      part: "preference"
+    >
+    long_name: "User Preference"
+    attrs: <
+      key: "description"
+      value: <
+        s: "No description."
+      >
+    >
+    attrs: <
+      key: "version"
+      value: <
+        s: "1.0.0"
+      >
+    >
+    endpoints: <
+      key: "GET /preference"
+      value: <
+        name: "GET /preference"
+        docstring: "No description."
+        attrs: <
+          key: "patterns"
+          value: <
+            a: <
+              elt: <
+                s: "rest"
+              >
+            >
+          >
+        >
+        stmt: <
+          ret: <
+            payload: "ok <: sequence of Preferences_obj"
+          >
+        >
+        rest_params: <
+          method: GET
+          path: "/preference"
+        >
+        source_context: <
+          file: "tests/preference.yaml"
+          start: <
+            line: 13
+            col: 8
+          >
+          end: <
+            line: 20
+            col: 4
+          >
+        >
+      >
+    >
+    types: <
+      key: "Preferences"
+      value: <
+        sequence: <
+          type_ref: <
+            context: <
+              appname: <
+                part: "preference"
+              >
+              path: "Preferences"
+            >
+            ref: <
+              path: "Preferences_obj"
+            >
+          >
+          source_context: <
+            file: "tests/preference.yaml"
+            start: <
+              line: 33
+              col: 4
+            >
+            end: <
+              line: 35
+            >
+          >
+        >
+        source_context: <
+          file: "tests/preference.yaml"
+          start: <
+            line: 33
+            col: 4
+          >
+          end: <
+            line: 35
+          >
+        >
+      >
+    >
+    types: <
+      key: "Preferences_obj"
+      value: <
+        tuple: <
+          attr_defs: <
+            key: "preferenceName"
+            value: <
+              primitive: STRING
+              attrs: <
+                key: "json_tag"
+                value: <
+                  s: "preferenceName"
+                >
+              >
+              source_context: <
+                file: "tests/preference.yaml"
+                start: <
+                  line: 22
+                  col: 26
+                >
+                end: <
+                  line: 23
+                  col: 8
+                >
+              >
+            >
+          >
+          attr_defs: <
+            key: "preferenceValue"
+            value: <
+              primitive: STRING
+              attrs: <
+                key: "json_tag"
+                value: <
+                  s: "preferenceValue"
+                >
+              >
+              opt: true
+              source_context: <
+                file: "tests/preference.yaml"
+                start: <
+                  line: 24
+                  col: 27
+                >
+                end: <
+                  line: 25
+                  col: 8
+                >
+              >
+            >
+          >
+          attr_defs: <
+            key: "status"
+            value: <
+              type_ref: <
+                context: <
+                  appname: <
+                    part: "preference"
+                  >
+                  path: "Preferences_obj"
+                >
+                ref: <
+                  path: "Preferences_obj_status"
+                >
+              >
+              attrs: <
+                key: "json_tag"
+                value: <
+                  s: "status"
+                >
+              >
+              source_context: <
+                file: "tests/preference.yaml"
+                start: <
+                  line: 26
+                  col: 18
+                >
+                end: <
+                  line: 27
+                  col: 8
+                >
+              >
+            >
+          >
+          attr_defs: <
+            key: "userId"
+            value: <
+              primitive: STRING
+              attrs: <
+                key: "json_tag"
+                value: <
+                  s: "userId"
+                >
+              >
+              source_context: <
+                file: "tests/preference.yaml"
+                start: <
+                  line: 28
+                  col: 18
+                >
+                end: <
+                  line: 30
+                  col: 4
+                >
+              >
+            >
+          >
+        >
+        source_context: <
+          file: "tests/preference.yaml"
+          start: <
+            line: 20
+            col: 4
+          >
+          end: <
+            line: 30
+            col: 4
+          >
+        >
+      >
+    >
+    types: <
+      key: "Preferences_obj_status"
+      value: <
+        primitive: STRING
+        source_context: <
+          file: "tests/preference.yaml"
+          start: <
+            line: 30
+            col: 4
+          >
+          end: <
+            line: 33
+            col: 4
+          >
+        >
+      >
+    >
+    source_context: <
+      file: "tests/preference.yaml"
+      start: <
+        line: 7
+        col: 1
+      >
+      end: <
+        line: 7
+        col: 11
+      >
+    >
+  >
+>

--- a/pkg/parse/tests/preference.yaml
+++ b/pkg/parse/tests/preference.yaml
@@ -1,0 +1,39 @@
+openapi: 3.0.0
+info:
+  version: "1.0.0"
+  title: User Preference
+paths:
+  /preference:
+    get:
+      responses:
+        "200":
+          description: This is a sample description
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Preferences"
+components:
+  schemas:
+    Preferences:
+      type: array
+      items:
+        required:
+          - userId
+          - preferenceName
+          - status
+        properties:
+          userId:
+            type: string
+            format: uuid
+          preferenceName:
+            type: string
+          preferenceValue:
+            type: string
+          status:
+            type: string
+            description: Preference Status
+            enum:
+              - test
+              - enabled
+              - disabled
+              - delete


### PR DESCRIPTION
Fixes https://github.com/anz-bank/sysl/issues/593

Changes proposed in this pull request:
- Adds support for openapi3 spec import into sysl files using this syntax `import preference.yaml as preference ~openapi3`

Checklist:
- [ X ] Added related tests
- [ X ] Made corresponding changes to the documentation (in a followup PR https://github.com/anz-bank/sysl/pull/780)
