### PR TITLE
Fix broken reference in ordering.yaml

### DIFF
--- a/demo/examples/Code-Generation/ordering.yaml
+++ b/demo/examples/Code-Generation/ordering.yaml
@@ -3,6 +3,6 @@ Code Generation:
   - intro.md
   - api/sysl/simple.sysl
   - generate.sh
-  - lspframework/server/server.go
+  - internal/server/server.go
   - main.go
   - test.sh


### PR DESCRIPTION
Fixes an issue caused by an incorrect search and replace, introduced in aa2fc63b32ef1af8eff149f5c39af030210f86f1
