### PR TITLE
Wbnf grammar fixes

### DIFF
--- a/pkg/parser/endpoints.wbnf
+++ b/pkg/parser/endpoints.wbnf
@@ -1,10 +1,13 @@
-endpoint -> (rest_endpoint | simple_endpoint | collector | event);
+endpoint -> (rest_endpoint | collector | event | simple_endpoint);
 
-simple_endpoint -> endpoint_name=(APPNAME) QSTRING? params? attribs? ":"
-                   (
-                       WRAPPED_SHORTCUT
-                       | %!InlineCommentIndent(annotation | stmt)
-                   );
+simple_endpoint -> endpoint_name=(APPNAME) QSTRING? params? attribs? 
+                    (
+                        ":"
+                           (
+                               WRAPPED_SHORTCUT
+                               | %!InlineCommentIndent(annotation | stmt)
+                           )
+                    )?;
 
 rest_endpoint -> http_path attribs? ":"
                  %!InlineCommentIndent(method_def | rest_endpoint);

--- a/pkg/parser/stmt.wbnf
+++ b/pkg/parser/stmt.wbnf
@@ -29,4 +29,4 @@ ret_stmt -> "return" ret_val=(TEXT);
 
 group_stmt -> NAME ":" %!InlineCommentIndent(stmt);
 
-text_stmt -> doc_string=("|" [^(\r?\n)]*) | QSTRING | TEXT ("<-" NAME)? | SHORTCUT;
+text_stmt -> doc_string=("|" [^\n]*) | QSTRING | TEXT ("<-" NAME)? | SHORTCUT;

--- a/pkg/parser/sysl.wbnf
+++ b/pkg/parser/sysl.wbnf
@@ -55,6 +55,7 @@ table -> mode=("!table"|"!type") NAME attribs?  ":"
          table_row -> table_field
                     | annotation
                     | table
+                    | unspecified=TEXT_WITH_WHITESPACE
                     | SHORTCUT;
          
          table_field -> field_with_default_value optional="?"? attribs? (":" annotations)?;

--- a/pkg/parser/sysl.wbnf
+++ b/pkg/parser/sysl.wbnf
@@ -39,11 +39,11 @@ app_decl   -> annotation
             | COMMENT_NO_NL
             | WRAPPED_SHORTCUT
             | type_decl
-            | endpoint
             | event
             | subscribe
             | view
-            | mixin;
+            | mixin
+            | endpoint;
 
 
 // -------------- Types --------------- //

--- a/pkg/parser/sysl.wbnf
+++ b/pkg/parser/sysl.wbnf
@@ -52,11 +52,11 @@ type_decl -> table | facade | alias | union | enum;
 
 table -> mode=("!table"|"!type") NAME attribs?  ":"
          (WRAPPED_SHORTCUT | %!InlineCommentIndent(table_row)) {
-         table_row -> table_field
+         table_row -> SHORTCUT
+                    | table_field
                     | annotation
                     | table
-                    | unspecified=TEXT_WITH_WHITESPACE
-                    | SHORTCUT;
+                    | unspecified=TEXT_WITH_WHITESPACE;
          
          table_field -> field_with_default_value optional="?"? attribs? (":" annotations)?;
          
@@ -131,7 +131,16 @@ TEXT -> [^\n]+;
 TEXT_LINE -> /{\s* ( [^\s:(] [^(#\r\n:]* [^#\s\r\n(:] )};
 APPNAME -> (pkg=@):"." > (app=@):"::" > APPNAME_PART;
 APPNAME_PART -> (TEXT_WITH_WHITESPACE | QSTRING)+;
-TEXT_WITH_WHITESPACE -> /{[a-zA-Z_][-\w]*(?:[-\t\_]*\w+)*};
+TEXT_WITH_WHITESPACE -> [.a-zA-Z_]
+                        (
+                            ([>/\w]+):/{(\- [\<\&\+\t\_\w] | \< [\>\+\&\t\_\w] | [\>\+\&\t\_])*}
+                            | ([>/\w]+):/{(\- \w)*}
+                            | /{\- [\w \/]}
+                            | /{\< [\w\>]}
+                        )*
+                        {
+                            .wrapRE -> /{()[\_\t]*};
+                        };
 PREDICATE -> [^\n:]+;
 SHORTCUT -> "...";
 WRAPPED_SHORTCUT -> COMMENT* \n* SHORTCUT COMMENT_NO_NL?;

--- a/pkg/parser/sysl.wbnf
+++ b/pkg/parser/sysl.wbnf
@@ -113,7 +113,7 @@ annotation -> "@" var_name=([a-zA-Z_][-\w.]*) "=" value=(QSTRING | array_of_stri
 
 annotations -> %!Indented(annotation);
 
-multi_line_docstring -> ":" %!InlineCommentIndent("|" TEXT);
+multi_line_docstring -> ":" %!InlineCommentIndent("|" TEXT?);
 
 http_path_var_with_type -> "{" var=(NAME | DIGITS) "<:" type=(NativeDataTypes | reference) "}";
 

--- a/scripts/grammar-out.txt
+++ b/scripts/grammar-out.txt
@@ -156,6 +156,7 @@ success ./pkg/importer/tests-openapi/simple_with_special_char_endpoint.sysl
 success ./pkg/importer/tests-openapi/header-body-params.sysl
 success ./pkg/importer/tests-openapi/query-params.sysl
 success ./pkg/importer/tests-openapi/simple-array.sysl
+success ./pkg/importer/tests-openapi/circular-dependency.sysl
 success ./pkg/importer/tests-openapi/query-body-param.sysl
 success ./pkg/importer/tests-openapi/path-returns-typed-array.sysl
 success ./pkg/importer/tests-openapi/nested-types.sysl
@@ -189,6 +190,7 @@ success ./pkg/parse/tests/until_loop.sysl
 success ./pkg/parse/tests/oneof.sysl
 success ./pkg/parse/tests/funcs.sysl
 success ./pkg/parse/tests/test4.sysl
+success ./pkg/parse/tests/openapi3.sysl
 success ./pkg/parse/tests/duplicate_import.sysl
 success ./pkg/parse/tests/library.sysl
 success ./pkg/parse/tests/alias_inline.sysl
@@ -239,4 +241,4 @@ fail    ./unsorted/lib/lang/json.sysl
 fail    ./unsorted/lib/lang/java.sysl
 fail    ./unsorted/lib/base/grammar.sysl
 fail    ./pkg/database/db_scripts/invalid.sysl
-Passes:237 Fails:4
+Passes:239 Fails:4


### PR DESCRIPTION
This PR adds several changes to the syntax based on the old parser.

Note to reviewer: One of the change is to allow simple endpoints to be empty without adding `...` at the end. Some old sysl files have this, please decide if you want to support this again.

Changes proposed in this pull request:
- Add support for unspecified field in type/table grammar
- Fixed docstring parsing (it didn't allow `(`)
- Allow empty docstring
- Allow more special character in `APPNAME`
- Allow empty simple endpoint that does not have `...` at the end
