### PR TITLE
Add sysl wrapper package WIP

### DIFF
--- a/pkg/sysl/sysl.proto
+++ b/pkg/sysl/sysl.proto
@@ -220,7 +220,7 @@ message Type {
     SourceContext source_context = 99;
 
     enum Primitive {
-        NO_Primitive = 0;
+        NO_Primitive = 0; //NO_Primitive is an interface that can be used to evaluate whether a type is a primitive or not
         EMPTY       = 1;
         ANY         = 2;
         BOOL        = 3;

--- a/pkg/syslwrapper/README.md
+++ b/pkg/syslwrapper/README.md
@@ -1,0 +1,253 @@
+# syslwrapper
+
+This package adds an abstraction layer around sysl proto types defined in the sysl package.
+This is currently a work in progress, but is intended to make working with sysl types much easier and to solve common issues around working with sysl type references, as well as parsing return statements.
+
+## Usage
+
+```go
+func main() {
+	filename := "demo/grocerystore/GroceryStore.sysl"
+	syslModules, err := parse.NewParser().Parse(filename, afero.NewOsFs())
+	if err != nil {
+		panic(err)
+	}
+   
+	mapper := MakeAppMapper(syslModules)
+    mapper.IndexTypes() // This indexes all the sysl.Type in each application in a map, which can be accessed using "AppName:TypeName"
+    mapper.ConvertTypes() // This converts the indexed types into syslwrapper.Type
+    simpleApps, err := mapper.Map() // Maps the applications in syslModules into simple syslwrapperApps
+    
+    getInventoryEndpoint := simpleApps.["GroceryStore"].Endpoints["GET /inventory"]
+    params := getInventoryEndpoint.Params
+    responses := getInventoryEndpoint.Responses
+    
+    prettyPrintParams, err := json.MarshalIndent(params, "", " ")
+	prettyPrintResponses, err := json.MarshalIndent(responses, "", " ")
+	prettyPrintInventoryResponse, err := json.MarshalIndent(mapper.SimpleTypes["GroceryStore:fooid"], "", " ")
+    fmt.Println(string(prettyPrintParams))
+	fmt.Println(string(prettyPrintResponses))
+	fmt.Println(string(prettyPrintInventoryResponse))
+}
+```
+
+### Response Statement Parsing
+
+Responses are returned as
+```json
+{
+ "200": {
+  "In": "",
+  "Description": "",
+  "Name": "200",
+  "Type": {
+   "Description": "",
+   "Optional": false,
+   "Reference": "",
+   "Type": "list",
+   "Items": [
+    {
+     "Description": "",
+     "Optional": false,
+     "Reference": "GroceryStore:InventoryResponse",
+     "Type": "ref",
+     "Items": null,
+     "Enum": null,
+     "Properties": null
+    }
+   ],
+   "Enum": null,
+   "Properties": null
+  }
+ }
+}
+```
+Let's compare this with what the `sysl.Application` type gives us if we called `syslModules.Apps["GroceryStore"].Endpoints["GET /inventory"].Stmt`
+```
+[
+ {
+  "Stmt": {
+   "Call": {
+    "target": {
+     "part": [
+      "Inventory"
+     ]
+    },
+    "endpoint": "GET /inventory"
+   }
+  }
+ },
+ {
+  "Stmt": {
+   "Ret": {
+    "payload": "sequence of InventoryResponse"
+   }
+  }
+ }
+]
+```
+
+### Parameter Type Conversion
+
+Here's what `simpleApps["GroceryStore"].Endpoints["GET /inventory"].Params` gives us
+
+```json
+{
+ "fooid": {
+  "In": "header",
+  "Description": "",
+  "Name": "fooid",
+  "Type": {
+   "Description": "",
+   "Optional": false,
+   "Reference": "",
+   "Type": "string",
+   "Items": null,
+   "Enum": null,
+   "Properties": null
+  }
+ }
+}
+```
+
+Let's compare this with what the `sysl.Application` type gives us if we called `syslModules.Apps["GroceryStore"].Endpoints["GET /inventory"].Param`
+```json
+[
+ {
+  "name": "fooid",
+  "type": {
+   "Type": {
+    "Primitive": 6
+   },
+   "attrs": {
+    "name": {
+     "Attribute": {
+      "S": "FooID"
+     }
+    },
+    "patterns": {
+     "Attribute": {
+      "A": {
+       "elt": [
+        {
+         "Attribute": {
+          "S": "header"
+         }
+        },
+        {
+         "Attribute": {
+          "S": "required"
+         }
+        }
+       ]
+      }
+     }
+    }
+   }
+  }
+ }
+]
+```
+
+### Type Lookups
+
+If we wanted to lookup what InventoryResponse was, we can just call
+
+```go
+    mapper.SimpleTypes["GroceryStore:InventoryResponse"]
+```
+
+which returns
+
+```json
+{
+ "Description": "",
+ "Optional": false,
+ "Reference": "",
+ "Type": "tuple",
+ "Items": null,
+ "Enum": null,
+ "Properties": {
+  "item_id": {
+   "Description": "",
+   "Optional": false,
+   "Reference": "",
+   "Type": "string",
+   "Items": null,
+   "Enum": null,
+   "Properties": null
+  },
+  "quantity": {
+   "Description": "",
+   "Optional": false,
+   "Reference": "",
+   "Type": "int",
+   "Items": null,
+   "Enum": null,
+   "Properties": null
+  }
+ }
+}
+```
+
+### Type Resolution (WIP)
+
+Lets say you don't care for having to deal with looking up type references, you just want definite types for all of these
+
+`mapper.ResolveTypes()`
+
+Or if you want to just resolve one type, use `mapper.ResolveTypes()` Not Yet Fully Implemented
+
+This function goes through each type reference and replaces it with the actual data type. This converts the data types from a graph representation to a tree representation.
+
+This feature is still under construction, with some recursion that needs to be resolved.
+
+Example
+```go
+func main() {
+	filename := "demo/grocerystore/GroceryStore.sysl"
+	syslModules, err := parse.NewParser().Parse(filename, afero.NewOsFs())
+	if err != nil {
+		panic(err)
+	}
+
+	mapper := syslwrapper.MakeAppMapper(syslModules)
+	mapper.IndexTypes()
+	mapper.ResolveTypes()
+	mapper.ConvertTypes()
+	simpleApps, err := mapper.Map()
+
+	responses := simpleApps["GroceryStore"].Endpoints["GET /inventory"].Response
+	prettyPrintResponses, err := json.MarshalIndent(responses, "", " ")
+	fmt.Println(string(prettyPrintResponses))
+}
+```
+
+```json
+{
+ "200": {
+  "In": "",
+  "Description": "",
+  "Name": "200",
+  "Type": {
+   "Description": "",
+   "Optional": false,
+   "Reference": "",
+   "Type": "list",
+   "Items": [
+    {
+     "Description": "",
+     "Optional": false,
+     "Reference": "GroceryStore:InventoryResponse",
+     "Type": "ref",
+     "Items": null,
+     "Enum": null,
+     "Properties": null
+    }
+   ],
+   "Enum": null,
+   "Properties": null
+  }
+ }
+}
+```

--- a/pkg/syslwrapper/app.go
+++ b/pkg/syslwrapper/app.go
@@ -28,7 +28,7 @@ type Parameter struct {
 }
 
 type Type struct {
-	Source     string // The full name of the app where the type is defined
+	Reference  string // The full name of the app where the type is defined
 	Type       string
 	Items      []*Type
 	Enum       map[string]int64
@@ -293,6 +293,7 @@ func (am *AppMapper) convertTypeToString(t *sysl.Type) *Type {
 	var items []*Type
 	var properties map[string]*Type
 	var enum map[string]int64
+	var ref string
 
 	if t == nil {
 		fmt.Printf("empty type")
@@ -314,6 +315,9 @@ func (am *AppMapper) convertTypeToString(t *sysl.Type) *Type {
 		simpleType = "map"
 		items = append(items, am.convertTypeToString(t.GetMap().Key))
 		items = append(items, am.convertTypeToString(t.GetMap().Value))
+	case *sysl.Type_TypeRef:
+		simpleType = "ref"
+		ref = t.GetRef().GetAppname().String() + ":" + t.GetTypeRef().GetRef().GetPath()
 	case *sysl.Type_Tuple_:
 		simpleType = "tuple"
 		properties = make(map[string]*Type, 15)

--- a/pkg/syslwrapper/app.go
+++ b/pkg/syslwrapper/app.go
@@ -1,0 +1,339 @@
+package syslutil
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/anz-bank/sysl/pkg/sysl"
+)
+
+// App is a simplified representation of an application in sysl
+type App struct {
+	Name       string
+	Attributes map[string]string
+	Endpoints  map[string]*Endpoint
+	Types      map[string]*Type
+}
+
+type Endpoint struct {
+	Path       string
+	Params     map[string]*Parameter
+	Response   map[string]*Parameter
+	Downstream []string
+}
+
+type Parameter struct {
+	Name string
+	Type *Type
+}
+
+type Type struct {
+	Source     string // The full name of the app where the type is defined
+	Type       string
+	Items      []*Type
+	Enum       map[string]int64
+	Properties map[string]*Type
+}
+
+type AppMapper struct {
+	Module *sysl.Module
+	Types  map[string]*sysl.Type // A map of all non reference sysl types
+}
+
+// MakeAppMapper creates an appmapper
+func MakeAppMapper(m *sysl.Module) *AppMapper {
+	return &AppMapper{
+		Module: m,
+	}
+}
+
+// ImportModule takes a sysl module and maps them into an array of simplified App structs
+// It resolves any type references and cross application calls
+func (am *AppMapper) Map() (map[string]*App, error) {
+	var simpleApps = make(map[string]*App, 15)
+	for _, app := range am.Module.Apps {
+		simpleApp, err := am.BuildApplication(app)
+		if err != nil {
+			return nil, err
+		}
+		simpleApps[simpleApp.Name] = simpleApp
+	}
+	return simpleApps, nil
+}
+
+// BuildApplication returns a clean representation of a Sysl Application
+// which hides the complexities of the protobuf generated type.
+func (am *AppMapper) BuildApplication(a *sysl.Application) (*App, error) {
+	cleanApp := &App{
+		Name:       strings.Join(a.GetName().GetPart(), " "),
+		Attributes: am.mapAttributes(a.GetAttrs()),
+		Endpoints:  am.mapEndpoints(strings.Join(a.GetName().GetPart(), " "), a.GetEndpoints()),
+		Types:      am.mapTypes(strings.Join(a.GetName().GetPart(), " "), a.GetTypes()),
+	}
+	return cleanApp, nil
+}
+
+// Creates a map of all types
+// TODO Check if colon is valid in typename
+func (am *AppMapper) IndexTypes() map[string]*sysl.Type {
+	var typeIndex map[string]*sysl.Type = make(map[string]*sysl.Type, 10)
+	for appName, app := range am.Module.Apps {
+		for typeName, typeVal := range app.Types {
+			typeIndex[appName+":"+typeName] = typeVal
+		}
+	}
+	am.Types = typeIndex
+	return typeIndex
+}
+
+// TODO: Resolve Parameters
+
+// Iterates over types and resolves typerefs
+func (am *AppMapper) resolveTypes() {
+	for key, value := range am.Types {
+		am.Types[key] = am.resolveType(value)
+	}
+}
+
+// Only handles string attributes, support for int64, float64 and array attributes not implemented
+func (am *AppMapper) mapAttributes(attributes map[string]*sysl.Attribute) map[string]string {
+	var attr = make(map[string]string, 15)
+	for key, value := range attributes {
+		attr[key] = value.GetS()
+	}
+	return attr
+}
+
+func (am *AppMapper) mapTypes(appName string, syslTypes map[string]*sysl.Type) map[string]*Type {
+	simpleTypes := make(map[string]*Type, 15)
+	for typeName, _ := range syslTypes {
+		simpleTypes[typeName] = am.convertTypeToString(am.Types[appName+":"+typeName])
+	}
+	return simpleTypes
+}
+
+func (am *AppMapper) mapEndpoints(appName string, ep map[string]*sysl.Endpoint) map[string]*Endpoint {
+	endpoints := make(map[string]*Endpoint, 15)
+	for key, value := range ep {
+		endpoints[key] = &Endpoint{
+			Path:     key,
+			Params:   am.mapAllParams(value),
+			Response: am.mapResponse(value.GetStmt()),
+		}
+	}
+	return endpoints
+}
+
+func (am *AppMapper) mapResponse(stmt []*sysl.Statement) map[string]*Parameter {
+	responseTypes := make(map[string]*Parameter, 15)
+	for i := range stmt {
+		var returnType *Type
+		var returnName string
+		if stmt[i].GetRet() == nil {
+			continue
+		}
+		if strings.Contains(stmt[i].GetRet().Payload, "<:") {
+			returnStatement := strings.Split(stmt[i].GetRet().Payload, " <: ")
+			returnRef := strings.Replace(returnStatement[1], ".", ":", 1)
+			returnType = am.convertTypeToString(am.Types[returnRef])
+			returnName = returnStatement[0]
+
+		} else {
+			// If it's a primitive, we return it
+			returnName = "default"
+			returnType = &Type{
+				Type: stmt[i].GetRet().Payload,
+			}
+
+		}
+
+		responseTypes[returnName] = &Parameter{
+			Name: returnName,
+			Type: returnType,
+		}
+	}
+
+	return responseTypes
+}
+
+func (am *AppMapper) mapAllParams(endpoint *sysl.Endpoint) map[string]*Parameter {
+	params := am.mapParams(endpoint.Param)
+	params = am.mapRestParams(endpoint.RestParams, params)
+	return params
+}
+
+func (am *AppMapper) mapRestParams(p *sysl.Endpoint_RestParams, params map[string]*Parameter) map[string]*Parameter {
+	if p.GetQueryParam() != nil {
+		params = am.mapQueryParams(p.QueryParam, params)
+	}
+
+	if p.GetUrlParam() != nil {
+		params = am.mapURLParams(p.UrlParam, params)
+	}
+
+	return params
+}
+
+func (am *AppMapper) mapURLParams(urlParams []*sysl.Endpoint_RestParams_QueryParam, params map[string]*Parameter) map[string]*Parameter {
+	if urlParams == nil {
+		return params
+	}
+	for _, urlParam := range urlParams {
+		fmt.Println(urlParam.GetName())
+		params[urlParam.GetName()] = &Parameter{
+			Name: urlParam.GetName(),
+			Type: am.resolveParamType(urlParam.GetType()),
+		}
+	}
+	return params
+}
+
+func (am *AppMapper) mapQueryParams(queryParams []*sysl.Endpoint_RestParams_QueryParam, params map[string]*Parameter) map[string]*Parameter {
+	if queryParams == nil {
+		return params
+	}
+	for _, queryParam := range queryParams {
+		fmt.Println(queryParam.GetName())
+		params[queryParam.GetName()] = &Parameter{
+			Name: queryParam.GetName(),
+			Type: am.resolveParamType(queryParam.GetType()),
+		}
+	}
+	return params
+}
+
+func (am *AppMapper) mapParams(p []*sysl.Param) map[string]*Parameter {
+	params := make(map[string]*Parameter, 15)
+	for _, param := range p {
+		params[param.GetName()] = &Parameter{
+			Name: param.GetName(),
+			Type: am.resolveParamType(param.GetType()),
+		}
+	}
+	return params
+}
+
+func (am *AppMapper) resolveParamType(syslType *sysl.Type) *Type {
+	// Lookup type in Types
+	typeResolved := am.resolveType(syslType)
+	return am.convertTypeToString(typeResolved)
+}
+
+// Takes a sysl type and resolves all references recursively
+// Resolves typerefs and collections of types into the base primitives
+// TODO: Handle circular dependencies
+func (am *AppMapper) resolveType(t *sysl.Type) *sysl.Type {
+	if t == nil {
+		return t
+	}
+	var resolved = t
+	var err error
+	switch t.Type.(type) {
+	case *sysl.Type_OneOf_:
+		for index, val := range t.GetOneOf().Type {
+			resolved.GetOneOf().Type[index] = am.resolveType(val)
+		}
+	case *sysl.Type_Map_:
+		resolved.GetMap().Key = am.resolveType(t.GetMap().Key)
+		resolved.GetMap().Value = am.resolveType(t.GetMap().Value)
+	case *sysl.Type_TypeRef:
+		resolved, err = am.TypeFromRef(t)
+	case *sysl.Type_Tuple_:
+		for key, value := range t.GetTuple().AttrDefs {
+			resolved.GetTuple().AttrDefs[key] = am.resolveType(value)
+		}
+	case *sysl.Type_List_:
+		resolved.GetList().Type = am.resolveType(t.GetList().Type)
+	}
+
+	if err != nil {
+		panic(err)
+	}
+	return resolved
+}
+
+// Resolves type references
+// Type references within the same application don't have the appName, so it must be passed in
+func (am *AppMapper) TypeFromRef(t *sysl.Type) (*sysl.Type, error) {
+	// TypeRefs can have various formats.
+	// When a type defined in the same app is referenced
+	// 	- no context is provided
+	// 	- the ref.path[0] element is the type name
+	// When a type from another app is referenced in a parameter
+	// 	- context is NOT provided
+	//  - ref.appName is provided
+	// 	- the ref.path[0] element is the type name
+	// When a type from another app is referenced
+	// 	- context is provided
+	// 	- the ref.path[0] element is the application name
+	var appName string
+	if t == nil {
+		return nil, fmt.Errorf("invalid arguments")
+	}
+
+	ref := t.GetTypeRef().GetRef()
+	if ref.GetAppname() != nil {
+		appName = strings.Join(ref.Appname.Part, "")
+	}
+	typeName := strings.Join(ref.GetPath(), ".")
+	if len(ref.GetPath()) > 1 {
+		appName = ref.Path[0]
+		typeName = ref.Path[1]
+	}
+	resolvedType, ok := am.Types[appName+":"+typeName]
+	if !ok {
+		return nil, fmt.Errorf("unable to find type ref for %s", typeName)
+	}
+	return resolvedType, nil
+}
+
+// Converts sysl type to a string representatino of the type
+func (am *AppMapper) convertTypeToString(t *sysl.Type) *Type {
+	var simpleType string
+	var items []*Type
+	var properties map[string]*Type
+	var enum map[string]int64
+
+	if t == nil {
+		fmt.Printf("empty type")
+		return &Type{}
+	}
+
+	switch t.Type.(type) {
+	case *sysl.Type_NoType_:
+		simpleType = "notype"
+	case *sysl.Type_Primitive_:
+		simpleType = am.convertPrimitive(t.String())
+	case *sysl.Type_Enum_:
+		simpleType = "enum"
+		enum = t.GetEnum().GetItems()
+	case *sysl.Type_List_:
+		simpleType = "list"
+		items = append(items, am.convertTypeToString(t.GetList().Type))
+	case *sysl.Type_Map_:
+		simpleType = "map"
+		items = append(items, am.convertTypeToString(t.GetMap().Key))
+		items = append(items, am.convertTypeToString(t.GetMap().Value))
+	case *sysl.Type_Tuple_:
+		simpleType = "tuple"
+		properties = make(map[string]*Type, 15)
+		for k, v := range t.GetTuple().AttrDefs {
+			properties[k] = am.convertTypeToString(v)
+		}
+	}
+
+	return &Type{
+		Type:       simpleType,
+		Items:      items,
+		Properties: properties,
+		Enum:       enum,
+	}
+}
+
+func (am *AppMapper) convertPrimitive(typeStr string) string {
+	primTypeFirstLine := strings.Split(typeStr, " ")[0]
+	primType := strings.Split(primTypeFirstLine, ":")[1]
+	primTypeLower := strings.ToLower(primType)
+	primTypeNoSpace := strings.TrimSpace(primTypeLower)
+	return primTypeNoSpace
+}

--- a/pkg/syslwrapper/app.go
+++ b/pkg/syslwrapper/app.go
@@ -237,7 +237,7 @@ func (am *AppMapper) resolveType(t *sysl.Type) *sysl.Type {
 		resolved.GetMap().Key = am.resolveType(t.GetMap().Key)
 		resolved.GetMap().Value = am.resolveType(t.GetMap().Value)
 	case *sysl.Type_TypeRef:
-		resolved, err = am.TypeFromRef(t)
+		resolved, err = am.MapType(t)
 	case *sysl.Type_Tuple_:
 		for key, value := range t.GetTuple().AttrDefs {
 			resolved.GetTuple().AttrDefs[key] = am.resolveType(value)
@@ -252,9 +252,8 @@ func (am *AppMapper) resolveType(t *sysl.Type) *sysl.Type {
 	return resolved
 }
 
-// Resolves type references
-// Type references within the same application don't have the appName, so it must be passed in
-func (am *AppMapper) TypeFromRef(t *sysl.Type) (*sysl.Type, error) {
+// MapType converts types from sysl.Type to Type
+func (am *AppMapper) MapType(t *sysl.Type) (*sysl.Type, error) {
 	// TypeRefs can have various formats.
 	// When a type defined in the same app is referenced
 	// 	- no context is provided
@@ -317,7 +316,7 @@ func (am *AppMapper) convertTypeToString(t *sysl.Type) *Type {
 		items = append(items, am.convertTypeToString(t.GetMap().Value))
 	case *sysl.Type_TypeRef:
 		simpleType = "ref"
-		ref = t.GetRef().GetAppname().String() + ":" + t.GetTypeRef().GetRef().GetPath()
+		//ref =  t.GetTypeRef().GetRef().GetAppname().String() + ":" + t.GetTypeRef().GetRef().GetPath()
 	case *sysl.Type_Tuple_:
 		simpleType = "tuple"
 		properties = make(map[string]*Type, 15)
@@ -331,6 +330,7 @@ func (am *AppMapper) convertTypeToString(t *sysl.Type) *Type {
 		Items:      items,
 		Properties: properties,
 		Enum:       enum,
+		Reference:  ref,
 	}
 }
 

--- a/pkg/syslwrapper/app.go
+++ b/pkg/syslwrapper/app.go
@@ -33,7 +33,7 @@ type Parameter struct {
 
 type Type struct {
 	Description string
-	Reference   string // The full name of the app where the type is defined
+	Reference   string // The full name of the app:typename
 	Type        string
 	Items       []*Type
 	Enum        map[string]int64
@@ -41,8 +41,9 @@ type Type struct {
 }
 
 type AppMapper struct {
-	Module *sysl.Module
-	Types  map[string]*sysl.Type // A map of all non reference sysl types
+	Module      *sysl.Module
+	Types       map[string]*sysl.Type // A map of all non reference sysl types
+	SimpleTypes map[string]*Type
 }
 
 // MakeAppMapper creates an appmapper
@@ -89,6 +90,15 @@ func (am *AppMapper) IndexTypes() map[string]*sysl.Type {
 	}
 	am.Types = typeIndex
 	return typeIndex
+}
+
+func (am *AppMapper) ConvertTypes() map[string]*Type {
+	simpleTypes := make(map[string]*Type)
+	for typeName, syslType := range am.Types {
+		simpleTypes[typeName] = am.MapType(syslType)
+	}
+	am.SimpleTypes = simpleTypes
+	return simpleTypes
 }
 
 // TODO: Resolve Parameters

--- a/pkg/syslwrapper/app.go
+++ b/pkg/syslwrapper/app.go
@@ -377,10 +377,10 @@ func (am *AppMapper) MapType(t *sysl.Type) *Type {
 			enum[index] = str
 		}
 	case *sysl.Type_Sequence:
-		simpleType = "list"
+		simpleType = "list" //nolint:goconst
 		items = append(items, am.MapType(t.GetSequence()))
 	case *sysl.Type_List_:
-		simpleType = "list"
+		simpleType = "list" //nolint:goconst
 		items = append(items, am.MapType(t.GetList().Type))
 	case *sysl.Type_Map_:
 		simpleType = "map"

--- a/pkg/syslwrapper/app.go
+++ b/pkg/syslwrapper/app.go
@@ -216,7 +216,7 @@ func (am *AppMapper) mapSimpleReturnType(retName string, appName string) *Type {
 
 func isPrimitive(typeName string) bool {
 	switch typeName {
-	case "double", "int64", "float64", "string", "bool", "date", "datetime":
+	case "double", "int64", "float64", "string", "bool", "date", "datetime": //nolint:goconst
 		return true
 	default:
 		return false

--- a/pkg/syslwrapper/app.go
+++ b/pkg/syslwrapper/app.go
@@ -1,4 +1,4 @@
-package syslutil
+package syslwrapper
 
 import (
 	"fmt"
@@ -16,23 +16,26 @@ type App struct {
 }
 
 type Endpoint struct {
-	Path       string
-	Params     map[string]*Parameter
-	Response   map[string]*Parameter
-	Downstream []string
+	Description string
+	Path        string
+	Params      map[string]*Parameter
+	Response    map[string]*Parameter
+	Downstream  []string
 }
 
 type Parameter struct {
-	Name string
-	Type *Type
+	Description string
+	Name        string
+	Type        *Type
 }
 
 type Type struct {
-	Reference  string // The full name of the app where the type is defined
-	Type       string
-	Items      []*Type
-	Enum       map[string]int64
-	Properties map[string]*Type
+	Description string
+	Reference   string // The full name of the app where the type is defined
+	Type        string
+	Items       []*Type
+	Enum        map[string]int64
+	Properties  map[string]*Type
 }
 
 type AppMapper struct {
@@ -140,7 +143,7 @@ func (am *AppMapper) mapResponse(stmt []*sysl.Statement) map[string]*Parameter {
 
 		} else {
 			// If it's a primitive, we return it
-			returnName = "default"
+			returnName = "200"
 			returnType = &Type{
 				Type: stmt[i].GetRet().Payload,
 			}
@@ -215,8 +218,8 @@ func (am *AppMapper) mapParams(p []*sysl.Param) map[string]*Parameter {
 
 func (am *AppMapper) resolveParamType(syslType *sysl.Type) *Type {
 	// Lookup type in Types
-	typeResolved := am.resolveType(syslType)
-	return am.MapType(typeResolved)
+	//typeResolved := am.resolveType(syslType)
+	return am.MapType(syslType)
 }
 
 // Takes a sysl type and resolves all references recursively

--- a/pkg/syslwrapper/app.go
+++ b/pkg/syslwrapper/app.go
@@ -103,7 +103,7 @@ func (am *AppMapper) ConvertTypes() map[string]*Type {
 }
 
 // Iterates over types and resolves typerefs
-func (am *AppMapper) resolveTypes() {
+func (am *AppMapper) ResolveTypes() {
 	for key, value := range am.Types {
 		am.Types[key] = am.resolveType(value)
 	}

--- a/pkg/syslwrapper/app_test.go
+++ b/pkg/syslwrapper/app_test.go
@@ -1,4 +1,4 @@
-package syslutil
+package syslwrapper
 
 import (
 	"encoding/json"
@@ -17,6 +17,21 @@ func readSyslModule(filename string) (*sysl.Module, error) {
 	return mod, err
 }
 
+func TestMapUnresolvedRest(t *testing.T) {
+	mod, err := readSyslModule("./tests/types.sysl")
+	assert.NoError(t, err)
+	mapper := MakeAppMapper(mod)
+	mapper.IndexTypes()
+	simpleApps, err := mapper.Map()
+	assert.NoError(t, err)
+	printStr, _ := json.MarshalIndent(simpleApps, "", " ")
+	t.Log(string(printStr))
+	assert.Equal(t, "string", simpleApps["SampleRestApp"].Endpoints["POST /login/{CustomerID}"].Params["CustomerID"].Type.Type)
+	assert.Equal(t, "string", simpleApps["SampleRestApp"].Endpoints["POST /login/{CustomerID}"].Params["newPost"].Type.Type)
+	assert.Equal(t, "string", simpleApps["SampleRestApp"].Endpoints["POST /login/{CustomerID}"].Response["default"].Type.Type)
+	assert.Equal(t, "string", simpleApps["SampleRestApp"].Endpoints["POST /post"].Params["newPost"].Type.Type)
+	assert.Equal(t, "string", simpleApps["SampleRestApp"].Endpoints["GET /post"].Params["PostId"].Type.Type)
+}
 func TestMapRest(t *testing.T) {
 	mod, err := readSyslModule("./tests/rest.sysl")
 	assert.NoError(t, err)

--- a/pkg/syslwrapper/app_test.go
+++ b/pkg/syslwrapper/app_test.go
@@ -78,7 +78,7 @@ func TestMapRest(t *testing.T) {
 	assert.NoError(t, err)
 	mapper := MakeAppMapper(mod)
 	mapper.IndexTypes()
-	mapper.resolveTypes()
+	mapper.ResolveTypes()
 	simpleApps, err := mapper.Map()
 	assert.NoError(t, err)
 	prettyPrint(t, simpleApps)
@@ -92,7 +92,7 @@ func TestMap(t *testing.T) {
 	assert.NoError(t, err)
 	mapper := MakeAppMapper(mod)
 	mapper.IndexTypes()
-	mapper.resolveTypes()
+	mapper.ResolveTypes()
 	simpleApps, err := mapper.Map()
 	assert.NoError(t, err)
 	prettyPrint(t, simpleApps)
@@ -107,7 +107,7 @@ func TestResolveTypesWithSyslFile(t *testing.T) {
 	assert.NoError(t, err)
 	mapper := MakeAppMapper(mod)
 	typeIndex := mapper.IndexTypes()
-	mapper.resolveTypes()
+	mapper.ResolveTypes()
 
 	expectedResult := MakeTuple(map[string]*sysl.Type{
 		"query":   MakePrimitive("int"),
@@ -152,7 +152,7 @@ func TestResolveNonExistentType(t *testing.T) {
 	mapper := MakeAppMapper(mod)
 	mapper.IndexTypes()
 
-	mapper.resolveTypes()
+	mapper.ResolveTypes()
 
 	assert.Equal(t, nil, mapper.Types["app2:request"].GetType())
 	assert.Equal(t, nil, mapper.Types["app1:list"].GetType())
@@ -170,7 +170,7 @@ func TestResolveTypesNil(t *testing.T) {
 
 	mapper := MakeAppMapper(mod)
 	typeIndex := mapper.IndexTypes()
-	mapper.resolveTypes()
+	mapper.ResolveTypes()
 	prettyPrint(t, typeIndex["app2:request"])
 	assert.Equal(t, nil, typeIndex["app2:request"].GetType())
 	assert.Equal(t, nil, typeIndex["app1:list"].GetType())

--- a/pkg/syslwrapper/app_test.go
+++ b/pkg/syslwrapper/app_test.go
@@ -1,0 +1,332 @@
+package syslutil
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/anz-bank/sysl/pkg/parse"
+	"github.com/anz-bank/sysl/pkg/sysl"
+	"github.com/anz-bank/sysl/pkg/syslutil"
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
+)
+
+func readSyslModule(filename string) (*sysl.Module, error) {
+	mod, err := parse.NewParser().Parse(filename,
+		syslutil.NewChrootFs(afero.NewOsFs(), "."))
+	return mod, err
+}
+
+func TestMapRest(t *testing.T) {
+	mod, err := readSyslModule("./tests/rest.sysl")
+	assert.NoError(t, err)
+	mapper := MakeAppMapper(mod)
+	mapper.IndexTypes()
+	mapper.resolveTypes()
+	simpleApps, err := mapper.Map()
+	assert.NoError(t, err)
+	printStr, _ := json.MarshalIndent(simpleApps, "", " ")
+	t.Log(string(printStr))
+	assert.Equal(t, "string", simpleApps["SampleRestApp"].Endpoints["POST /login/{CustomerID}"].Params["CustomerID"].Type.Type)
+	assert.Equal(t, "string", simpleApps["SampleRestApp"].Endpoints["POST /login/{CustomerID}"].Params["newPost"].Type.Type)
+	assert.Equal(t, "string", simpleApps["SampleRestApp"].Endpoints["POST /login/{CustomerID}"].Response["default"].Type.Type)
+	assert.Equal(t, "string", simpleApps["SampleRestApp"].Endpoints["POST /post"].Params["newPost"].Type.Type)
+	assert.Equal(t, "string", simpleApps["SampleRestApp"].Endpoints["GET /post"].Params["PostId"].Type.Type)
+}
+func TestMap(t *testing.T) {
+	mod, err := readSyslModule("./tests/types.sysl")
+	assert.NoError(t, err)
+	mapper := MakeAppMapper(mod)
+	mapper.IndexTypes()
+	mapper.resolveTypes()
+	simpleApps, err := mapper.Map()
+	assert.NoError(t, err)
+	printStr, _ := json.MarshalIndent(simpleApps, "", " ")
+	t.Log(string(printStr))
+	assert.Equal(t, "", simpleApps["Server"].Types["Response"].Properties["balance"].Type)
+	assert.Equal(t, "tuple", simpleApps["Server"].Types["Response"].Properties["query"].Type)
+	assert.Equal(t, "int", simpleApps["Server"].Types["Response"].Properties["query"].Properties["amount"].Type)
+	assert.Equal(t, "tuple", simpleApps["MobileApp"].Endpoints["Login"].Params["input"].Type.Type)
+	assert.Equal(t, "tuple", simpleApps["MobileApp"].Endpoints["Login"].Params["input"].Type.Type)
+	assert.Equal(t, "string", simpleApps["MobileApp"].Endpoints["Login"].Params["input"].Type.Properties["query"].Type)
+}
+func TestResolveTypesWithSyslFile(t *testing.T) {
+	mod, err := readSyslModule("./tests/types.sysl")
+	assert.NoError(t, err)
+	mapper := MakeAppMapper(mod)
+	typeIndex := mapper.IndexTypes()
+	mapper.resolveTypes()
+
+	expectedResult := makeTuple(map[string]*sysl.Type{
+		"query":   makePrimitive("int"),
+		"balance": makePrimitive("empty"),
+	})
+
+	printStr, _ := json.MarshalIndent(mapper.Types, "", " ")
+	t.Log(string(printStr))
+	assert.Equal(t, expectedResult.GetAttrs()["query"], typeIndex["Server:Response"].GetAttrs()["query"])
+	assert.Equal(t, expectedResult.GetAttrs()["balance"], typeIndex["Server:Response"].GetAttrs()["balance"])
+}
+
+func TestResolveNonExistentType(t *testing.T) {
+	type1 := makeTypeRef("app1", []string{"login"}, "app2", []string{"nonexist"})
+	param1 := makeParam("Login", type1)
+	var app1 = makeApp("app1", []*sysl.Param{param1}, map[string]*sysl.Type{"list": nil})
+	var app2 = makeApp("app2", []*sysl.Param{}, map[string]*sysl.Type{"request": nil})
+	var mod = &sysl.Module{
+		Apps: map[string]*sysl.Application{
+			"app1": &app1,
+			"app2": &app2,
+		},
+	}
+
+	mapper := MakeAppMapper(mod)
+	mapper.IndexTypes()
+
+	mapper.resolveTypes()
+	assert.Equal(t, nil, mapper.Types["app2:request"])
+	assert.Equal(t, nil, mapper.Types["app1:list"])
+}
+func TestResolveTypesNil(t *testing.T) {
+	type1 := makeTypeRef("app1", []string{"login"}, "app2", []string{"request"})
+	var app1 = makeApp("app1", []*sysl.Param{}, map[string]*sysl.Type{"list": type1})
+	var app2 = makeApp("app2", []*sysl.Param{}, map[string]*sysl.Type{"request": nil})
+	var mod = &sysl.Module{
+		Apps: map[string]*sysl.Application{
+			"app1": &app1,
+			"app2": &app2,
+		},
+	}
+
+	mapper := MakeAppMapper(mod)
+	typeIndex := mapper.IndexTypes()
+	mapper.resolveTypes()
+
+	assert.Equal(t, nil, typeIndex["app2:request"])
+	assert.Equal(t, &sysl.Type{}, typeIndex["app1:list"])
+}
+func TestResolveTypes(t *testing.T) {
+	type1 := makeList(makeTypeRef("app1", []string{"login"}, "app2", []string{"request"}))
+	type2 := makePrimitive("string")
+	param1 := makeParam("Login", type1)
+	var app1 = makeApp("app1", []*sysl.Param{param1}, map[string]*sysl.Type{"list": type1})
+	var app2 = makeApp("app2", []*sysl.Param{}, map[string]*sysl.Type{"request": type2})
+	var mod = &sysl.Module{
+		Apps: map[string]*sysl.Application{
+			"app1": &app1,
+			"app2": &app2,
+		},
+	}
+
+	mapper := MakeAppMapper(mod)
+	typeIndex := mapper.IndexTypes()
+	mapper.resolveTypes()
+
+	assert.Equal(t, type2, typeIndex["app2:request"])
+	assert.Equal(t, makeList(makePrimitive("string")), typeIndex["app1:list"])
+}
+
+func TestResolveTypeOneOf(t *testing.T) {
+	type1 := makeOneOf([]*sysl.Type{makeTypeRef("app1", []string{"login"}, "app2", []string{"request"})})
+	type2 := makePrimitive("string")
+	param1 := makeParam("Login", type1)
+	var app1 = makeApp("app1", []*sysl.Param{param1}, map[string]*sysl.Type{})
+	var app2 = makeApp("app2", []*sysl.Param{}, map[string]*sysl.Type{"request": type2})
+	var mod = &sysl.Module{
+		Apps: map[string]*sysl.Application{
+			"app1": &app1,
+			"app2": &app2,
+		},
+	}
+
+	mapper := MakeAppMapper(mod)
+	typeIndex := mapper.IndexTypes()
+
+	syslType := mapper.resolveType(type1)
+	assert.Equal(t, type2, typeIndex["app2"+":"+"request"])
+	assert.Equal(t, makeOneOf([]*sysl.Type{makePrimitive("string")}), type1)
+	assert.Equal(t, makeOneOf([]*sysl.Type{makePrimitive("string")}), syslType)
+}
+
+func TestResolveTypeMap(t *testing.T) {
+	type1 := makeMap(makeTypeRef("app1", []string{"login"}, "app2", []string{"request"}), makePrimitive("string"))
+	type2 := makePrimitive("string")
+	param1 := makeParam("Login", type1)
+	var app1 = makeApp("app1", []*sysl.Param{param1}, map[string]*sysl.Type{})
+	var app2 = makeApp("app2", []*sysl.Param{}, map[string]*sysl.Type{"request": type2})
+	var mod = &sysl.Module{
+		Apps: map[string]*sysl.Application{
+			"app1": &app1,
+			"app2": &app2,
+		},
+	}
+
+	mapper := MakeAppMapper(mod)
+	typeIndex := mapper.IndexTypes()
+
+	syslType := mapper.resolveType(type1)
+	assert.Equal(t, type2, typeIndex["app2:request"])
+	assert.Equal(t, makeMap(makePrimitive("string"), makePrimitive("string")), type1)
+	assert.Equal(t, makeMap(makePrimitive("string"), makePrimitive("string")), syslType)
+}
+func TestResolveTypeList(t *testing.T) {
+	type1 := makeList(makeTypeRef("app1", []string{"login"}, "app2", []string{"request"}))
+	type2 := makePrimitive("string")
+	param1 := makeParam("Login", type1)
+	var app1 = makeApp("app1", []*sysl.Param{param1}, map[string]*sysl.Type{})
+	var app2 = makeApp("app2", []*sysl.Param{}, map[string]*sysl.Type{"request": type2})
+	var mod = &sysl.Module{
+		Apps: map[string]*sysl.Application{
+			"app1": &app1,
+			"app2": &app2,
+		},
+	}
+
+	mapper := MakeAppMapper(mod)
+	typeIndex := mapper.IndexTypes()
+
+	syslType := mapper.resolveType(type1)
+	assert.Equal(t, type2, typeIndex["app2"+"request"])
+	assert.Equal(t, makeList(makePrimitive("string")), type1)
+	assert.Equal(t, makeList(makePrimitive("string")), syslType)
+}
+
+func TestResolveTypeTypeRef(t *testing.T) {
+	type1 := makeTypeRef("app1", []string{"login"}, "app2", []string{"request"})
+	type2 := makePrimitive("string")
+	param1 := makeParam("Login", type1)
+	var app1 = makeApp("app1", []*sysl.Param{param1}, map[string]*sysl.Type{})
+	var app2 = makeApp("app2", []*sysl.Param{}, map[string]*sysl.Type{"request": type2})
+	var mod = &sysl.Module{
+		Apps: map[string]*sysl.Application{
+			"app1": &app1,
+			"app2": &app2,
+		},
+	}
+
+	mapper := MakeAppMapper(mod)
+	typeIndex := mapper.IndexTypes()
+
+	syslType := mapper.resolveType(type1)
+	assert.Equal(t, type2, typeIndex["app2:request"])
+	assert.Equal(t, makePrimitive("string"), syslType)
+}
+
+func TestTypesFromRef(t *testing.T) {
+	type1 := makeTypeRef("app1", []string{"login"}, "app2", []string{"request"})
+	type2 := makePrimitive("string")
+	param1 := makeParam("Login", type1)
+	param2 := makeParam("Auth", makePrimitive("string"))
+	var app1 = makeApp("app1", []*sysl.Param{param1}, map[string]*sysl.Type{})
+	var app2 = makeApp("app2", []*sysl.Param{param2}, map[string]*sysl.Type{"request": type2})
+	var mod = &sysl.Module{
+		Apps: map[string]*sysl.Application{
+			"app1": &app1,
+			"app2": &app2,
+		},
+	}
+
+	mapper := MakeAppMapper(mod)
+	mapper.IndexTypes()
+	syslType, err := mapper.TypeFromRef(mod.Apps["app1"].Endpoints["testEndpoint"].Param[0].Type)
+	if err != nil {
+		t.Error(err)
+	}
+	typeIndex := mapper.IndexTypes()
+	assert.Equal(t, type2, typeIndex["app2:request"])
+	assert.Equal(t, type2, syslType)
+}
+
+func TestTypeConversionPrimative(t *testing.T) {
+	type2 := makePrimitive("string")
+	param2 := makeParam("Auth", makePrimitive("string"))
+	var app2 = makeApp("app2", []*sysl.Param{param2}, map[string]*sysl.Type{"request": type2})
+	var mod = &sysl.Module{
+		Apps: map[string]*sysl.Application{
+			"app2": &app2,
+		},
+	}
+
+	mapper := MakeAppMapper(mod)
+	convertedType1 := mapper.convertTypeToString(type2)
+	assert.Equal(t, &Type{
+		Type: "string",
+	}, convertedType1)
+}
+func TestTypeConversionList(t *testing.T) {
+	type2 := makeList(makePrimitive("string"))
+	param2 := makeParam("Auth", makePrimitive("string"))
+	var app2 = makeApp("app2", []*sysl.Param{param2}, map[string]*sysl.Type{"request": type2})
+	var mod = &sysl.Module{
+		Apps: map[string]*sysl.Application{
+			"app2": &app2,
+		},
+	}
+
+	expectedResult := &Type{
+		Type: "list",
+		Items: []*Type{
+			{
+				Type: "string",
+			},
+		},
+	}
+
+	mapper := MakeAppMapper(mod)
+	convertedType1 := mapper.convertTypeToString(type2)
+	assert.Equal(t, expectedResult, convertedType1)
+}
+
+func TestTypeConversionMap(t *testing.T) {
+	type2 := makeMap(makePrimitive("string"), makePrimitive("string"))
+	param2 := makeParam("Auth", makePrimitive("string"))
+	var app2 = makeApp("app2", []*sysl.Param{param2}, map[string]*sysl.Type{"request": type2})
+	var mod = &sysl.Module{
+		Apps: map[string]*sysl.Application{
+			"app2": &app2,
+		},
+	}
+
+	expectedResult := &Type{
+		Type: "map",
+		Items: []*Type{
+			{
+				Type: "string",
+			}, {
+				Type: "string",
+			},
+		},
+	}
+	mapper := MakeAppMapper(mod)
+	convertedType1 := mapper.convertTypeToString(type2)
+	assert.Equal(t, expectedResult, convertedType1)
+}
+
+func TestTypeConversionEnum(t *testing.T) {
+	enumerate := map[string]int64{
+		"apple":  1,
+		"orange": 2,
+	}
+	mapper := MakeAppMapper(&sysl.Module{})
+	typeToConvert := makeEnum(enumerate)
+	expectedResult := &Type{
+		Type: "enum",
+		Enum: enumerate,
+	}
+	convertedType1 := mapper.convertTypeToString(typeToConvert)
+	assert.Equal(t, expectedResult, convertedType1)
+}
+func TestTypeConversionNoType(t *testing.T) {
+	expectedResult := &Type{
+		Type: "notype",
+	}
+	mapper := MakeAppMapper(&sysl.Module{})
+	convertedType1 := mapper.convertTypeToString(makeNoType())
+	assert.Equal(t, expectedResult, convertedType1)
+}
+
+func TestConvertPrimitive(t *testing.T) {
+	mapper := MakeAppMapper(&sysl.Module{})
+	result := mapper.convertPrimitive("Primitive:STRING Source Context")
+	assert.Equal(t, "string", result)
+}

--- a/pkg/syslwrapper/app_test.go
+++ b/pkg/syslwrapper/app_test.go
@@ -353,18 +353,16 @@ func TestTypeConversionMap(t *testing.T) {
 }
 
 func TestTypeConversionEnum(t *testing.T) {
-	enumerate := map[string]int64{
-		"apple":  1,
-		"orange": 2,
+	enumerate := map[int64]string{
+		1: "apple",
+		2: "orange",
 	}
 	mapper := MakeAppMapper(&sysl.Module{})
 	typeToConvert := MakeEnum(enumerate)
-	expectedResult := &Type{
-		Type: "enum",
-		Enum: enumerate,
-	}
 	convertedType1 := mapper.MapType(typeToConvert)
-	assert.Equal(t, expectedResult, convertedType1)
+	assert.Equal(t, "enum", convertedType1.Type)
+	assert.Equal(t, "apple", convertedType1.Enum[1])
+	assert.Equal(t, "orange", convertedType1.Enum[2])
 }
 func TestTypeConversionNoType(t *testing.T) {
 	expectedResult := &Type{

--- a/pkg/syslwrapper/app_test.go
+++ b/pkg/syslwrapper/app_test.go
@@ -41,8 +41,6 @@ func TestMap(t *testing.T) {
 	mapper.resolveTypes()
 	simpleApps, err := mapper.Map()
 	assert.NoError(t, err)
-	printStr, _ := json.MarshalIndent(simpleApps, "", " ")
-	t.Log(string(printStr))
 	assert.Equal(t, "", simpleApps["Server"].Types["Response"].Properties["balance"].Type)
 	assert.Equal(t, "tuple", simpleApps["Server"].Types["Response"].Properties["query"].Type)
 	assert.Equal(t, "int", simpleApps["Server"].Types["Response"].Properties["query"].Properties["amount"].Type)
@@ -62,8 +60,6 @@ func TestResolveTypesWithSyslFile(t *testing.T) {
 		"balance": MakePrimitive("empty"),
 	})
 
-	printStr, _ := json.MarshalIndent(mapper.Types, "", " ")
-	t.Log(string(printStr))
 	assert.Equal(t, expectedResult.GetAttrs()["query"], typeIndex["Server:Response"].GetAttrs()["query"])
 	assert.Equal(t, expectedResult.GetAttrs()["balance"], typeIndex["Server:Response"].GetAttrs()["balance"])
 }
@@ -85,7 +81,7 @@ func TestMapTypeRef(t *testing.T) {
 
 	mappedType := mapper.MapType(type1)
 	assert.Equal(t, "ref", mappedType.Type)
-	assert.Equal(t, "app2.request", mappedType.Reference)
+	assert.Equal(t, "app2:request", mappedType.Reference)
 }
 func TestResolveNonExistentType(t *testing.T) {
 	type1 := MakeTypeRef("app1", []string{"login"}, "app2", []string{"nonexist"})

--- a/pkg/syslwrapper/app_test.go
+++ b/pkg/syslwrapper/app_test.go
@@ -57,9 +57,9 @@ func TestResolveTypesWithSyslFile(t *testing.T) {
 	typeIndex := mapper.IndexTypes()
 	mapper.resolveTypes()
 
-	expectedResult := makeTuple(map[string]*sysl.Type{
-		"query":   makePrimitive("int"),
-		"balance": makePrimitive("empty"),
+	expectedResult := MakeTuple(map[string]*sysl.Type{
+		"query":   MakePrimitive("int"),
+		"balance": MakePrimitive("empty"),
 	})
 
 	printStr, _ := json.MarshalIndent(mapper.Types, "", " ")
@@ -69,10 +69,10 @@ func TestResolveTypesWithSyslFile(t *testing.T) {
 }
 
 func TestResolveNonExistentType(t *testing.T) {
-	type1 := makeTypeRef("app1", []string{"login"}, "app2", []string{"nonexist"})
-	param1 := makeParam("Login", type1)
-	var app1 = makeApp("app1", []*sysl.Param{param1}, map[string]*sysl.Type{"list": nil})
-	var app2 = makeApp("app2", []*sysl.Param{}, map[string]*sysl.Type{"request": nil})
+	type1 := MakeTypeRef("app1", []string{"login"}, "app2", []string{"nonexist"})
+	param1 := MakeParam("Login", type1)
+	var app1 = MakeApp("app1", []*sysl.Param{param1}, map[string]*sysl.Type{"list": nil})
+	var app2 = MakeApp("app2", []*sysl.Param{}, map[string]*sysl.Type{"request": nil})
 	var mod = &sysl.Module{
 		Apps: map[string]*sysl.Application{
 			"app1": &app1,
@@ -88,9 +88,9 @@ func TestResolveNonExistentType(t *testing.T) {
 	assert.Equal(t, nil, mapper.Types["app1:list"])
 }
 func TestResolveTypesNil(t *testing.T) {
-	type1 := makeTypeRef("app1", []string{"login"}, "app2", []string{"request"})
-	var app1 = makeApp("app1", []*sysl.Param{}, map[string]*sysl.Type{"list": type1})
-	var app2 = makeApp("app2", []*sysl.Param{}, map[string]*sysl.Type{"request": nil})
+	type1 := MakeTypeRef("app1", []string{"login"}, "app2", []string{"request"})
+	var app1 = MakeApp("app1", []*sysl.Param{}, map[string]*sysl.Type{"list": type1})
+	var app2 = MakeApp("app2", []*sysl.Param{}, map[string]*sysl.Type{"request": nil})
 	var mod = &sysl.Module{
 		Apps: map[string]*sysl.Application{
 			"app1": &app1,
@@ -106,11 +106,11 @@ func TestResolveTypesNil(t *testing.T) {
 	assert.Equal(t, &sysl.Type{}, typeIndex["app1:list"])
 }
 func TestResolveTypes(t *testing.T) {
-	type1 := makeList(makeTypeRef("app1", []string{"login"}, "app2", []string{"request"}))
-	type2 := makePrimitive("string")
-	param1 := makeParam("Login", type1)
-	var app1 = makeApp("app1", []*sysl.Param{param1}, map[string]*sysl.Type{"list": type1})
-	var app2 = makeApp("app2", []*sysl.Param{}, map[string]*sysl.Type{"request": type2})
+	type1 := MakeList(MakeTypeRef("app1", []string{"login"}, "app2", []string{"request"}))
+	type2 := MakePrimitive("string")
+	param1 := MakeParam("Login", type1)
+	var app1 = MakeApp("app1", []*sysl.Param{param1}, map[string]*sysl.Type{"list": type1})
+	var app2 = MakeApp("app2", []*sysl.Param{}, map[string]*sysl.Type{"request": type2})
 	var mod = &sysl.Module{
 		Apps: map[string]*sysl.Application{
 			"app1": &app1,
@@ -123,15 +123,15 @@ func TestResolveTypes(t *testing.T) {
 	mapper.resolveTypes()
 
 	assert.Equal(t, type2, typeIndex["app2:request"])
-	assert.Equal(t, makeList(makePrimitive("string")), typeIndex["app1:list"])
+	assert.Equal(t, MakeList(MakePrimitive("string")), typeIndex["app1:list"])
 }
 
 func TestResolveTypeOneOf(t *testing.T) {
-	type1 := makeOneOf([]*sysl.Type{makeTypeRef("app1", []string{"login"}, "app2", []string{"request"})})
-	type2 := makePrimitive("string")
-	param1 := makeParam("Login", type1)
-	var app1 = makeApp("app1", []*sysl.Param{param1}, map[string]*sysl.Type{})
-	var app2 = makeApp("app2", []*sysl.Param{}, map[string]*sysl.Type{"request": type2})
+	type1 := MakeOneOf([]*sysl.Type{MakeTypeRef("app1", []string{"login"}, "app2", []string{"request"})})
+	type2 := MakePrimitive("string")
+	param1 := MakeParam("Login", type1)
+	var app1 = MakeApp("app1", []*sysl.Param{param1}, map[string]*sysl.Type{})
+	var app2 = MakeApp("app2", []*sysl.Param{}, map[string]*sysl.Type{"request": type2})
 	var mod = &sysl.Module{
 		Apps: map[string]*sysl.Application{
 			"app1": &app1,
@@ -144,16 +144,16 @@ func TestResolveTypeOneOf(t *testing.T) {
 
 	syslType := mapper.resolveType(type1)
 	assert.Equal(t, type2, typeIndex["app2"+":"+"request"])
-	assert.Equal(t, makeOneOf([]*sysl.Type{makePrimitive("string")}), type1)
-	assert.Equal(t, makeOneOf([]*sysl.Type{makePrimitive("string")}), syslType)
+	assert.Equal(t, MakeOneOf([]*sysl.Type{MakePrimitive("string")}), type1)
+	assert.Equal(t, MakeOneOf([]*sysl.Type{MakePrimitive("string")}), syslType)
 }
 
 func TestResolveTypeMap(t *testing.T) {
-	type1 := makeMap(makeTypeRef("app1", []string{"login"}, "app2", []string{"request"}), makePrimitive("string"))
-	type2 := makePrimitive("string")
-	param1 := makeParam("Login", type1)
-	var app1 = makeApp("app1", []*sysl.Param{param1}, map[string]*sysl.Type{})
-	var app2 = makeApp("app2", []*sysl.Param{}, map[string]*sysl.Type{"request": type2})
+	type1 := MakeMap(MakeTypeRef("app1", []string{"login"}, "app2", []string{"request"}), MakePrimitive("string"))
+	type2 := MakePrimitive("string")
+	param1 := MakeParam("Login", type1)
+	var app1 = MakeApp("app1", []*sysl.Param{param1}, map[string]*sysl.Type{})
+	var app2 = MakeApp("app2", []*sysl.Param{}, map[string]*sysl.Type{"request": type2})
 	var mod = &sysl.Module{
 		Apps: map[string]*sysl.Application{
 			"app1": &app1,
@@ -166,15 +166,15 @@ func TestResolveTypeMap(t *testing.T) {
 
 	syslType := mapper.resolveType(type1)
 	assert.Equal(t, type2, typeIndex["app2:request"])
-	assert.Equal(t, makeMap(makePrimitive("string"), makePrimitive("string")), type1)
-	assert.Equal(t, makeMap(makePrimitive("string"), makePrimitive("string")), syslType)
+	assert.Equal(t, MakeMap(MakePrimitive("string"), MakePrimitive("string")), type1)
+	assert.Equal(t, MakeMap(MakePrimitive("string"), MakePrimitive("string")), syslType)
 }
 func TestResolveTypeList(t *testing.T) {
-	type1 := makeList(makeTypeRef("app1", []string{"login"}, "app2", []string{"request"}))
-	type2 := makePrimitive("string")
-	param1 := makeParam("Login", type1)
-	var app1 = makeApp("app1", []*sysl.Param{param1}, map[string]*sysl.Type{})
-	var app2 = makeApp("app2", []*sysl.Param{}, map[string]*sysl.Type{"request": type2})
+	type1 := MakeList(MakeTypeRef("app1", []string{"login"}, "app2", []string{"request"}))
+	type2 := MakePrimitive("string")
+	param1 := MakeParam("Login", type1)
+	var app1 = MakeApp("app1", []*sysl.Param{param1}, map[string]*sysl.Type{})
+	var app2 = MakeApp("app2", []*sysl.Param{}, map[string]*sysl.Type{"request": type2})
 	var mod = &sysl.Module{
 		Apps: map[string]*sysl.Application{
 			"app1": &app1,
@@ -187,16 +187,16 @@ func TestResolveTypeList(t *testing.T) {
 
 	syslType := mapper.resolveType(type1)
 	assert.Equal(t, type2, typeIndex["app2"+"request"])
-	assert.Equal(t, makeList(makePrimitive("string")), type1)
-	assert.Equal(t, makeList(makePrimitive("string")), syslType)
+	assert.Equal(t, MakeList(MakePrimitive("string")), type1)
+	assert.Equal(t, MakeList(MakePrimitive("string")), syslType)
 }
 
 func TestResolveTypeTypeRef(t *testing.T) {
-	type1 := makeTypeRef("app1", []string{"login"}, "app2", []string{"request"})
-	type2 := makePrimitive("string")
-	param1 := makeParam("Login", type1)
-	var app1 = makeApp("app1", []*sysl.Param{param1}, map[string]*sysl.Type{})
-	var app2 = makeApp("app2", []*sysl.Param{}, map[string]*sysl.Type{"request": type2})
+	type1 := MakeTypeRef("app1", []string{"login"}, "app2", []string{"request"})
+	type2 := MakePrimitive("string")
+	param1 := MakeParam("Login", type1)
+	var app1 = MakeApp("app1", []*sysl.Param{param1}, map[string]*sysl.Type{})
+	var app2 = MakeApp("app2", []*sysl.Param{}, map[string]*sysl.Type{"request": type2})
 	var mod = &sysl.Module{
 		Apps: map[string]*sysl.Application{
 			"app1": &app1,
@@ -209,16 +209,16 @@ func TestResolveTypeTypeRef(t *testing.T) {
 
 	syslType := mapper.resolveType(type1)
 	assert.Equal(t, type2, typeIndex["app2:request"])
-	assert.Equal(t, makePrimitive("string"), syslType)
+	assert.Equal(t, MakePrimitive("string"), syslType)
 }
 
 func TestTypesFromRef(t *testing.T) {
-	type1 := makeTypeRef("app1", []string{"login"}, "app2", []string{"request"})
-	type2 := makePrimitive("string")
-	param1 := makeParam("Login", type1)
-	param2 := makeParam("Auth", makePrimitive("string"))
-	var app1 = makeApp("app1", []*sysl.Param{param1}, map[string]*sysl.Type{})
-	var app2 = makeApp("app2", []*sysl.Param{param2}, map[string]*sysl.Type{"request": type2})
+	type1 := MakeTypeRef("app1", []string{"login"}, "app2", []string{"request"})
+	type2 := MakePrimitive("string")
+	param1 := MakeParam("Login", type1)
+	param2 := MakeParam("Auth", MakePrimitive("string"))
+	var app1 = MakeApp("app1", []*sysl.Param{param1}, map[string]*sysl.Type{})
+	var app2 = MakeApp("app2", []*sysl.Param{param2}, map[string]*sysl.Type{"request": type2})
 	var mod = &sysl.Module{
 		Apps: map[string]*sysl.Application{
 			"app1": &app1,
@@ -228,7 +228,7 @@ func TestTypesFromRef(t *testing.T) {
 
 	mapper := MakeAppMapper(mod)
 	mapper.IndexTypes()
-	syslType, err := mapper.TypeFromRef(mod.Apps["app1"].Endpoints["testEndpoint"].Param[0].Type)
+	syslType, err := mapper.MapType(mod.Apps["app1"].Endpoints["testEndpoint"].Param[0].Type)
 	if err != nil {
 		t.Error(err)
 	}
@@ -238,9 +238,9 @@ func TestTypesFromRef(t *testing.T) {
 }
 
 func TestTypeConversionPrimative(t *testing.T) {
-	type2 := makePrimitive("string")
-	param2 := makeParam("Auth", makePrimitive("string"))
-	var app2 = makeApp("app2", []*sysl.Param{param2}, map[string]*sysl.Type{"request": type2})
+	type2 := MakePrimitive("string")
+	param2 := MakeParam("Auth", MakePrimitive("string"))
+	var app2 = MakeApp("app2", []*sysl.Param{param2}, map[string]*sysl.Type{"request": type2})
 	var mod = &sysl.Module{
 		Apps: map[string]*sysl.Application{
 			"app2": &app2,
@@ -254,9 +254,9 @@ func TestTypeConversionPrimative(t *testing.T) {
 	}, convertedType1)
 }
 func TestTypeConversionList(t *testing.T) {
-	type2 := makeList(makePrimitive("string"))
-	param2 := makeParam("Auth", makePrimitive("string"))
-	var app2 = makeApp("app2", []*sysl.Param{param2}, map[string]*sysl.Type{"request": type2})
+	type2 := MakeList(MakePrimitive("string"))
+	param2 := MakeParam("Auth", MakePrimitive("string"))
+	var app2 = MakeApp("app2", []*sysl.Param{param2}, map[string]*sysl.Type{"request": type2})
 	var mod = &sysl.Module{
 		Apps: map[string]*sysl.Application{
 			"app2": &app2,
@@ -278,9 +278,9 @@ func TestTypeConversionList(t *testing.T) {
 }
 
 func TestTypeConversionMap(t *testing.T) {
-	type2 := makeMap(makePrimitive("string"), makePrimitive("string"))
-	param2 := makeParam("Auth", makePrimitive("string"))
-	var app2 = makeApp("app2", []*sysl.Param{param2}, map[string]*sysl.Type{"request": type2})
+	type2 := MakeMap(MakePrimitive("string"), MakePrimitive("string"))
+	param2 := MakeParam("Auth", MakePrimitive("string"))
+	var app2 = MakeApp("app2", []*sysl.Param{param2}, map[string]*sysl.Type{"request": type2})
 	var mod = &sysl.Module{
 		Apps: map[string]*sysl.Application{
 			"app2": &app2,
@@ -308,7 +308,7 @@ func TestTypeConversionEnum(t *testing.T) {
 		"orange": 2,
 	}
 	mapper := MakeAppMapper(&sysl.Module{})
-	typeToConvert := makeEnum(enumerate)
+	typeToConvert := MakeEnum(enumerate)
 	expectedResult := &Type{
 		Type: "enum",
 		Enum: enumerate,
@@ -321,7 +321,7 @@ func TestTypeConversionNoType(t *testing.T) {
 		Type: "notype",
 	}
 	mapper := MakeAppMapper(&sysl.Module{})
-	convertedType1 := mapper.convertTypeToString(makeNoType())
+	convertedType1 := mapper.convertTypeToString(MakeNoType())
 	assert.Equal(t, expectedResult, convertedType1)
 }
 

--- a/pkg/syslwrapper/test_helper.go
+++ b/pkg/syslwrapper/test_helper.go
@@ -1,4 +1,4 @@
-package syslutil
+package syslwrapper
 
 import (
 	"strings"

--- a/pkg/syslwrapper/test_helper.go
+++ b/pkg/syslwrapper/test_helper.go
@@ -1,0 +1,259 @@
+package syslutil
+
+import (
+	"strings"
+
+	"github.com/anz-bank/sysl/pkg/sysl"
+)
+
+func makeAppName(name string) *sysl.AppName {
+	return &sysl.AppName{
+		Part: strings.Split(name, " "),
+	}
+}
+
+// Creates a type reference from one context to another.
+// contextApp is the name of the app where the typeref is used
+// refApp is the app where the
+func makeTypeRef(contextApp string, contextTypePath []string, refApp string, refTypePath []string) *sysl.Type {
+	return &sysl.Type{
+		Type: &sysl.Type_TypeRef{
+			TypeRef: &sysl.ScopedRef{
+				Context: &sysl.Scope{
+					Appname: makeAppName(contextApp),
+					Path:    contextTypePath,
+				},
+				Ref: &sysl.Scope{
+					Appname: makeAppName(refApp),
+					Path:    refTypePath,
+				},
+			},
+		},
+	}
+}
+
+func makePrimitive(primType string) *sysl.Type {
+	var resolvedType *sysl.Type
+	switch primType {
+	case "noprimitive":
+		resolvedType = &sysl.Type{
+			Type: &sysl.Type_Primitive_{
+				Primitive: sysl.Type_NO_Primitive,
+			},
+		}
+	case "empty":
+		resolvedType = &sysl.Type{
+			Type: &sysl.Type_Primitive_{
+				Primitive: sysl.Type_EMPTY,
+			},
+		}
+	case "any":
+		resolvedType = &sysl.Type{
+			Type: &sysl.Type_Primitive_{
+				Primitive: sysl.Type_ANY,
+			},
+		}
+	case "bool":
+		resolvedType = &sysl.Type{
+			Type: &sysl.Type_Primitive_{
+				Primitive: sysl.Type_BOOL,
+			},
+		}
+	case "int":
+		resolvedType = &sysl.Type{
+			Type: &sysl.Type_Primitive_{
+				Primitive: sysl.Type_INT,
+			},
+		}
+	case "float":
+		resolvedType = &sysl.Type{
+			Type: &sysl.Type_Primitive_{
+				Primitive: sysl.Type_FLOAT,
+			},
+		}
+	case "decimal":
+		resolvedType = &sysl.Type{
+			Type: &sysl.Type_Primitive_{
+				Primitive: sysl.Type_DECIMAL,
+			},
+		}
+	case "string":
+		resolvedType = &sysl.Type{
+			Type: &sysl.Type_Primitive_{
+				Primitive: sysl.Type_STRING,
+			},
+		}
+	case "bytes":
+		resolvedType = &sysl.Type{
+			Type: &sysl.Type_Primitive_{
+				Primitive: sysl.Type_BYTES,
+			},
+		}
+	case "string8":
+		resolvedType = &sysl.Type{
+			Type: &sysl.Type_Primitive_{
+				Primitive: sysl.Type_STRING_8,
+			},
+		}
+	case "date":
+		resolvedType = &sysl.Type{
+			Type: &sysl.Type_Primitive_{
+				Primitive: sysl.Type_DATE,
+			},
+		}
+	case "datetime":
+		resolvedType = &sysl.Type{
+			Type: &sysl.Type_Primitive_{
+				Primitive: sysl.Type_DATETIME,
+			},
+		}
+	case "xml":
+		resolvedType = &sysl.Type{
+			Type: &sysl.Type_Primitive_{
+				Primitive: sysl.Type_XML,
+			},
+		}
+	case "uuid":
+		resolvedType = &sysl.Type{
+			Type: &sysl.Type_Primitive_{
+				Primitive: sysl.Type_UUID,
+			},
+		}
+	}
+	return resolvedType
+}
+
+func makeEnum(enum map[string]int64) *sysl.Type {
+	return &sysl.Type{
+		Type: &sysl.Type_Enum_{
+			Enum: &sysl.Type_Enum{
+				Items: enum,
+			},
+		},
+	}
+}
+
+func makeTuple(tuple map[string]*sysl.Type) *sysl.Type {
+	return &sysl.Type{
+		Type: &sysl.Type_Tuple_{
+			Tuple: &sysl.Type_Tuple{
+				AttrDefs: tuple,
+			},
+		},
+	}
+}
+
+func makeList(listType *sysl.Type) *sysl.Type {
+	return &sysl.Type{
+		Type: &sysl.Type_List_{
+			List: &sysl.Type_List{
+				Type: listType,
+			},
+		},
+	}
+}
+
+func makeMap(keyType *sysl.Type, valueType *sysl.Type) *sysl.Type {
+	return &sysl.Type{
+		Type: &sysl.Type_Map_{
+			Map: &sysl.Type_Map{
+				Key:   keyType,
+				Value: valueType,
+			},
+		},
+	}
+}
+
+func makeOneOf(oneOfType []*sysl.Type) *sysl.Type {
+	return &sysl.Type{
+		Type: &sysl.Type_OneOf_{
+			OneOf: &sysl.Type_OneOf{
+				Type: oneOfType,
+			},
+		},
+	}
+}
+
+//TODO Relatino, set, sequence, notype
+// This is complext. TODO
+func makeRelation(oneOfType []*sysl.Type) *sysl.Type {
+	return &sysl.Type{
+		Type: &sysl.Type_Relation_{
+			Relation: &sysl.Type_Relation{},
+		},
+	}
+}
+
+func makeSet(oneOfType []*sysl.Type) *sysl.Type {
+	return &sysl.Type{
+		Type: &sysl.Type_OneOf_{
+			OneOf: &sysl.Type_OneOf{
+				Type: oneOfType,
+			},
+		},
+	}
+}
+
+func makeNoType() *sysl.Type {
+	return &sysl.Type{
+		Type: &sysl.Type_NoType_{
+			NoType: &sysl.Type_NoType{},
+		},
+	}
+}
+
+func makeType(name string, value interface{}, t string) *sysl.Type {
+	var resolvedType *sysl.Type
+
+	switch t {
+	case "relation":
+		resolvedType = &sysl.Type{
+			Type: &sysl.Type_Relation_{
+				Relation: &sysl.Type_Relation{},
+			},
+		}
+	case "set":
+		resolvedType = &sysl.Type{
+			Type: &sysl.Type_Set{
+				Set: makeType("app", "", "int"),
+			},
+		}
+	case "sequence":
+		resolvedType = &sysl.Type{
+			Type: &sysl.Type_Sequence{
+				Sequence: makeType("app", "", "int"),
+			},
+		}
+	case "notype":
+		resolvedType = &sysl.Type{
+			Type: &sysl.Type_NoType_{
+				NoType: &sysl.Type_NoType{},
+			},
+		}
+	}
+	return resolvedType
+}
+
+func makeParam(name string, paramType *sysl.Type) *sysl.Param {
+	var param = sysl.Param{
+		Name: name,
+		Type: paramType,
+	}
+	return &param
+}
+
+func makeApp(name string, params []*sysl.Param, types map[string]*sysl.Type) sysl.Application {
+	var appName = makeAppName(name)
+
+	var ep = sysl.Endpoint{
+		Param: params,
+	}
+	var endpoints = map[string]*sysl.Endpoint{"testEndpoint": &ep}
+	var app = sysl.Application{
+		Name:      appName,
+		LongName:  name,
+		Endpoints: endpoints,
+		Types:     types,
+	}
+	return app
+}

--- a/pkg/syslwrapper/test_helper.go
+++ b/pkg/syslwrapper/test_helper.go
@@ -237,6 +237,16 @@ func MakeType(name string, value interface{}, t string) *sysl.Type {
 	return resolvedType
 }
 
+func MakeReturnStatement(payload string) *sysl.Statement {
+	return &sysl.Statement{
+		Stmt: &sysl.Statement_Ret{
+			Ret: &sysl.Return{
+				Payload: payload,
+			},
+		},
+	}
+}
+
 func MakeParam(name string, paramType *sysl.Type) *sysl.Param {
 	var param = sysl.Param{
 		Name: name,

--- a/pkg/syslwrapper/test_helper.go
+++ b/pkg/syslwrapper/test_helper.go
@@ -6,7 +6,7 @@ import (
 	"github.com/anz-bank/sysl/pkg/sysl"
 )
 
-func makeAppName(name string) *sysl.AppName {
+func MakeAppName(name string) *sysl.AppName {
 	return &sysl.AppName{
 		Part: strings.Split(name, " "),
 	}
@@ -15,16 +15,16 @@ func makeAppName(name string) *sysl.AppName {
 // Creates a type reference from one context to another.
 // contextApp is the name of the app where the typeref is used
 // refApp is the app where the
-func makeTypeRef(contextApp string, contextTypePath []string, refApp string, refTypePath []string) *sysl.Type {
+func MakeTypeRef(contextApp string, contextTypePath []string, refApp string, refTypePath []string) *sysl.Type {
 	return &sysl.Type{
 		Type: &sysl.Type_TypeRef{
 			TypeRef: &sysl.ScopedRef{
 				Context: &sysl.Scope{
-					Appname: makeAppName(contextApp),
+					Appname: MakeAppName(contextApp),
 					Path:    contextTypePath,
 				},
 				Ref: &sysl.Scope{
-					Appname: makeAppName(refApp),
+					Appname: MakeAppName(refApp),
 					Path:    refTypePath,
 				},
 			},
@@ -32,7 +32,7 @@ func makeTypeRef(contextApp string, contextTypePath []string, refApp string, ref
 	}
 }
 
-func makePrimitive(primType string) *sysl.Type {
+func MakePrimitive(primType string) *sysl.Type {
 	var resolvedType *sysl.Type
 	switch primType {
 	case "noprimitive":
@@ -123,7 +123,7 @@ func makePrimitive(primType string) *sysl.Type {
 	return resolvedType
 }
 
-func makeEnum(enum map[string]int64) *sysl.Type {
+func MakeEnum(enum map[string]int64) *sysl.Type {
 	return &sysl.Type{
 		Type: &sysl.Type_Enum_{
 			Enum: &sysl.Type_Enum{
@@ -133,7 +133,7 @@ func makeEnum(enum map[string]int64) *sysl.Type {
 	}
 }
 
-func makeTuple(tuple map[string]*sysl.Type) *sysl.Type {
+func MakeTuple(tuple map[string]*sysl.Type) *sysl.Type {
 	return &sysl.Type{
 		Type: &sysl.Type_Tuple_{
 			Tuple: &sysl.Type_Tuple{
@@ -143,7 +143,7 @@ func makeTuple(tuple map[string]*sysl.Type) *sysl.Type {
 	}
 }
 
-func makeList(listType *sysl.Type) *sysl.Type {
+func MakeList(listType *sysl.Type) *sysl.Type {
 	return &sysl.Type{
 		Type: &sysl.Type_List_{
 			List: &sysl.Type_List{
@@ -153,7 +153,7 @@ func makeList(listType *sysl.Type) *sysl.Type {
 	}
 }
 
-func makeMap(keyType *sysl.Type, valueType *sysl.Type) *sysl.Type {
+func MakeMap(keyType *sysl.Type, valueType *sysl.Type) *sysl.Type {
 	return &sysl.Type{
 		Type: &sysl.Type_Map_{
 			Map: &sysl.Type_Map{
@@ -164,7 +164,7 @@ func makeMap(keyType *sysl.Type, valueType *sysl.Type) *sysl.Type {
 	}
 }
 
-func makeOneOf(oneOfType []*sysl.Type) *sysl.Type {
+func MakeOneOf(oneOfType []*sysl.Type) *sysl.Type {
 	return &sysl.Type{
 		Type: &sysl.Type_OneOf_{
 			OneOf: &sysl.Type_OneOf{
@@ -176,7 +176,7 @@ func makeOneOf(oneOfType []*sysl.Type) *sysl.Type {
 
 //TODO Relatino, set, sequence, notype
 // This is complext. TODO
-func makeRelation(oneOfType []*sysl.Type) *sysl.Type {
+func MakeRelation(oneOfType []*sysl.Type) *sysl.Type {
 	return &sysl.Type{
 		Type: &sysl.Type_Relation_{
 			Relation: &sysl.Type_Relation{},
@@ -184,7 +184,7 @@ func makeRelation(oneOfType []*sysl.Type) *sysl.Type {
 	}
 }
 
-func makeSet(oneOfType []*sysl.Type) *sysl.Type {
+func MakeSet(oneOfType []*sysl.Type) *sysl.Type {
 	return &sysl.Type{
 		Type: &sysl.Type_OneOf_{
 			OneOf: &sysl.Type_OneOf{
@@ -194,7 +194,7 @@ func makeSet(oneOfType []*sysl.Type) *sysl.Type {
 	}
 }
 
-func makeNoType() *sysl.Type {
+func MakeNoType() *sysl.Type {
 	return &sysl.Type{
 		Type: &sysl.Type_NoType_{
 			NoType: &sysl.Type_NoType{},
@@ -202,7 +202,7 @@ func makeNoType() *sysl.Type {
 	}
 }
 
-func makeType(name string, value interface{}, t string) *sysl.Type {
+func MakeType(name string, value interface{}, t string) *sysl.Type {
 	var resolvedType *sysl.Type
 
 	switch t {
@@ -215,13 +215,13 @@ func makeType(name string, value interface{}, t string) *sysl.Type {
 	case "set":
 		resolvedType = &sysl.Type{
 			Type: &sysl.Type_Set{
-				Set: makeType("app", "", "int"),
+				Set: MakeType("app", "", "int"),
 			},
 		}
 	case "sequence":
 		resolvedType = &sysl.Type{
 			Type: &sysl.Type_Sequence{
-				Sequence: makeType("app", "", "int"),
+				Sequence: MakeType("app", "", "int"),
 			},
 		}
 	case "notype":
@@ -234,7 +234,7 @@ func makeType(name string, value interface{}, t string) *sysl.Type {
 	return resolvedType
 }
 
-func makeParam(name string, paramType *sysl.Type) *sysl.Param {
+func MakeParam(name string, paramType *sysl.Type) *sysl.Param {
 	var param = sysl.Param{
 		Name: name,
 		Type: paramType,
@@ -242,8 +242,8 @@ func makeParam(name string, paramType *sysl.Type) *sysl.Param {
 	return &param
 }
 
-func makeApp(name string, params []*sysl.Param, types map[string]*sysl.Type) sysl.Application {
-	var appName = makeAppName(name)
+func MakeApp(name string, params []*sysl.Param, types map[string]*sysl.Type) sysl.Application {
+	var appName = MakeAppName(name)
 
 	var ep = sysl.Endpoint{
 		Param: params,

--- a/pkg/syslwrapper/test_helper.go
+++ b/pkg/syslwrapper/test_helper.go
@@ -123,11 +123,15 @@ func MakePrimitive(primType string) *sysl.Type {
 	return resolvedType
 }
 
-func MakeEnum(enum map[string]int64) *sysl.Type {
+func MakeEnum(enum map[int64]string) *sysl.Type {
+	swappedEnum := make(map[string]int64)
+	for index, str := range enum {
+		swappedEnum[str] = index
+	}
 	return &sysl.Type{
 		Type: &sysl.Type_Enum_{
 			Enum: &sysl.Type_Enum{
-				Items: enum,
+				Items: swappedEnum,
 			},
 		},
 	}

--- a/pkg/syslwrapper/test_helper.go
+++ b/pkg/syslwrapper/test_helper.go
@@ -174,25 +174,24 @@ func MakeOneOf(oneOfType []*sysl.Type) *sysl.Type {
 	}
 }
 
-//TODO Relatino, set, sequence, notype
-// This is complext. TODO
-func MakeRelation(oneOfType []*sysl.Type) *sysl.Type {
-	return &sysl.Type{
-		Type: &sysl.Type_Relation_{
-			Relation: &sysl.Type_Relation{},
-		},
-	}
-}
+//TODO relation, set, sequence, notype
+// func MakeRelation(oneOfType []*sysl.Type) *sysl.Type {
+// 	return &sysl.Type{
+// 		Type: &sysl.Type_Relation_{
+// 			Relation: &sysl.Type_Relation{},
+// 		},
+// 	}
+// }
 
-func MakeSet(oneOfType []*sysl.Type) *sysl.Type {
-	return &sysl.Type{
-		Type: &sysl.Type_OneOf_{
-			OneOf: &sysl.Type_OneOf{
-				Type: oneOfType,
-			},
-		},
-	}
-}
+// func MakeSet(oneOfType []*sysl.Type) *sysl.Type {
+// 	return &sysl.Type{
+// 		Type: &sysl.Type_OneOf_{
+// 			OneOf: &sysl.Type_OneOf{
+// 				Type: oneOfType,
+// 			},
+// 		},
+// 	}
+// }
 
 func MakeNoType() *sysl.Type {
 	return &sysl.Type{

--- a/pkg/syslwrapper/tests/rest.sysl
+++ b/pkg/syslwrapper/tests/rest.sysl
@@ -1,0 +1,15 @@
+SampleRestApp:
+    # To specify a rest endpoint use / to let sysl know that you're using rest
+    /login/{CustomerID<:string}:
+            # Now use rest methods with the endpoint
+            POST (newPost <: string [~body]):
+                return string
+
+    /post:
+        # Now use rest methods with the endpoint
+        POST (newPost <: string [~body]):
+            return string
+
+        GET (newPost <: string) ?PostId=string:
+            return string
+

--- a/pkg/syslwrapper/tests/rest.sysl
+++ b/pkg/syslwrapper/tests/rest.sysl
@@ -7,7 +7,7 @@ SampleRestApp:
 
     /post:
         # Now use rest methods with the endpoint
-        POST (PostID <: PostID [~body]):
+        POST (PostID <: SampleRestApp.PostID [~body]):
             return Post
 
         GET (limit <: int) ?PostId=string:

--- a/pkg/syslwrapper/tests/rest.sysl
+++ b/pkg/syslwrapper/tests/rest.sysl
@@ -7,9 +7,18 @@ SampleRestApp:
 
     /post:
         # Now use rest methods with the endpoint
-        POST (newPost <: string [~body]):
-            return string
+        POST (PostID <: PostID [~body]):
+            return Post
 
-        GET (newPost <: string) ?PostId=string:
+        GET (limit <: int) ?PostId=string:
             return string
+    
+    
+    !type Post:
+        description <: string
+        content <: string
+
+    !type PostID:
+        id <: int
+    
 

--- a/pkg/syslwrapper/tests/types.sysl
+++ b/pkg/syslwrapper/tests/types.sysl
@@ -1,0 +1,27 @@
+MobileApp:
+    @package = "ApplicationPackage"
+    Login(input <: Server.Request):
+        Server <- Authenticate
+        return ok <: Server.Response
+
+Server:
+    @package = "ServerPackage"
+    !type Response:
+        query <: MegaDatabase.Money
+        balance <: MegaDatabase.Empty
+    !type Request:
+        query <: string
+
+    Authenticate(input <: Server.Request):
+        return ok <: Server.Response
+
+# This is an example of apps with types made up of different apps
+MegaDatabase:
+    # This was meant to be an example of how different applications can be in the same package
+    @package = "ServerPackage"
+    !type Empty[~empty]:
+        ...
+    !type Money:
+        amount <: int
+    !type AnotherEmpty:
+        ...


### PR DESCRIPTION
This PR adds a syslwrapper package which abstracts some of the complex details of the sysl.App data type.

This is used by an openapi3 exporter PR which will be coming up.

It's not a complete implementation yet, and still needs some more work, which will be coming in future PRs.


Changes proposed in this pull request:
- [x] Add wrapper type for sysl.Application
- [x] Implement type resolution

To be done in future PRs
Fix https://github.com/anz-bank/sysl/issues/786.
- [ ] Add dependency info 
- [ ] Consolidate helper functions for creating sysl applications
- [ ] Create test util for inline Sysl
- [ ] Tidy util functions

Checklist:
- [x] Added related tests
- [x] Made corresponding changes to the documentation
