### PR TITLE
Fix #805, update pkg/importer/openapi2conv to work with kin-openapi v0.5.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,7 @@ require (
 	github.com/dlclark/regexp2 v1.2.0 // indirect
 	github.com/fullstorydev/grpcui v0.2.1
 	github.com/fullstorydev/grpcurl v1.5.0
-	github.com/getkin/kin-openapi v0.3.0
+	github.com/getkin/kin-openapi v0.5.1
 	github.com/ghodss/yaml v1.0.0
 	github.com/go-chi/chi v4.0.4+incompatible
 	github.com/go-openapi/errors v0.19.4 // indirect

--- a/go.sum
+++ b/go.sum
@@ -114,6 +114,8 @@ github.com/fullstorydev/grpcurl v1.5.0 h1:IfN08voSku7YD7N28Kpcw5fZWq9ahQopEzTpWU
 github.com/fullstorydev/grpcurl v1.5.0/go.mod h1:fBzJMv8zhFPeNhr4OAc/97pYPQfvGDsEdNB36oNsnbs=
 github.com/getkin/kin-openapi v0.3.0 h1:xsQ4mA20YJDMgIHdHqMKZ66QUe6/hi+x6yLsTTz8xyQ=
 github.com/getkin/kin-openapi v0.3.0/go.mod h1:W8dhxZgpE84ciM+VIItFqkmZ4eHtuomrdIHtASQIqi0=
+github.com/getkin/kin-openapi v0.5.1 h1:eTe5fqly4FQTjSSMLekYckymPJHEJ4unOvY8c2hSYr4=
+github.com/getkin/kin-openapi v0.5.1/go.mod h1:zZQMFkVgRHCdhgb6ihCTIo9dyDZFvX0k/xAKqw1FhPw=
 github.com/ghodss/yaml v1.0.0 h1:wQHKEahhL6wmXdzwWG11gIVCkOv05bNOh+Rxn0yngAk=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/globalsign/mgo v0.0.0-20180905125535-1ca0a4f7cbcb/go.mod h1:xkRDCp4j0OGD1HRkm4kmhM+pmpv3AKq5SU7GMg4oO/Q=

--- a/go.sum
+++ b/go.sum
@@ -112,8 +112,6 @@ github.com/fullstorydev/grpcui v0.2.1/go.mod h1:GmjekePsrhFLIB6j2t3ih4u/88Q8IU6J
 github.com/fullstorydev/grpcurl v1.3.2/go.mod h1:kvk8xPCXOrwVd9zYdjy+xSOT4YWm6kyth4Y9NMfBns4=
 github.com/fullstorydev/grpcurl v1.5.0 h1:IfN08voSku7YD7N28Kpcw5fZWq9ahQopEzTpWUqmXW8=
 github.com/fullstorydev/grpcurl v1.5.0/go.mod h1:fBzJMv8zhFPeNhr4OAc/97pYPQfvGDsEdNB36oNsnbs=
-github.com/getkin/kin-openapi v0.3.0 h1:xsQ4mA20YJDMgIHdHqMKZ66QUe6/hi+x6yLsTTz8xyQ=
-github.com/getkin/kin-openapi v0.3.0/go.mod h1:W8dhxZgpE84ciM+VIItFqkmZ4eHtuomrdIHtASQIqi0=
 github.com/getkin/kin-openapi v0.5.1 h1:eTe5fqly4FQTjSSMLekYckymPJHEJ4unOvY8c2hSYr4=
 github.com/getkin/kin-openapi v0.5.1/go.mod h1:zZQMFkVgRHCdhgb6ihCTIo9dyDZFvX0k/xAKqw1FhPw=
 github.com/ghodss/yaml v1.0.0 h1:wQHKEahhL6wmXdzwWG11gIVCkOv05bNOh+Rxn0yngAk=

--- a/pkg/importer/openapi2conv/openapi2_conv.go
+++ b/pkg/importer/openapi2conv/openapi2_conv.go
@@ -252,7 +252,7 @@ func ToV3Response(response *openapi2.Response) (*openapi3.ResponseRef, error) {
 		}, nil
 	}
 	result := &openapi3.Response{
-		Description: response.Description,
+		Description: &response.Description,
 	}
 	if schemaRef := response.Schema; schemaRef != nil {
 		result.WithJSONSchemaRef(ToV3SchemaRef(schemaRef))
@@ -628,7 +628,7 @@ func FromV3Response(ref *openapi3.ResponseRef) (*openapi2.Response, error) {
 		return nil, nil
 	}
 	result := &openapi2.Response{
-		Description: response.Description,
+		Description: *response.Description,
 	}
 	if content := response.Content; content != nil {
 		if ct := content["application/json"]; ct != nil {


### PR DESCRIPTION
Fixes #805 .

Changes proposed in this pull request:
- Updated the current pkg/import/openapi2conv to work with the newest kin-openapi (currently v0.5.1).
 
