### PR TITLE
Fix make failure linux

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -174,7 +174,10 @@ jobs:
 
   build-examples:
     name: Build Examples
-    runs-on: macos-latest
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macOS-latest]
+    runs-on: ${{ matrix.os }}
     steps:
       - name: Set up Go 1.13
         uses: actions/setup-go@v1

--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ all: test lint build buildlsp coverage examples ## test, lint, build, coverage t
 TUTORIALS: $(wildcard ./demo/examples/*) $(wildcard ./demo/examples/*/*)
 
 examples: TUTORIALS
-	cd demo/examples/ && go run generate_website.go && cd ../../ && test -z "$$(git status --porcelain)"
+	cd demo/examples/ && go run generate_website.go && cd ../../  && git --no-pager diff HEAD && test -z "$$(git status --porcelain)"
 
 .PHONY: all install grammar antlr build lint test coverage clean check-tidy
 lint: ## Run golangci-lint
@@ -36,7 +36,7 @@ coverage: ## Run tests and verify the test coverage remains high
 	./scripts/test-with-coverage.sh 80
 
 check-tidy: ## Check go.mod and go.sum is tidy
-	go mod tidy && test -z "$$(git status --porcelain)"
+	go mod tidy && git --no-pager diff HEAD && test -z "$$(git status --porcelain)"
 
 test: ## Run tests without coverage
 	$(TESTEXE)

--- a/demo/examples/Code-Generation/ordering.yaml
+++ b/demo/examples/Code-Generation/ordering.yaml
@@ -1,6 +1,6 @@
 # This file specifies the order that the documentation is rendered in
 Code Generation:
-  - intro.md
+  - Intro.md
   - api/sysl/simple.sysl
   - generate.sh
   - internal/server/server.go

--- a/demo/examples/generate_website.go
+++ b/demo/examples/generate_website.go
@@ -288,18 +288,18 @@ func parseExamples() []*Example {
 				example.GitRepoURL = fmt.Sprintf("%s/%s", gitRepoExample, exampleName)
 				fmt.Println(example.GitRepoURL)
 				var sourcePaths []string
-				subOrderingFileName := path.Join(exampleID, orderingfile)
+				subOrderingFileName := path.Join(exampleName, orderingfile)
 
 				if _, err := os.Stat(subOrderingFileName); err == nil {
 					subOrdering := unmarshalYaml(subOrderingFileName)
 					fmt.Println()
 
 					for _, x := range subOrdering[0][topic] {
-						sourcePaths = append(sourcePaths, path.Join(exampleID, x))
+						sourcePaths = append(sourcePaths, path.Join(exampleName, x))
 					}
 
 				} else {
-					sourcePaths = mustGlob(exampleID + "/*")
+					sourcePaths = mustGlob(exampleName + "/*")
 
 				}
 				for _, sourcePath := range sourcePaths {
@@ -372,6 +372,7 @@ func isImageFile(filename string) (bool, string) {
 }
 
 func syslplaygroundLink(code, cmd string) string {
+	fmt.Println(code)
 	code = encode(code)
 	cmd = encode(cmd)
 	return fmt.Sprintf(syslPlaygroundURL+"?input=%s&cmd=%s", code, cmd)


### PR DESCRIPTION
Fixes an issue with the make file creating large diffs when run on linux.

Changes proposed in this pull request:
- Update CI for `make examples` to run on linux and macos
- Update generate_website.go

Checklist:
- [x] Added related tests
- [x] Made corresponding changes to the documentation
