### PR TITLE
Fixes an issue with set and table support in syslwrapper

### DIFF
--- a/pkg/syslwrapper/app.go
+++ b/pkg/syslwrapper/app.go
@@ -96,7 +96,9 @@ func (am *AppMapper) IndexTypes() map[string]*sysl.Type {
 func (am *AppMapper) ConvertTypes() map[string]*Type {
 	simpleTypes := make(map[string]*Type)
 	for typeName, syslType := range am.Types {
-		simpleTypes[typeName] = am.MapType(syslType)
+		if am.MapType(syslType) != nil {
+			simpleTypes[typeName] = am.MapType(syslType)
+		}
 	}
 	am.SimpleTypes = simpleTypes
 	return simpleTypes
@@ -121,7 +123,9 @@ func (am *AppMapper) mapAttributes(attributes map[string]*sysl.Attribute) map[st
 func (am *AppMapper) mapTypes(appName string, syslTypes map[string]*sysl.Type) map[string]*Type {
 	simpleTypes := make(map[string]*Type, 15)
 	for typeName := range syslTypes {
-		simpleTypes[typeName] = am.MapType(am.Types[appName+":"+typeName])
+		if am.MapType(am.Types[appName+":"+typeName]) != nil {
+			simpleTypes[typeName] = am.MapType(am.Types[appName+":"+typeName])
+		}
 	}
 	return simpleTypes
 }
@@ -408,7 +412,7 @@ func (am *AppMapper) MapType(t *sysl.Type) *Type {
 	var ref string
 
 	if t == nil {
-		return &Type{}
+		return nil
 	}
 
 	switch t.Type.(type) {
@@ -443,6 +447,12 @@ func (am *AppMapper) MapType(t *sysl.Type) *Type {
 		simpleType = "tuple"
 		properties = make(map[string]*Type, 15)
 		for k, v := range t.GetTuple().AttrDefs {
+			properties[k] = am.MapType(v)
+		}
+	case *sysl.Type_Relation_:
+		simpleType = "relation"
+		properties = make(map[string]*Type, 15)
+		for k, v := range t.GetRelation().AttrDefs {
 			properties[k] = am.MapType(v)
 		}
 	default:

--- a/pkg/syslwrapper/app.go
+++ b/pkg/syslwrapper/app.go
@@ -96,8 +96,8 @@ func (am *AppMapper) IndexTypes() map[string]*sysl.Type {
 func (am *AppMapper) ConvertTypes() map[string]*Type {
 	simpleTypes := make(map[string]*Type)
 	for typeName, syslType := range am.Types {
-		if am.MapType(syslType) != nil {
-			simpleTypes[typeName] = am.MapType(syslType)
+		if simpleType := am.MapType(syslType); simpleType != nil {
+			simpleTypes[typeName] = simpleType
 		}
 	}
 	am.SimpleTypes = simpleTypes
@@ -123,8 +123,8 @@ func (am *AppMapper) mapAttributes(attributes map[string]*sysl.Attribute) map[st
 func (am *AppMapper) mapTypes(appName string, syslTypes map[string]*sysl.Type) map[string]*Type {
 	simpleTypes := make(map[string]*Type, 15)
 	for typeName := range syslTypes {
-		if am.MapType(am.Types[appName+":"+typeName]) != nil {
-			simpleTypes[typeName] = am.MapType(am.Types[appName+":"+typeName])
+		if simpleTypeFromLookup := am.MapType(am.Types[appName+":"+typeName]); simpleTypeFromLookup != nil {
+			simpleTypes[typeName] = simpleTypeFromLookup
 		}
 	}
 	return simpleTypes

--- a/pkg/syslwrapper/app_test.go
+++ b/pkg/syslwrapper/app_test.go
@@ -241,6 +241,29 @@ func TestTypeConversionPrimative(t *testing.T) {
 		Type: "string",
 	}, convertedType1)
 }
+
+func TestTypeConversionSet(t *testing.T) {
+	type2 := MakeSet(MakePrimitive("string"))
+	var app2 = MakeApp("app2", []*sysl.Param{}, map[string]*sysl.Type{"request": type2})
+	var mod = &sysl.Module{
+		Apps: map[string]*sysl.Application{
+			"app2": &app2,
+		},
+	}
+
+	expectedResult := &Type{
+		Type: "set",
+		Items: []*Type{
+			{
+				Type: "string",
+			},
+		},
+	}
+
+	mapper := MakeAppMapper(mod)
+	convertedType1 := mapper.MapType(type2)
+	assert.Equal(t, expectedResult, convertedType1)
+}
 func TestTypeConversionList(t *testing.T) {
 	type2 := MakeList(MakePrimitive("string"))
 	param2 := MakeParam("Auth", MakePrimitive("string"))
@@ -279,6 +302,7 @@ func TestMapReturnStatements(t *testing.T) {
 	statements := []*sysl.Statement{
 		MakeReturnStatement("string"),
 		MakeReturnStatement("default <: string"),
+		MakeReturnStatement("301 <: set of app2.request"),
 		MakeReturnStatement("401 <: request"),
 		MakeReturnStatement("404 <: sequence of request"),
 		MakeReturnStatement("500 <: sequence of app2.request"),
@@ -289,6 +313,18 @@ func TestMapReturnStatements(t *testing.T) {
 			Name: "200",
 			Type: &Type{
 				Type: "string",
+			},
+		},
+		"301": {
+			Name: "301",
+			Type: &Type{
+				Items: []*Type{
+					{
+						Type:      "ref",
+						Reference: "app2:request",
+					},
+				},
+				Type: "set",
 			},
 		},
 		"default": {

--- a/pkg/syslwrapper/app_test.go
+++ b/pkg/syslwrapper/app_test.go
@@ -242,6 +242,34 @@ func TestTypeConversionPrimative(t *testing.T) {
 	}, convertedType1)
 }
 
+func TestTypeConversionRelation(t *testing.T) {
+	type2 := MakeRelation(map[string]*sysl.Type{
+		"id":   MakePrimitive("string"),
+		"name": MakePrimitive("string"),
+	}, "id", []string{})
+	var app2 = MakeApp("app2", []*sysl.Param{}, map[string]*sysl.Type{"request": type2})
+	var mod = &sysl.Module{
+		Apps: map[string]*sysl.Application{
+			"app2": &app2,
+		},
+	}
+
+	expectedResult := &Type{
+		Type: "relation",
+		Properties: map[string]*Type{
+			"id": {
+				Type: "string",
+			},
+			"name": {
+				Type: "string",
+			},
+		},
+	}
+
+	mapper := MakeAppMapper(mod)
+	convertedType1 := mapper.MapType(type2)
+	assert.Equal(t, expectedResult, convertedType1)
+}
 func TestTypeConversionSet(t *testing.T) {
 	type2 := MakeSet(MakePrimitive("string"))
 	var app2 = MakeApp("app2", []*sysl.Param{}, map[string]*sysl.Type{"request": type2})
@@ -426,5 +454,5 @@ func prettyPrint(t *testing.T, v interface{}) {
 	if err != nil {
 		t.Log(t, err)
 	}
-	t.Log(t, json)
+	t.Log(t, string(json))
 }

--- a/pkg/syslwrapper/test_helper.go
+++ b/pkg/syslwrapper/test_helper.go
@@ -179,13 +179,27 @@ func MakeOneOf(oneOfType []*sysl.Type) *sysl.Type {
 }
 
 //TODO relation, set, sequence, notype
-// func MakeRelation(oneOfType []*sysl.Type) *sysl.Type {
-// 	return &sysl.Type{
-// 		Type: &sysl.Type_Relation_{
-// 			Relation: &sysl.Type_Relation{},
-// 		},
-// 	}
-// }
+func MakeRelation(types map[string]*sysl.Type, primaryKey string, keys []string) *sysl.Type {
+	var relationKeys []*sysl.Type_Relation_Key
+	for _, val := range keys {
+		relationKeys = append(relationKeys, &sysl.Type_Relation_Key{
+			AttrName: []string{val},
+		})
+	}
+	relation := &sysl.Type{
+		Type: &sysl.Type_Relation_{
+			Relation: &sysl.Type_Relation{
+				AttrDefs: types,
+				PrimaryKey: &sysl.Type_Relation_Key{
+					AttrName: []string{primaryKey},
+				},
+				Key: relationKeys,
+			},
+		},
+	}
+
+	return relation
+}
 
 func MakeSet(setType *sysl.Type) *sysl.Type {
 	return &sysl.Type{

--- a/pkg/syslwrapper/test_helper.go
+++ b/pkg/syslwrapper/test_helper.go
@@ -187,15 +187,13 @@ func MakeOneOf(oneOfType []*sysl.Type) *sysl.Type {
 // 	}
 // }
 
-// func MakeSet(oneOfType []*sysl.Type) *sysl.Type {
-// 	return &sysl.Type{
-// 		Type: &sysl.Type_OneOf_{
-// 			OneOf: &sysl.Type_OneOf{
-// 				Type: oneOfType,
-// 			},
-// 		},
-// 	}
-// }
+func MakeSet(setType *sysl.Type) *sysl.Type {
+	return &sysl.Type{
+		Type: &sysl.Type_Set{
+			Set: setType,
+		},
+	}
+}
 
 func MakeNoType() *sysl.Type {
 	return &sysl.Type{


### PR DESCRIPTION
Changes proposed:

- Add support for set in responses and type definitions
- Add basic support for relation type in sysl type definitions




Checklist:
- [x] Added related tests
- [ ] Made corresponding changes to the documentation