### PR TITLE
Modify the handling of table refs

### DIFF
--- a/pkg/syslwrapper/app_test.go
+++ b/pkg/syslwrapper/app_test.go
@@ -56,6 +56,20 @@ func TestResolveTypesWithSyslFile(t *testing.T) {
 	assert.Equal(t, expectedResult.GetAttrs()["balance"], typeIndex["Server:Response"].GetAttrs()["balance"])
 }
 
+func TestMapPetStoreToSimpleTypes(t *testing.T) {
+	mod, err := parse.NewParser().Parse("../../demo/petshop/petshop.sysl", afero.NewOsFs())
+	assert.NoError(t, err)
+	mapper := MakeAppMapper(mod)
+	mapper.IndexTypes()
+	mapper.ConvertTypes()
+	expected := &Type{
+		Type:      "ref",
+		Reference: "PetShopModel:Breed",
+	}
+	assert.Equal(t, "relation", mapper.SimpleTypes["PetShopModel:Pet"].Type)
+	assert.Equal(t, expected, mapper.SimpleTypes["PetShopModel:Pet"].Properties["breedId"])
+}
+
 func TestMapTypeRef(t *testing.T) {
 	type1 := MakeTypeRef("app1", []string{"login"}, "app2", []string{"request"})
 	type2 := MakePrimitive("string")


### PR DESCRIPTION
Previously, !table definitions in sysl had their fields mapped to references which are defined as {{tablename}}:{{fieldname}}

This commit changes the behaviour to instead return a reference to the type in the format {{appname}}:{{typename}} so that it is consisent with the behaviour of other type references.

Changes proposed in this pull request:
- Update handling of reference types in tables to be consistent with other references

Checklist:
- [x] Added related tests
- [x] Made corresponding changes to the documentation
