### PR TITLE
Fix map types conversion in syslwrapper

### DIFF
--- a/pkg/syslwrapper/app_test.go
+++ b/pkg/syslwrapper/app_test.go
@@ -56,6 +56,32 @@ func TestResolveTypesWithSyslFile(t *testing.T) {
 	assert.Equal(t, expectedResult.GetAttrs()["balance"], typeIndex["Server:Response"].GetAttrs()["balance"])
 }
 
+func TestConvertMapType(t *testing.T) {
+	mod, err := parse.NewParser().Parse("./tests/map.sysl", afero.NewOsFs())
+	assert.NoError(t, err)
+	mapper := MakeAppMapper(mod)
+	mapper.IndexTypes()
+	simpleTypes := mapper.ConvertTypes()
+
+	expectedResult := &Type{
+		Type: "map",
+		Properties: map[string]*Type{
+			"item_id": {
+				Type: "string",
+			},
+			"quantity": {
+				Type: "int",
+			},
+			"message": {
+				Type:      "ref",
+				Reference: "MapType:Message",
+			},
+		},
+		PrimaryKey: "item_id",
+	}
+
+	assert.Equal(t, expectedResult, simpleTypes["MapType:InventoryResponse"])
+}
 func TestMapPetStoreToSimpleTypes(t *testing.T) {
 	mod, err := parse.NewParser().Parse("../../demo/petshop/petshop.sysl", afero.NewOsFs())
 	assert.NoError(t, err)

--- a/pkg/syslwrapper/tests/map.sysl
+++ b/pkg/syslwrapper/tests/map.sysl
@@ -1,0 +1,11 @@
+MapType [package="io.sysl.demo.petshop.api", ~rest]:
+    !type InventoryResponse[json_map_key="item_id"]:
+            item_id <: string:
+                @json_tag = "item_id"
+            quantity <: int:
+                @json_tag = "quantity"
+            message <: Message
+
+    !type Message:
+        code <: int
+        description <: string


### PR DESCRIPTION
Fixes an issue in syslwrapper where maps weren't correctly imported. Maps are defined like the following example:

    !type InventoryResponse[json_map_key="item_id"]:
            item_id <: string:
                @json_tag = "item_id"
            quantity <: int:
                @json_tag = "quantity"

This is non-ideal, but due to limitations in the grammar, that's how they were implemented.

In this commit, we update the json_map_key to fill the Types.PrimaryKey field introduced for relation types in the simplified syslwrapper.Type struct.

In addition, Tuples with a json_map_key attribute will be converted into the "map" type.

Checklist:
- [x] Added related tests
- [x] Made corresponding changes to the documentation
