### PR TITLE
Update incorrect data-type in language docs

### DIFF
--- a/docs/website/content/docs/language.md
+++ b/docs/website/content/docs/language.md
@@ -287,7 +287,7 @@ Server:
 Sysl supports following data types out of the box.
 
 ```
-double
+decimal
 int64
 float64
 string


### PR DESCRIPTION
Fix an incorrect data-type listed in the language docs
- Double is not a sysl type, should be decimal instead