### PR TITLE
Refactor importers to use an interface

### DIFF
--- a/pkg/importer/formats.go
+++ b/pkg/importer/formats.go
@@ -1,0 +1,93 @@
+package importer
+
+import (
+	"fmt"
+	"path"
+	"strings"
+
+	"github.com/ghodss/yaml"
+)
+
+// Format represents a format that can be imported into Sysl
+type Format struct {
+	Name      string   // Name of the format
+	Signature string   // This is a string which can be used to uniquely identify the format
+	FileExt   []string // The file extension of the format
+}
+
+var SYSL = Format{
+	Name:      "sysl",
+	Signature: "",
+	FileExt:   []string{".sysl"},
+}
+
+var XSD = Format{
+	Name:      "xsd",
+	Signature: ``,
+	FileExt:   []string{".xsd", ".xml"},
+}
+
+var Grammar = Format{
+	Name:      "grammar",
+	Signature: "",
+	FileExt:   []string{".g"},
+}
+
+// OpenAPI3 is identified by the openapi header. -  The value MUST be "3.x.x".
+// For more details refer to https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.0.md#oasDocument
+var OpenAPI3 = Format{
+	Name:      "openapi3",
+	Signature: `openapi: "3`,
+	FileExt:   []string{".yaml", ".json", ".yml"},
+}
+
+// Swagger only has 2.0.0 as the single valid format -  The value MUST be "2.0".
+// For more details refer to https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#swaggerObject
+var Swagger = Format{
+	Name:      "swagger",
+	Signature: `swagger: "2.0"`,
+	FileExt:   []string{".yaml", ".json", ".yml"},
+}
+
+// GuessFileType detects the file based on the extension and the file itself.
+// It returns the detected format if successful, or an error, if it has failed.
+// It first tries to match the file extensions before checking the files for signatures such as swagger: "2.0"
+func GuessFileType(filename string, data []byte, validFormats []Format) (*Format, error) {
+	var matchesExt []Format
+	ext := path.Ext(filename)
+	for _, format := range validFormats {
+		for _, formatExt := range format.FileExt {
+			if formatExt == ext {
+				matchesExt = append(matchesExt, format)
+				break
+			}
+		}
+	}
+
+	if len(matchesExt) == 1 {
+		return &matchesExt[0], nil
+	}
+
+	var matchesSignature []Format
+	// Convert to yaml so we only need to compare a single format
+	if ext == ".json" {
+		var err error
+		data, err = yaml.JSONToYAML(data)
+		if err != nil {
+			return nil, fmt.Errorf("error converting spec to yaml for: %s", filename)
+		}
+	}
+
+	for _, format := range matchesExt {
+		if strings.Contains(string(data), format.Signature) {
+			matchesSignature = append(matchesSignature, format)
+		}
+	}
+
+	if len(matchesSignature) == 1 {
+		return &matchesSignature[0], nil
+	}
+
+	// We return an error if the number of matches is less than 0 or greater than 1
+	return nil, fmt.Errorf("error detecting input file format for: %s", filename)
+}

--- a/pkg/importer/formats_test.go
+++ b/pkg/importer/formats_test.go
@@ -1,0 +1,51 @@
+package importer
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+var formatsToTest = []Format{
+	XSD,
+	OpenAPI3,
+	SYSL,
+	Swagger,
+}
+
+var formatTests = []struct {
+	testName     string
+	fileName     string
+	fileContents []byte
+	out          *Format
+	err          error
+}{
+	{"Parses XML ext", ".xml", []byte{}, &XSD, nil},
+	{"Parses XSD ext", ".xsd", []byte{}, &XSD, nil},
+	{"Parses sysl ext", ".sysl", []byte{}, &SYSL, nil},
+	{"Parses openapi3 yaml files", ".yaml", []byte(`openapi: "3.0.0"`), &OpenAPI3, nil},
+	{"Parses openapi3 yaml files", ".yaml", []byte(`openapi: "3.0.3"`), &OpenAPI3, nil},
+	{"Parses openapi3 json files", ".json", []byte(`{"openapi": "3.0.0"}`), &OpenAPI3, nil},
+	{"Parses swagger2 yaml files", ".yaml", []byte(`swagger: "2.0"`), &Swagger, nil},
+	{"Parses swagger2 json files", ".json", []byte(`{"swagger": "2.0"}`), &Swagger, nil},
+	{"Parses xsd files", ".xsd", []byte(`xml`), &XSD, nil},
+	{"Parses xml files", ".xml", []byte(`xml`), &XSD, nil},
+	{"Fails for unknown extension", ".abcde", []byte{}, nil, errors.New("error detecting input file format for: ")},
+	{"Fails for invalid json", ".json", []byte{}, nil, errors.New("error converting json to yaml for: ")},
+	{"Fails for empty string", "", []byte{}, nil, errors.New("error detecting input file format for: ")},
+}
+
+//nolint:scopelint
+func TestGuessFileType(t *testing.T) {
+	for _, tt := range formatTests {
+		t.Run(tt.testName, func(t *testing.T) {
+			t.Parallel()
+			guessedType, err := GuessFileType(tt.fileName, tt.fileContents, formatsToTest)
+			assert.Equal(t, tt.err, err)
+			if tt.out != nil {
+				assert.Equal(t, tt.out.Name, guessedType.Name)
+			}
+		})
+	}
+}

--- a/pkg/importer/importer.go
+++ b/pkg/importer/importer.go
@@ -1,5 +1,11 @@
 package importer
 
+import (
+	"fmt"
+
+	"github.com/sirupsen/logrus"
+)
+
 // Importer is an interface implemented by all sysl importers
 type Importer interface {
 	// Load takes in a string in a format supported by an the importer
@@ -9,4 +15,35 @@ type Importer interface {
 	WithAppName(appName string) Importer
 	// WithPackage allows the exported Sysl package attribute to be specified
 	WithPackage(packageName string) Importer
+}
+
+var Formats = []Format{
+	Grammar,
+	OpenAPI3,
+	Swagger,
+	XSD,
+}
+
+// Factory takes in an absolute filePath and a file and returns an importer from the detected file type
+func Factory(filePath string, file []byte, logger *logrus.Logger) (Importer, error) {
+	fileType, err := GuessFileType(filePath, file, Formats)
+	if err != nil {
+		return nil, err
+	}
+	switch fileType.Name {
+	case Swagger.Name:
+		logger.Debugln("Detected OpenAPI2")
+		return MakeOpenAPI2Importer(logger, "", filePath), nil
+	case OpenAPI3.Name:
+		logger.Debugln("Detected OpenAPI3")
+		return MakeOpenAPI3Importer(logger, "", filePath), nil
+	case XSD.Name:
+		logger.Debugln("Detected XSD")
+		return MakeXSDImporter(logger), nil
+	case Grammar.Name:
+		logger.Debugln("Detected Grammar file")
+		return nil, fmt.Errorf("importer disabled for: %s", fileType.Name)
+	default:
+		return nil, fmt.Errorf("an importer does not exist for: %s", fileType.Name)
+	}
 }

--- a/pkg/importer/importer.go
+++ b/pkg/importer/importer.go
@@ -1,0 +1,12 @@
+package importer
+
+// Importer is an interface implemented by all sysl importers
+type Importer interface {
+	// Load takes in a string in a format supported by an the importer
+	// It returns the converted Sysl as a string
+	Load(file string) (string, error)
+	// WithAppName allows the exported Sysl application name to be specified
+	WithAppName(appName string) Importer
+	// WithPackage allows the exported Sysl package attribute to be specified
+	WithPackage(packageName string) Importer
+}

--- a/pkg/importer/importer_test.go
+++ b/pkg/importer/importer_test.go
@@ -17,8 +17,6 @@ type testConfig struct {
 	name          string
 	testDir       string
 	testExtension string
-	mode          string
-	fn            Func
 }
 
 func runImportEqualityTests(t *testing.T, cfg testConfig) {
@@ -33,23 +31,21 @@ func runImportEqualityTests(t *testing.T, cfg testConfig) {
 		ext := filepath.Ext(f.Name())
 		if strings.EqualFold(ext, cfg.testExtension) {
 			filename := strings.TrimSuffix(f.Name(), ext)
-			t.Run(fmt.Sprintf("%s - %s", cfg.name, filename), func(t *testing.T) {
+			t.Run(fmt.Sprintf("%s-%s", cfg.name, filename), func(t *testing.T) {
 				t.Parallel()
-				swaggerFile := syslutil.MustAbsolute(t, filepath.Join(cfg.testDir, filename+cfg.testExtension))
-				input, err := ioutil.ReadFile(swaggerFile)
+				fileToImport := syslutil.MustAbsolute(t, filepath.Join(cfg.testDir, filename+cfg.testExtension))
+				input, err := ioutil.ReadFile(fileToImport)
 				require.NoError(t, err)
 				syslFile := filepath.Join(cfg.testDir, filename+".sysl")
 				expected, err := ioutil.ReadFile(syslFile)
 				require.NoError(t, err)
 				expected = syslutil.HandleCRLF(expected)
-
-				outputData := OutputData{
-					AppName:     "testapp",
-					Package:     "package_foo",
-					SwaggerRoot: filepath.Dir(swaggerFile),
-					Mode:        cfg.mode,
-				}
-				result, err := cfg.fn(outputData, string(input), logger)
+				absFilePath, err := filepath.Abs(filepath.Join(cfg.testDir, filename+cfg.testExtension))
+				require.NoError(t, err)
+				imp, err := Factory(absFilePath, input, logger)
+				require.NoError(t, err)
+				imp.WithAppName("testapp").WithPackage("package_foo")
+				result, err := imp.Load(string(input))
 				require.NoError(t, err)
 				require.Equal(t, string(expected), result)
 			})
@@ -62,18 +58,14 @@ func TestLoadSwaggerFromTestFiles(t *testing.T) {
 		name:          "TestLoadSwaggerFromTestFiles",
 		testDir:       "tests-swagger",
 		testExtension: ".yaml",
-		mode:          ModeSwagger,
-		fn:            LoadSwaggerText,
 	})
 }
 
-func TestLoadOpenApiFromTestFiles(t *testing.T) {
+func TestLoadOpenAPIFromTestFiles(t *testing.T) {
 	runImportEqualityTests(t, testConfig{
 		name:          "TestLoadOpenAPIFromTestFiles",
 		testDir:       "tests-openapi",
 		testExtension: ".yaml",
-		mode:          ModeOpenAPI,
-		fn:            LoadOpenAPIText,
 	})
 }
 
@@ -82,8 +74,6 @@ func TestLoadXSDFromTestFiles(t *testing.T) {
 		name:          "TestLoadXSDFromTestFiles",
 		testDir:       "tests-xsd",
 		testExtension: ".xsd",
-		mode:          ModeXSD,
-		fn:            LoadXSDText,
 	})
 }
 

--- a/pkg/importer/modes.go
+++ b/pkg/importer/modes.go
@@ -1,9 +1,0 @@
-package importer
-
-const (
-	ModeOpenAPI = "openapi"
-	ModeSwagger = "swagger"
-	ModeXSD     = "xsd"
-	ModeGrammar = "grammar"
-	ModeAuto    = "auto"
-)

--- a/pkg/importer/openapi.go
+++ b/pkg/importer/openapi.go
@@ -83,19 +83,6 @@ func (l *OpenAPI3Importer) WithPackage(pkg string) Importer {
 	return l
 }
 
-func (l *OpenAPI3Importer) newLoaderWithExternalSpec(path string, swagger *openapi3.Swagger) {
-	l.externalSpecs[path] = &OpenAPI3Importer{
-		logger:        l.logger,
-		externalSpecs: make(map[string]*OpenAPI3Importer),
-		spec:          swagger,
-		types:         TypeList{},
-		swaggerRoot:   filepath.Dir(path),
-	}
-	l.externalSpecs[path].convertTypes()
-	// external refs are usually found during initEndpoints, this is to find all external refs
-	l.externalSpecs[path].convertEndpoints()
-}
-
 // basepath represents the Swagger basepath value.
 // This is a swagger only field that isn't relevant to openapi3
 func (l *OpenAPI3Importer) convertInfo(args OutputData, basepath string) SyslInfo {

--- a/pkg/importer/openapi.go
+++ b/pkg/importer/openapi.go
@@ -15,60 +15,80 @@ import (
 
 const openapiv3DefinitionPrefix = "#/components/schemas/"
 
-func LoadOpenAPIText(args OutputData, text string, logger *logrus.Logger) (out string, err error) {
-	if strings.Contains(text, "swagger") {
-		return LoadSwaggerText(args, text, logger)
-	}
-	swagger, err := openapi3.NewSwaggerLoader().LoadSwaggerFromData([]byte(text))
-	if err != nil {
-		return "", err
-	}
-	return importOpenAPI(args, swagger, logger, "")
-}
-
-func importOpenAPI(args OutputData,
-	swagger *openapi3.Swagger,
-	logger *logrus.Logger, basepath string) (out string, err error) {
-	l := &loader{
+func MakeOpenAPI3Importer(logger *logrus.Logger, basePath string, filePath string) *OpenAPI3Importer {
+	return &OpenAPI3Importer{
 		logger:            logger,
-		externalSpecs:     make(map[string]*loader),
-		spec:              swagger,
+		externalSpecs:     make(map[string]*OpenAPI3Importer),
 		types:             TypeList{},
 		intermediateTypes: TypeList{},
-		mode:              args.Mode,
-		swaggerRoot:       args.SwaggerRoot,
+		basePath:          basePath,
+		swaggerRoot:       filePath,
 	}
-	l.convertTypes()
-	endpoints := l.convertEndpoints()
-
-	result := &bytes.Buffer{}
-	w := newWriter(result, logger)
-	if err := w.Write(l.convertInfo(args, basepath), l.types, endpoints...); err != nil {
-		return "", err
-	}
-	return result.String(), nil
 }
 
-type loader struct {
+type OpenAPI3Importer struct {
+	appName       string
+	pkg           string
+	basePath      string // Used for Swagger2.0 files which have a basePath field
 	logger        *logrus.Logger
-	externalSpecs map[string]*loader
+	externalSpecs map[string]*OpenAPI3Importer
 	spec          *openapi3.Swagger
 	types         TypeList
 	// intermediateTypes is a temporary list which places the type is in parsing process still.
 	// It can help to support circular dependency, like type A has an array contains type A itself.
 	intermediateTypes TypeList
 	swaggerRoot       string
-	mode              string
 	globalParams      Parameters
 }
 
-func (l *loader) newLoaderWithExternalSpec(path string, swagger *openapi3.Swagger) {
-	l.externalSpecs[path] = &loader{
+func (l *OpenAPI3Importer) Load(input string) (string, error) {
+	loader := openapi3.NewSwaggerLoader()
+	loader.IsExternalRefsAllowed = true
+	url, err := url.Parse(l.swaggerRoot)
+	if err != nil {
+		return "", err
+	}
+	swagger, err := loader.LoadSwaggerFromDataWithPath([]byte(input), url)
+	if err != nil {
+		return "", fmt.Errorf("error loading openapi3 file:%w", err)
+	}
+	l.spec = swagger
+	return l.Parse()
+}
+
+func (l *OpenAPI3Importer) Parse() (string, error) {
+	l.convertTypes()
+	endpoints := l.convertEndpoints()
+
+	result := &bytes.Buffer{}
+	w := newWriter(result, l.logger)
+	if err := w.Write(l.convertInfo(OutputData{
+		AppName: l.appName,
+		Package: l.pkg,
+	}, l.basePath), l.types, endpoints...); err != nil {
+		return "", err
+	}
+	return result.String(), nil
+}
+
+// Set the AppName of the imported app
+func (l *OpenAPI3Importer) WithAppName(appName string) Importer {
+	l.appName = appName
+	return l
+}
+
+// Set the package attribute of the imported app
+func (l *OpenAPI3Importer) WithPackage(pkg string) Importer {
+	l.pkg = pkg
+	return l
+}
+
+func (l *OpenAPI3Importer) newLoaderWithExternalSpec(path string, swagger *openapi3.Swagger) {
+	l.externalSpecs[path] = &OpenAPI3Importer{
 		logger:        l.logger,
-		externalSpecs: make(map[string]*loader),
+		externalSpecs: make(map[string]*OpenAPI3Importer),
 		spec:          swagger,
 		types:         TypeList{},
-		mode:          l.mode,
 		swaggerRoot:   filepath.Dir(path),
 	}
 	l.externalSpecs[path].convertTypes()
@@ -76,7 +96,9 @@ func (l *loader) newLoaderWithExternalSpec(path string, swagger *openapi3.Swagge
 	l.externalSpecs[path].convertEndpoints()
 }
 
-func (l *loader) convertInfo(args OutputData, basepath string) SyslInfo {
+// basepath represents the Swagger basepath value.
+// This is a swagger only field that isn't relevant to openapi3
+func (l *OpenAPI3Importer) convertInfo(args OutputData, basepath string) SyslInfo {
 	info := SyslInfo{
 		OutputData:  args,
 		Title:       l.spec.Info.Title,
@@ -107,7 +129,7 @@ func (l *loader) convertInfo(args OutputData, basepath string) SyslInfo {
 	return info
 }
 
-func (l *loader) convertTypes() {
+func (l *OpenAPI3Importer) convertTypes() {
 	// First init the swagger -> sysl mappings
 	var swaggerToSyslMappings = map[string]string{
 		"boolean": "bool",
@@ -132,7 +154,7 @@ func (l *loader) convertTypes() {
 	l.types.Sort()
 }
 
-func (l *loader) typeFromRef(path string) Type {
+func (l *OpenAPI3Importer) typeFromRef(path string) Type {
 	// matches with external file remote reference
 	if isOpenAPIOrSwaggerExt(path) {
 		if t := l.typeFromRemoteRef(path); t != nil {
@@ -162,7 +184,7 @@ func (l *loader) typeFromRef(path string) Type {
 	return nil
 }
 
-func (l *loader) typeFromRemoteRef(path string) Type {
+func (l *OpenAPI3Importer) typeFromRemoteRef(path string) Type {
 	cleaned := strings.Split(path, "#")
 	if len(cleaned) != 2 {
 		return nil
@@ -185,7 +207,7 @@ func (l *loader) typeFromRemoteRef(path string) Type {
 	return l.externalSpecs[refPath].typeFromRef(defPath)
 }
 
-func (l *loader) loadExternalSchema(path string) {
+func (l *OpenAPI3Importer) loadExternalSchema(path string) {
 	l.newLoaderWithExternalSpec(path, l.getOpenapi3(path))
 }
 
@@ -198,7 +220,7 @@ func guessYamlType(filename string, data []byte) string {
 
 	return "unknown"
 }
-func (l *loader) getOpenapi3(path string) *openapi3.Swagger {
+func (l *OpenAPI3Importer) getOpenapi3(path string) *openapi3.Swagger {
 	var swagger *openapi3.Swagger
 	data, err := ioutil.ReadFile(path)
 	if err != nil {
@@ -219,7 +241,7 @@ func (l *loader) getOpenapi3(path string) *openapi3.Swagger {
 	return swagger
 }
 
-func (l *loader) typeFromSchemaRef(name string, ref *openapi3.SchemaRef) Type {
+func (l *OpenAPI3Importer) typeFromSchemaRef(name string, ref *openapi3.SchemaRef) Type {
 	if ref == nil {
 		return nil
 	}
@@ -237,7 +259,7 @@ func sortProperties(props FieldList) {
 	})
 }
 
-func (l *loader) typeFromSchema(name string, schema *openapi3.Schema) Type {
+func (l *OpenAPI3Importer) typeFromSchema(name string, schema *openapi3.Schema) Type {
 	if t, found := l.types.Find(name); found {
 		return t
 	}
@@ -303,7 +325,7 @@ func (l *loader) typeFromSchema(name string, schema *openapi3.Schema) Type {
 	}
 }
 
-func (l *loader) convertEndpoints() []MethodEndpoints {
+func (l *OpenAPI3Importer) convertEndpoints() []MethodEndpoints {
 	epMap := map[string][]Endpoint{}
 
 	l.initGlobalParams()
@@ -371,7 +393,7 @@ func isSchemaDefinedObject(ref *openapi3.SchemaRef) bool {
 	return true
 }
 
-func (l *loader) initEndpoint(path string, op *openapi3.Operation, params Parameters) Endpoint {
+func (l *OpenAPI3Importer) initEndpoint(path string, op *openapi3.Operation, params Parameters) Endpoint {
 	var responses []Response
 	typePrefix := strings.NewReplacer(
 		"/", "_",
@@ -466,7 +488,7 @@ func (l *loader) initEndpoint(path string, op *openapi3.Operation, params Parame
 	return res
 }
 
-func (l *loader) initGlobalParams() {
+func (l *OpenAPI3Importer) initGlobalParams() {
 	l.globalParams = Parameters{
 		items:       map[string]Param{},
 		insertOrder: []string{},
@@ -477,7 +499,7 @@ func (l *loader) initGlobalParams() {
 	}
 }
 
-func (l *loader) findResponse(ref *openapi3.ResponseRef) *openapi3.Response {
+func (l *OpenAPI3Importer) findResponse(ref *openapi3.ResponseRef) *openapi3.Response {
 	if ref.Value != nil {
 		return ref.Value
 	}
@@ -488,7 +510,7 @@ func (l *loader) findResponse(ref *openapi3.ResponseRef) *openapi3.Response {
 	return &openapi3.Response{}
 }
 
-func (l *loader) buildParams(params openapi3.Parameters) Parameters {
+func (l *OpenAPI3Importer) buildParams(params openapi3.Parameters) Parameters {
 	out := Parameters{}
 	for _, param := range params {
 		var paramType Param
@@ -509,7 +531,7 @@ func (l *loader) buildParams(params openapi3.Parameters) Parameters {
 	return out
 }
 
-func (l *loader) buildParam(p *openapi3.Parameter) Param {
+func (l *OpenAPI3Importer) buildParam(p *openapi3.Parameter) Param {
 	name := p.Name
 	if hasToBeSyslSafe(p.In) {
 		name = convertToSyslSafe(name)

--- a/pkg/importer/openapi.go
+++ b/pkg/importer/openapi.go
@@ -247,7 +247,7 @@ func (l *OpenAPI3Importer) getExternalSpec(path string) *openapi3.Swagger {
 
 	switch format.Name {
 	case Swagger.Name:
-		swagger, _, err = convertToOpenapiv3(data)
+		swagger, _, err = convertToOpenAPI3(data)
 	case OpenAPI3.Name:
 		swagger, err = openapi3.NewSwaggerLoader().LoadSwaggerFromData(data)
 	}

--- a/pkg/importer/openapi_test.go
+++ b/pkg/importer/openapi_test.go
@@ -1,0 +1,57 @@
+package importer
+
+import (
+	"testing"
+
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMakeOpenAPI3Importer(t *testing.T) {
+	logger := logrus.New()
+	basePath := ""
+	importer := MakeOpenAPI3Importer(logger, basePath, "")
+	t.Log(importer)
+}
+
+func TestLoadOpenAPI3(t *testing.T) {
+	spec := `openapi: "3.0"
+info:
+  title: Simple
+paths:
+  /test/:
+    get:
+      responses:
+        200:
+          description: "200 OK"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SimpleObj"
+        500:
+          $ref: "#/components/responses/500Response"
+components:
+  schemas:
+    SimpleObj:
+      type: object
+      properties:
+        name:
+          type: string
+    SimpleObj2:
+      type: object
+      properties:
+        name:
+          type: SimpleObj
+  responses:
+    500Response:
+      description: Internal Server Error
+      schema:
+        $ref: "#/components/schemas/SimpleObj"
+`
+	logger := logrus.New()
+	basePath := ""
+	importer := MakeOpenAPI3Importer(logger, basePath, "")
+	result, err := importer.Load(spec)
+	assert.NoError(t, err)
+	t.Log(result)
+}

--- a/pkg/importer/swagger.go
+++ b/pkg/importer/swagger.go
@@ -15,7 +15,7 @@ import (
 )
 
 func LoadSwaggerText(args OutputData, oas2spec string, logger *logrus.Logger) (out string, err error) {
-	oas3spec, basePath, err := convertToOpenapiv3([]byte(oas2spec))
+	oas3spec, basePath, err := convertToOpenAPI3([]byte(oas2spec))
 	if err != nil {
 		return "", err
 	}
@@ -42,7 +42,7 @@ type OpenAPI2Importer struct {
 }
 
 func (l *OpenAPI2Importer) Load(oas2spec string) (string, error) {
-	oas3spec, basePath, err := convertToOpenapiv3([]byte(oas2spec))
+	oas3spec, basePath, err := convertToOpenAPI3([]byte(oas2spec))
 	if err != nil {
 		return "", fmt.Errorf("error converting openapi 2:%w", err)
 	}
@@ -64,7 +64,8 @@ func (l *OpenAPI2Importer) WithPackage(pkg string) Importer {
 	return l
 }
 
-func convertToOpenapiv3(data []byte) (*openapi3.Swagger, string, error) {
+// convertToOpenAPI3 takes a swagger spec and converts it to openapi3
+func convertToOpenAPI3(data []byte) (*openapi3.Swagger, string, error) {
 	var swagger2 openapi2.Swagger
 	jsondata, err := yaml.YAMLToJSON(data)
 	if err != nil {

--- a/pkg/importer/swagger.go
+++ b/pkg/importer/swagger.go
@@ -2,23 +2,66 @@ package importer
 
 import (
 	"encoding/json"
+	"fmt"
 	"strings"
 
-	"github.com/anz-bank/sysl/pkg/importer/openapi2conv"
 	"github.com/ghodss/yaml"
 
 	"github.com/getkin/kin-openapi/openapi2"
+	"github.com/getkin/kin-openapi/openapi2conv"
 	"github.com/getkin/kin-openapi/openapi3"
 
 	"github.com/sirupsen/logrus"
 )
 
-func LoadSwaggerText(args OutputData, text string, logger *logrus.Logger) (out string, err error) {
-	openapiv3, basePath, err := convertToOpenapiv3([]byte(text))
+func LoadSwaggerText(args OutputData, oas2spec string, logger *logrus.Logger) (out string, err error) {
+	oas3spec, basePath, err := convertToOpenapiv3([]byte(oas2spec))
 	if err != nil {
 		return "", err
 	}
-	return importOpenAPI(args, openapiv3, logger, basePath)
+	importer := MakeOpenAPI3Importer(logger, basePath, "")
+	importer.WithAppName(args.AppName).WithPackage(args.Package)
+	importer.spec = oas3spec
+	return importer.Parse()
+}
+
+func MakeOpenAPI2Importer(logger *logrus.Logger, basePath string, filePath string) *OpenAPI2Importer {
+	return &OpenAPI2Importer{OpenAPI3Importer: &OpenAPI3Importer{
+		logger:            logger,
+		externalSpecs:     make(map[string]*OpenAPI3Importer),
+		types:             TypeList{},
+		intermediateTypes: TypeList{},
+		basePath:          basePath,
+		swaggerRoot:       filePath,
+	}}
+}
+
+type OpenAPI2Importer struct {
+	openAPI2Spec string
+	*OpenAPI3Importer
+}
+
+func (l *OpenAPI2Importer) Load(oas2spec string) (string, error) {
+	oas3spec, basePath, err := convertToOpenapiv3([]byte(oas2spec))
+	if err != nil {
+		return "", fmt.Errorf("error converting openapi 2:%w", err)
+	}
+	l.openAPI2Spec = oas2spec
+	l.basePath = basePath
+	l.spec = oas3spec
+	return l.Parse()
+}
+
+// Set the AppName of the imported app
+func (l *OpenAPI2Importer) WithAppName(appName string) Importer {
+	l.appName = appName
+	return l
+}
+
+// Set the package attribute of the imported app
+func (l *OpenAPI2Importer) WithPackage(pkg string) Importer {
+	l.pkg = pkg
+	return l
 }
 
 func convertToOpenapiv3(data []byte) (*openapi3.Swagger, string, error) {

--- a/pkg/importer/swagger_test.go
+++ b/pkg/importer/swagger_test.go
@@ -1,0 +1,36 @@
+package importer
+
+import (
+	"testing"
+
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestLoadOpenAPI2(t *testing.T) {
+	spec := `swagger: "2.0"
+version: 1.0.0
+info:
+    title: Simple
+paths:
+    /test:
+        get:
+            responses:
+            200:
+                description: 200 OK
+                schema:
+                $ref: '#/definitions/SimpleObj'
+definitions:
+    SimpleObj:
+        type: object
+        properties:
+            name:
+                type: string
+`
+	logger := logrus.New()
+	basePath := ""
+	importer := MakeOpenAPI2Importer(logger, basePath, "")
+	result, err := importer.Load(spec)
+	assert.NoError(t, err)
+	t.Log(result)
+}


### PR DESCRIPTION
This is a fairly large PR that refactors the way that importers are called and removes the mode flag from the sysl import command. All file formats are now automatically detected. A warning message will now be presented if the flag is passed in.

This PR is best reviewed commit by commit.

Changes proposed in this pull request:
- Refactor sysl importers to use Importer interface
- Fix the way file detection is handled to be more specific
 

Checklist:
- [x] Added related tests
- [ ] Made corresponding changes to the documentation
