### PR TITLE
Add missing details to setup docs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ buildlsp: ## Build sysllsp into the ./dist folder
 .PHONY: release
 release: $(PLATFORMS) ## Build release binaries for all supported platforms into ./release
 
-install: build ## Install the sysl binary into $(GOPATH)/bin
+install: build ## Install the sysl binary into $(GOPATH)/bin. We don't use go install because we need to pass in LDFLAGS.
 	cp ./dist/sysl $(GOPATH)/bin
 
 clean: ## Clean temp and build files

--- a/Makefile
+++ b/Makefile
@@ -49,6 +49,7 @@ buildlsp: ## Build sysllsp into the ./dist folder
 release: $(PLATFORMS) ## Build release binaries for all supported platforms into ./release
 
 install: build ## Install the sysl binary into $(GOPATH)/bin. We don't use go install because we need to pass in LDFLAGS.
+	test -n "$(GOPATH)"  # $$GOPATH
 	cp ./dist/sysl $(GOPATH)/bin
 
 clean: ## Clean temp and build files

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -23,7 +23,8 @@ Prerequisites:
 
 - `make`
 - [Go 1.13+](https://golang.org/doc/install)
-- [golangci-lint](https://github.com/golangci/golangci-lint)
+- `GOPATH` env var set (this is used by the make install command)
+- [golangci-lint 1.23.8+](https://github.com/golangci/golangci-lint)
 
 Clone `sysl` to create a local copy on your computer:
 


### PR DESCRIPTION
Some minor documentation improvements to add missing details around building Sysl based on recent questions asked by new sysl users.

Changes proposed in this pull request:
- Add minimum version of golangci-lint needed
- Add requirement for GOPATH env var
- Add comment to makefile clarifying make install target

Checklist:
- [x] Added related tests
- [x] Made corresponding changes to the documentation
