### PR TITLE
#911 Enhance command sysl pb --mode=pb to output binary message

### DIFF
--- a/cmd/sysl/cmd_protobuf.go
+++ b/cmd/sysl/cmd_protobuf.go
@@ -56,5 +56,5 @@ func (p *protobuf) Execute(args cmdutils.ExecuteArgs) error {
 	if p.output == "-" {
 		return pbutil.GeneratePBBinaryMessage(os.Stdout, args.Modules[0])
 	}
-	return pbutil.GeneratePBBinaryMessage2File(args.Modules[0], p.output, args.Filesystem)
+	return pbutil.GeneratePBBinaryMessageFile(args.Modules[0], p.output, args.Filesystem)
 }

--- a/cmd/sysl/cmd_protobuf.go
+++ b/cmd/sysl/cmd_protobuf.go
@@ -20,9 +20,9 @@ func (p *protobuf) Name() string       { return "protobuf" }
 func (p *protobuf) MaxSyslModule() int { return 1 }
 
 func (p *protobuf) Configure(app *kingpin.Application) *kingpin.CmdClause {
-	cmd := app.Command(p.Name(), "Generate textpb/json").Alias("pb")
+	cmd := app.Command(p.Name(), "Generate textpb/json/binary").Alias("pb")
 	cmd.Flag("output", "output file name").Short('o').Default("-").StringVar(&p.output)
-	opts := []string{"textpb", "json"}
+	opts := []string{"textpb", "json", "pb"}
 	cmd.Flag("mode", fmt.Sprintf("output mode: [%s]", strings.Join(opts, ","))).
 		Default(opts[0]).
 		EnumVar(&p.mode, opts...)
@@ -44,8 +44,17 @@ func (p *protobuf) Execute(args cmdutils.ExecuteArgs) error {
 		}
 		return pbutil.JSONPB(args.Modules[0], p.output, args.Filesystem)
 	}
-	if p.output == "-" {
-		return pbutil.FTextPB(os.Stdout, args.Modules[0])
+
+	if p.mode == "" || p.mode == "textpb" {
+		if p.output == "-" {
+			return pbutil.FTextPB(os.Stdout, args.Modules[0])
+		}
+		return pbutil.TextPB(args.Modules[0], p.output, args.Filesystem)
 	}
-	return pbutil.TextPB(args.Modules[0], p.output, args.Filesystem)
+
+	// output format is binary
+	if p.output == "-" {
+		return pbutil.FPB(os.Stdout, args.Modules[0])
+	}
+	return pbutil.PB(args.Modules[0], p.output, args.Filesystem)
 }

--- a/cmd/sysl/cmd_protobuf.go
+++ b/cmd/sysl/cmd_protobuf.go
@@ -54,7 +54,7 @@ func (p *protobuf) Execute(args cmdutils.ExecuteArgs) error {
 
 	// output format is binary
 	if p.output == "-" {
-		return pbutil.FPB(os.Stdout, args.Modules[0])
+		return pbutil.GeneratePBBinaryMessage(os.Stdout, args.Modules[0])
 	}
-	return pbutil.PB(args.Modules[0], p.output, args.Filesystem)
+	return pbutil.GeneratePBBinaryMessage2File(args.Modules[0], p.output, args.Filesystem)
 }

--- a/pkg/pbutil/output.go
+++ b/pkg/pbutil/output.go
@@ -66,8 +66,8 @@ func FTextPB(w io.Writer, m protoreflect.ProtoMessage) error {
 	return err
 }
 
-// GeneratePBBinaryMessage2File generates binary message to the file specified by `filename`.
-func GeneratePBBinaryMessage2File(m protoreflect.ProtoMessage, filename string, fs afero.Fs) error {
+// GeneratePBBinaryMessageFile generates binary message to the file specified by `filename`.
+func GeneratePBBinaryMessageFile(m protoreflect.ProtoMessage, filename string, fs afero.Fs) error {
 	if m == nil {
 		return fmt.Errorf("module is nil: %#v", filename)
 	}

--- a/pkg/pbutil/output.go
+++ b/pkg/pbutil/output.go
@@ -66,7 +66,7 @@ func FTextPB(w io.Writer, m protoreflect.ProtoMessage) error {
 	return err
 }
 
-// GeneratePBBinaryMessage2File generates bianry message to the file specified by `filename`.
+// GeneratePBBinaryMessage2File generates binary message to the file specified by `filename`.
 func GeneratePBBinaryMessage2File(m protoreflect.ProtoMessage, filename string, fs afero.Fs) error {
 	if m == nil {
 		return fmt.Errorf("module is nil: %#v", filename)

--- a/pkg/pbutil/output.go
+++ b/pkg/pbutil/output.go
@@ -7,6 +7,7 @@ import (
 	"github.com/spf13/afero"
 	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/encoding/prototext"
+	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/reflect/protoreflect"
 )
 
@@ -62,5 +63,30 @@ func FTextPB(w io.Writer, m protoreflect.ProtoMessage) error {
 		return err
 	}
 	_, err = w.Write(mt)
+	return err
+}
+
+func PB(m protoreflect.ProtoMessage, filename string, fs afero.Fs) error {
+	if m == nil {
+		return fmt.Errorf("module is nil: %#v", filename)
+	}
+
+	f, err := fs.Create(filename)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	return FPB(f, m)
+}
+
+func FPB(w io.Writer, m protoreflect.ProtoMessage) error {
+	if m == nil {
+		return fmt.Errorf("module is nil")
+	}
+	bytes, err := proto.Marshal(m)
+	if err != nil {
+		return err
+	}
+	_, err = w.Write(bytes)
 	return err
 }

--- a/pkg/pbutil/output.go
+++ b/pkg/pbutil/output.go
@@ -66,7 +66,8 @@ func FTextPB(w io.Writer, m protoreflect.ProtoMessage) error {
 	return err
 }
 
-func PB(m protoreflect.ProtoMessage, filename string, fs afero.Fs) error {
+// GeneratePBBinaryMessage2File generates bianry message to the file specified by `filename`.
+func GeneratePBBinaryMessage2File(m protoreflect.ProtoMessage, filename string, fs afero.Fs) error {
 	if m == nil {
 		return fmt.Errorf("module is nil: %#v", filename)
 	}
@@ -76,10 +77,11 @@ func PB(m protoreflect.ProtoMessage, filename string, fs afero.Fs) error {
 		return err
 	}
 	defer f.Close()
-	return FPB(f, m)
+	return GeneratePBBinaryMessage(f, m)
 }
 
-func FPB(w io.Writer, m protoreflect.ProtoMessage) error {
+// GeneratePBBinaryMessage generates binary message to IO writer specified by `w`.
+func GeneratePBBinaryMessage(w io.Writer, m protoreflect.ProtoMessage) error {
 	if m == nil {
 		return fmt.Errorf("module is nil")
 	}

--- a/pkg/pbutil/output_test.go
+++ b/pkg/pbutil/output_test.go
@@ -140,24 +140,24 @@ func TestFPBNilModule(t *testing.T) {
 	assert.Equal(t, "", output.String())
 }
 
-func TestPB(t *testing.T) {
+func TestGeneratePBBinaryMessageFile(t *testing.T) {
 	t.Parallel()
 
 	unmarshalled := &sysl.Module{}
 	fs := afero.NewMemMapFs()
 	filename := "/out.pb"
-	require.NoError(t, GeneratePBBinaryMessage2File(testModule(), filename, fs))
+	require.NoError(t, GeneratePBBinaryMessageFile(testModule(), filename, fs))
 	output, err := afero.ReadFile(fs, filename)
 	require.NoError(t, err)
 	require.NoError(t, proto.Unmarshal(output, unmarshalled))
 	assert.True(t, proto.Equal(unmarshalled, protoreflect.ProtoMessage(testModule())))
 }
 
-func TestPBNilModule(t *testing.T) {
+func TestGeneratePBBinaryMessageFileNilModule(t *testing.T) {
 	t.Parallel()
 
 	fs := afero.NewMemMapFs()
 	filename := "/out.pb"
-	require.Error(t, GeneratePBBinaryMessage2File(nil, filename, fs))
+	require.Error(t, GeneratePBBinaryMessageFile(nil, filename, fs))
 	syslutil.AssertFsHasExactly(t, fs)
 }

--- a/pkg/pbutil/output_test.go
+++ b/pkg/pbutil/output_test.go
@@ -121,3 +121,43 @@ func TestFTextPBNilModule(t *testing.T) {
 	require.Error(t, FTextPB(&output, nil))
 	assert.Equal(t, "", output.String())
 }
+
+func TestFPB(t *testing.T) {
+	t.Parallel()
+
+	unmarshalled := &sysl.Module{}
+	var output bytes.Buffer
+	require.NoError(t, FPB(&output, testModule()))
+	require.NoError(t, proto.Unmarshal(output.Bytes(), unmarshalled))
+	assert.True(t, proto.Equal(unmarshalled, protoreflect.ProtoMessage(testModule())))
+}
+
+func TestFPBNilModule(t *testing.T) {
+	t.Parallel()
+
+	var output bytes.Buffer
+	require.Error(t, FPB(&output, nil))
+	assert.Equal(t, "", output.String())
+}
+
+func TestPB(t *testing.T) {
+	t.Parallel()
+
+	unmarshalled := &sysl.Module{}
+	fs := afero.NewMemMapFs()
+	filename := "/out.textpb"
+	require.NoError(t, PB(testModule(), filename, fs))
+	output, err := afero.ReadFile(fs, filename)
+	require.NoError(t, err)
+	require.NoError(t, proto.Unmarshal(output, unmarshalled))
+	assert.True(t, proto.Equal(unmarshalled, protoreflect.ProtoMessage(testModule())))
+}
+
+func TestPBNilModule(t *testing.T) {
+	t.Parallel()
+
+	fs := afero.NewMemMapFs()
+	filename := "/out.textpb"
+	require.Error(t, PB(nil, filename, fs))
+	syslutil.AssertFsHasExactly(t, fs)
+}

--- a/pkg/pbutil/output_test.go
+++ b/pkg/pbutil/output_test.go
@@ -127,7 +127,7 @@ func TestFPB(t *testing.T) {
 
 	unmarshalled := &sysl.Module{}
 	var output bytes.Buffer
-	require.NoError(t, FPB(&output, testModule()))
+	require.NoError(t, GeneratePBBinaryMessage(&output, testModule()))
 	require.NoError(t, proto.Unmarshal(output.Bytes(), unmarshalled))
 	assert.True(t, proto.Equal(unmarshalled, protoreflect.ProtoMessage(testModule())))
 }
@@ -136,7 +136,7 @@ func TestFPBNilModule(t *testing.T) {
 	t.Parallel()
 
 	var output bytes.Buffer
-	require.Error(t, FPB(&output, nil))
+	require.Error(t, GeneratePBBinaryMessage(&output, nil))
 	assert.Equal(t, "", output.String())
 }
 
@@ -146,7 +146,7 @@ func TestPB(t *testing.T) {
 	unmarshalled := &sysl.Module{}
 	fs := afero.NewMemMapFs()
 	filename := "/out.pb"
-	require.NoError(t, PB(testModule(), filename, fs))
+	require.NoError(t, GeneratePBBinaryMessage2File(testModule(), filename, fs))
 	output, err := afero.ReadFile(fs, filename)
 	require.NoError(t, err)
 	require.NoError(t, proto.Unmarshal(output, unmarshalled))
@@ -158,6 +158,6 @@ func TestPBNilModule(t *testing.T) {
 
 	fs := afero.NewMemMapFs()
 	filename := "/out.pb"
-	require.Error(t, PB(nil, filename, fs))
+	require.Error(t, GeneratePBBinaryMessage2File(nil, filename, fs))
 	syslutil.AssertFsHasExactly(t, fs)
 }

--- a/pkg/pbutil/output_test.go
+++ b/pkg/pbutil/output_test.go
@@ -145,7 +145,7 @@ func TestPB(t *testing.T) {
 
 	unmarshalled := &sysl.Module{}
 	fs := afero.NewMemMapFs()
-	filename := "/out.textpb"
+	filename := "/out.pb"
 	require.NoError(t, PB(testModule(), filename, fs))
 	output, err := afero.ReadFile(fs, filename)
 	require.NoError(t, err)
@@ -157,7 +157,7 @@ func TestPBNilModule(t *testing.T) {
 	t.Parallel()
 
 	fs := afero.NewMemMapFs()
-	filename := "/out.textpb"
+	filename := "/out.pb"
 	require.Error(t, PB(nil, filename, fs))
 	syslutil.AssertFsHasExactly(t, fs)
 }

--- a/pkg/pbutil/output_test.go
+++ b/pkg/pbutil/output_test.go
@@ -122,7 +122,7 @@ func TestFTextPBNilModule(t *testing.T) {
 	assert.Equal(t, "", output.String())
 }
 
-func TestFPB(t *testing.T) {
+func TestGeneratePBBinaryMessage(t *testing.T) {
 	t.Parallel()
 
 	unmarshalled := &sysl.Module{}
@@ -132,7 +132,7 @@ func TestFPB(t *testing.T) {
 	assert.True(t, proto.Equal(unmarshalled, protoreflect.ProtoMessage(testModule())))
 }
 
-func TestFPBNilModule(t *testing.T) {
+func TestGeneratePBBinaryMessageNilModule(t *testing.T) {
 	t.Parallel()
 
 	var output bytes.Buffer


### PR DESCRIPTION
* Please attach **WIP** tag when this PR is still work in progress.
* Please attach **breaking-change** tag if this PR potentially causes other components to fail or changes previous sysl executable's behaviour.

Fixes #911 .

Changes proposed in this pull request:
- Enhance command `sysl pb --mode=pb` to output binary message
- 

Checklist:
- [x] Added related tests
- [x] Made corresponding changes to the documentation
