### PR TITLE
use http://www.plantuml.com/plantuml as default value

### DIFF
--- a/docs/website/content/docs/commands/EnvironmentVariables.md
+++ b/docs/website/content/docs/commands/EnvironmentVariables.md
@@ -12,10 +12,11 @@ Several commands require environment variables to be set before they are able to
 
 ## SYSL_PLANTUML
 
-`export SYSL_PLANTUML=http://www.plantuml.com/plantuml`
+`SYSL_PLANTUML` is a flag to indicate the PlantUML server address. By default, it is `http://www.plantuml.com/plantuml`.
 
 For more details, refer to [Install](/docs/install/)
 
 ## SYSL_MODULES
 
-`export SYSL_MODULES=true` is a flag to indicate whether Sysl modules are enabled. By default, if this is not declared, Sysl modules are enabled.
+`SYSL_MODULES` is a flag to indicate whether Sysl modules are enabled. By default, if this is not declared, Sysl modules are enabled.
+To disable Sysl Modules, set the environment variable `SYSL_MODULES=off`.

--- a/docs/website/content/docs/commands/datamodel.md
+++ b/docs/website/content/docs/commands/datamodel.md
@@ -30,7 +30,7 @@ Optional flags:
 - `--class_format="%(classname)"`
 - ` Specify the format string for data diagram participants. May include %%(appname) and %%(@foo) for attribute foo (default: %(classname))
 - `-t, --title=TITLE` Diagram title
-- `-p, --plantuml=PLANTUML` base url of plantuml server (default: SYSL_PLANTUML or http://localhost:8080/plantuml see http://plantuml.com/server.html#install for more info)
+- `-p, --plantuml=PLANTUML` base url of plantuml server (default: SYSL_PLANTUML or http://www.plantuml.com/plantuml see http://plantuml.com/server.html#install for more info)
 - `-o, --output="%(epname).png"` Output file (default: %(epname).png)
 - `-j, --project=PROJECT` Project pseudo-app to render
 - `-d, --direct` Process data model directly without project manner

--- a/docs/website/content/docs/commands/integrations.md
+++ b/docs/website/content/docs/commands/integrations.md
@@ -34,7 +34,7 @@ Optional flags:
 - `` becomes the root, but the module can not import with absolute paths (or imports must
 - `` be relative).
 - `-t, --title=TITLE` diagram title
-- `-p, --plantuml=PLANTUML` base url of plantuml server (default: SYSL_PLANTUML or http://localhost:8080/plantuml
+- `-p, --plantuml=PLANTUML` base url of plantuml server (default: SYSL_PLANTUML or http://www.plantuml.com/plantuml
 - `` see http://plantuml.com/server.html#install for more info)
 - `-o, --output="%(epname).png"` output file(default: %(epname).png)
 - `-j, --project=PROJECT` project pseudo-app to render

--- a/docs/website/content/docs/commands/sd.md
+++ b/docs/website/content/docs/commands/sd.md
@@ -33,7 +33,7 @@ Optional flags:
 - `--app_format="%(appname)"`Specify the format string for sequence diagram participants. May include %%(appname)
   and %%(@foo) for attribute foo (default: %(appname))
 - `-t, --title=TITLE`diagram title
-- `-p, --plantuml=PLANTUML`base url of plantuml server (default: SYSL_PLANTUML or http://localhost:8080/plantuml
+- `-p, --plantuml=PLANTUML`base url of plantuml server (default: SYSL_PLANTUML or http://www.plantuml.com/plantuml
   see http://plantuml.com/server.html#install for more info)
 - `-o, --output="%(epname).png"`output file (default: %(epname).png)
 - `-s, --endpoint=ENDPOINT ...`Include endpoint in sequence diagram

--- a/docs/website/content/docs/install.md
+++ b/docs/website/content/docs/install.md
@@ -13,8 +13,7 @@ Sysl is a CLI (Command Line Interface) that executes with the `sysl` command.
 ## Prerequisites
 
 - [Go 1.13](https://golang.org/doc/install)
-- There are extra prerequisites for several subcommands like `sysl sd`(sequence diagram generation): - Sysl depends upon [PlantUML](http://plantuml.com/) for diagram generation. Some of the automated tests require a PlantUML dependency. Provide PlantUML access either via local installation or URL to remote service. Warning, for sensitive data the public service at www.plantuml.com is not suitable. You can use one of the following options to set up your environment: - execute `SYSL_PLANTUML=http://www.plantuml.com/plantuml` - add `export SYSL_PLANTUML=http://www.plantuml.com/plantuml` to your `.bashrc`
-  or similar - [install PlantUML](http://plantuml.com/starting) locally or run a local instance of the [PlantUML server](https://hub.docker.com/r/plantuml/plantuml-server/) using the docker image and run on port 8080. Otherwise you can refer to the [plantuml server guide](docs/plantUML_server.md)
+- There are extra prerequisites for several subcommands like `sysl sd`(sequence diagram generation): - Sysl depends upon [PlantUML](http://plantuml.com/) for diagram generation. Some of the automated tests require a PlantUML dependency. Provide PlantUML access either via local installation or URL to remote service. Warning, for sensitive data the public service at www.plantuml.com is not suitable. You can [install PlantUML](http://plantuml.com/starting) locally or run a local instance of the [PlantUML server](https://hub.docker.com/r/plantuml/plantuml-server/) using the docker image and run on port 8080. Otherwise you can refer to the [plantuml server guide](docs/plantUML_server.md)
 
 ---
 

--- a/pkg/diagrams/plantuml.go
+++ b/pkg/diagrams/plantuml.go
@@ -16,7 +16,7 @@ import (
 
 const (
 	PlantUMLEnvVar  = "SYSL_PLANTUML"
-	PlantUMLDefault = "http://localhost:8080/plantuml"
+	PlantUMLDefault = "http://www.plantuml.com/plantuml" // "http://localhost:8080/plantuml"
 	testDir         = "../../tests/"
 )
 


### PR DESCRIPTION
Fixes #919 .

Changes proposed in this pull request:
- use http://www.plantuml.com/plantuml as default value

Checklist:
- [x] Made corresponding changes to the documentation
