### PR TITLE
use PlantUML stereotype to represent primitive type

### DIFF
--- a/pkg/datamodeldiagram/datamodelview.go
+++ b/pkg/datamodeldiagram/datamodelview.go
@@ -13,8 +13,8 @@ import (
 const classString = `class`
 const relationArrow = `}--`
 const tupleArrow = `*--`
-const entityLessThanArrow = `<< (`
-const entityGreaterThanArrow = `) >>`
+const entityLessThanArrow = `<< `
+const entityGreaterThanArrow = ` >>`
 
 type DataModelParam struct {
 	cmdutils.ClassLabeler
@@ -117,7 +117,7 @@ func (v *DataModelView) DrawRelation(
 ) {
 	entityTokens := strings.Split(viewParam.EntityName, ".")
 	encEntity := v.UniqueVarForAppName(entityTokens[len(entityTokens)-1])
-	v.StringBuilder.WriteString(fmt.Sprintf("%s \"%s\" as %s %s%s,%s%s {\n", classString, viewParam.EntityName,
+	v.StringBuilder.WriteString(fmt.Sprintf("%s \"%s\" as %s %s(%s,%s)%s {\n", classString, viewParam.EntityName,
 		encEntity, entityLessThanArrow, viewParam.EntityHeader, viewParam.EntityColor, entityGreaterThanArrow))
 
 	// sort and iterate over attributes
@@ -166,14 +166,12 @@ func (v *DataModelView) DrawPrimitive(
 ) {
 	entityTokens := strings.Split(viewParam.EntityName, ".")
 	encEntity := v.UniqueVarForAppName(entityTokens[len(entityTokens)-1])
-	v.StringBuilder.WriteString(fmt.Sprintf("%s \"%s\" as %s %s%s,%s%s {\n", classString, viewParam.EntityName,
-		encEntity, entityLessThanArrow, viewParam.EntityHeader, viewParam.EntityColor, entityGreaterThanArrow))
+	v.StringBuilder.WriteString(fmt.Sprintf("%s \"%s\" as %s %s(%s,%s)%s%s {\n", classString, viewParam.EntityName,
+		encEntity, entityLessThanArrow, viewParam.EntityHeader, viewParam.EntityColor, strings.ToLower(entity), entityGreaterThanArrow))
 
 	if _, exists := relationshipMap[encEntity]; !exists {
 		relationshipMap[encEntity] = map[string]RelationshipParam{}
 	}
-	// Add default property id for primitive types
-	v.StringBuilder.WriteString(fmt.Sprintf("+ %s : %s\n", "id", strings.ToLower(entity)))
 	v.StringBuilder.WriteString("}\n")
 }
 
@@ -184,7 +182,7 @@ func (v *DataModelView) DrawTuple(
 	relationshipMap map[string]map[string]RelationshipParam,
 ) {
 	encEntity := v.UniqueVarForAppName(strings.Split(viewParam.EntityName, ".")...)
-	v.StringBuilder.WriteString(fmt.Sprintf("%s \"%s\" as %s %s%s,%s%s {\n", classString, viewParam.EntityName,
+	v.StringBuilder.WriteString(fmt.Sprintf("%s \"%s\" as %s %s(%s,%s)%s {\n", classString, viewParam.EntityName,
 		encEntity, entityLessThanArrow, viewParam.EntityHeader, viewParam.EntityColor, entityGreaterThanArrow))
 	var appName string
 	var relation string

--- a/pkg/datamodeldiagram/datamodelview.go
+++ b/pkg/datamodeldiagram/datamodelview.go
@@ -166,7 +166,7 @@ func (v *DataModelView) DrawPrimitive(
 ) {
 	entityTokens := strings.Split(viewParam.EntityName, ".")
 	encEntity := v.UniqueVarForAppName(entityTokens[len(entityTokens)-1])
-	v.StringBuilder.WriteString(fmt.Sprintf("%s \"%s\" as %s %s(%s,%s)%s%s {\n", classString, viewParam.EntityName,
+	v.StringBuilder.WriteString(fmt.Sprintf("%s \"%s\" as %s %s(%s,%s) %s%s {\n", classString, viewParam.EntityName,
 		encEntity, entityLessThanArrow, viewParam.EntityHeader, viewParam.EntityColor, strings.ToLower(entity), entityGreaterThanArrow))
 
 	if _, exists := relationshipMap[encEntity]; !exists {

--- a/pkg/datamodeldiagram/datamodelview.go
+++ b/pkg/datamodeldiagram/datamodelview.go
@@ -166,8 +166,9 @@ func (v *DataModelView) DrawPrimitive(
 ) {
 	entityTokens := strings.Split(viewParam.EntityName, ".")
 	encEntity := v.UniqueVarForAppName(entityTokens[len(entityTokens)-1])
-	v.StringBuilder.WriteString(fmt.Sprintf("%s \"%s\" as %s %s(%s,%s) %s%s {\n", classString, viewParam.EntityName,
-		encEntity, entityLessThanArrow, viewParam.EntityHeader, viewParam.EntityColor, strings.ToLower(entity), entityGreaterThanArrow))
+	v.StringBuilder.WriteString(fmt.Sprintf("%s \"%s\" as %s %s(%s,%s) %s%s {\n",
+		classString, viewParam.EntityName, encEntity,
+		entityLessThanArrow, viewParam.EntityHeader, viewParam.EntityColor, strings.ToLower(entity), entityGreaterThanArrow))
 
 	if _, exists := relationshipMap[encEntity]; !exists {
 		relationshipMap[encEntity] = map[string]RelationshipParam{}

--- a/pkg/datamodeldiagram/datamodelview_test.go
+++ b/pkg/datamodeldiagram/datamodelview_test.go
@@ -33,8 +33,7 @@ func TestDrawPrimitive(t *testing.T) {
 	v.DrawPrimitive(viewParam, "INT", relationshipMap)
 	actual := v.StringBuilder.String()
 
-	expected := "class \"uuid\" as _0 << (D,orchid) >> {\n" +
-		"+ id : int\n}\n"
+	expected := "class \"uuid\" as _0 << (D,orchid) int >> {\n" + "}\n"
 	assert.EqualValues(t, expected, actual, nil)
 	clMock.AssertExpectations(t)
 }


### PR DESCRIPTION
Changes proposed in this pull request:
- use PlantUML stereotype to represent primitive type
e.g. 
```
!alias FooRequest:
        string
```
|before|after|
|---|---|
|![image](https://user-images.githubusercontent.com/13619421/86193794-32c9eb80-bb90-11ea-846e-99a3c9d64f93.png)|![image](https://user-images.githubusercontent.com/13619421/86193782-2e053780-bb90-11ea-883a-4483f5b022fb.png)|
