### PR TITLE
json_tag attribute should not be escaped as they are simply strings

### DIFF
--- a/pkg/importer/openapi.go
+++ b/pkg/importer/openapi.go
@@ -310,7 +310,7 @@ func (l *OpenAPI3Importer) typeFromObject(name string, schema *openapi3.Schema) 
 			fieldType = l.typeFromSchemaRef(getSyslSafeName(name)+"_"+getSyslSafeName(propName), propSchema)
 		}
 		f := Field{
-			Name: getSyslSafeName(propName),
+			Name: propName,
 			Type: fieldType,
 		}
 		if !contains(propName, schema.Required) {

--- a/pkg/importer/tests-openapi/special-char-typename.sysl
+++ b/pkg/importer/tests-openapi/special-char-typename.sysl
@@ -21,13 +21,13 @@ testapp "Simple" [package="package_foo"]:
         name <: string?:
             @json_tag = "name"
         namewith%3Acolon <: string?:
-            @json_tag = "namewith%3Acolon"
+            @json_tag = "namewith:colon"
 
     !type SimpleObj%3AWithColon:
         name <: string?:
             @json_tag = "name"
         namewith%3Acolon <: string?:
-            @json_tag = "namewith%3Acolon"
+            @json_tag = "namewith:colon"
 
     !type SimpleObj2:
         name <: SimpleObj%3AWithColon?:
@@ -37,4 +37,4 @@ testapp "Simple" [package="package_foo"]:
         name <: string?:
             @json_tag = "name"
         namewith%3Acolon <: string?:
-            @json_tag = "namewith%3Acolon"
+            @json_tag = "namewith:colon"

--- a/pkg/importer/writer.go
+++ b/pkg/importer/writer.go
@@ -292,7 +292,7 @@ func (w *writer) writeDefinition(t *StandardType) {
 		}
 		suffix = appendAttributesString(suffix, prop.Attributes)
 
-		name := prop.Name
+		name := getSyslSafeName(prop.Name)
 		if IsBuiltIn(name) {
 			name += "_"
 		}


### PR DESCRIPTION
* Please attach **WIP** tag when this PR is still work in progress.
* Please attach **breaking-change** tag if this PR potentially causes other components to fail or changes previous sysl executable's behaviour.

Fixes # .

Changes proposed in this pull request:
- 
- 

Checklist:
- [ ] Added related tests
- [ ] Made corresponding changes to the documentation
