### PR TITLE
Add newline to docstring attributes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ lint: ## Run golangci-lint
 	golangci-lint run ./...
 
 golden: ## Updates golden test files in pkg/parse. TODO: Extend to work for all golden files
-	go test ./pkg/parse -update
+	go test ./pkg/parse ./pkg/exporter -update
 
 coverage: ## Run tests and verify the test coverage remains high
 	./scripts/test-with-coverage.sh 80

--- a/Makefile
+++ b/Makefile
@@ -15,9 +15,12 @@ TUTORIALS: $(wildcard ./demo/examples/*) $(wildcard ./demo/examples/*/*)
 examples: TUTORIALS
 	cd demo/examples/ && go run generate_website.go && cd ../../  && git --no-pager diff HEAD && test -z "$$(git status --porcelain)"
 
-.PHONY: all install grammar antlr build lint test coverage clean check-tidy
+.PHONY: all install grammar antlr build lint test coverage clean check-tidy golden
 lint: ## Run golangci-lint
 	golangci-lint run ./...
+
+golden: ## Updates golden test files in pkg/parse. TODO: Extend to work for all golden files
+	go test ./pkg/parse -update
 
 coverage: ## Run tests and verify the test coverage remains high
 	./scripts/test-with-coverage.sh 80

--- a/pkg/exporter/test-data/openapi2/EXAMPLE_SWAGGER_SPEC_WITH_ENDPOINT_PATH.yaml
+++ b/pkg/exporter/test-data/openapi2/EXAMPLE_SWAGGER_SPEC_WITH_ENDPOINT_PATH.yaml
@@ -8,7 +8,8 @@ definitions:
     type: object
 host: goat.example.com
 info:
-  description: No description.
+  description: |
+    No description.
   title: Goat CRUD API
   version: 1.2.3
 paths:

--- a/pkg/exporter/test-data/openapi2/EXAMPLE_SWAGGER_SPEC_WITH_ENDPOINT_PATH_WITH_200_RESPONSE_DESCRIPTION_ONLY.yaml
+++ b/pkg/exporter/test-data/openapi2/EXAMPLE_SWAGGER_SPEC_WITH_ENDPOINT_PATH_WITH_200_RESPONSE_DESCRIPTION_ONLY.yaml
@@ -1,6 +1,7 @@
 host: goat.example.com
 info:
-  description: No description.
+  description: |
+    No description.
   title: Goat CRUD API
   version: 1.2.3
 paths:

--- a/pkg/exporter/test-data/openapi2/EXAMPLE_SWAGGER_SPEC_WITH_ENDPOINT_PATH_WITH_201_LOCATION_HEADER_RESPONSE.yaml
+++ b/pkg/exporter/test-data/openapi2/EXAMPLE_SWAGGER_SPEC_WITH_ENDPOINT_PATH_WITH_201_LOCATION_HEADER_RESPONSE.yaml
@@ -11,7 +11,8 @@ definitions:
     type: object
 host: goat.example.com
 info:
-  description: No description.
+  description: |
+    No description.
   title: Goat CRUD API
   version: 1.2.3
 paths:

--- a/pkg/exporter/test-data/openapi2/EXAMPLE_SWAGGER_SPEC_WITH_ENDPOINT_PATH_WITH_201_RESPONSE_DESCRIPTION_ONLY.yaml
+++ b/pkg/exporter/test-data/openapi2/EXAMPLE_SWAGGER_SPEC_WITH_ENDPOINT_PATH_WITH_201_RESPONSE_DESCRIPTION_ONLY.yaml
@@ -1,6 +1,7 @@
 host: goat.example.com
 info:
-  description: No description.
+  description: |
+    No description.
   title: Goat CRUD API
   version: 1.2.3
 paths:

--- a/pkg/exporter/test-data/openapi2/EXAMPLE_SWAGGER_SPEC_WITH_ENDPOINT_PATH_WITH_BODY_PARAMETER.yaml
+++ b/pkg/exporter/test-data/openapi2/EXAMPLE_SWAGGER_SPEC_WITH_ENDPOINT_PATH_WITH_BODY_PARAMETER.yaml
@@ -11,7 +11,8 @@ definitions:
     type: object
 host: goat.example.com
 info:
-  description: No description.
+  description: |
+    No description.
   title: Goat CRUD API
   version: 1.2.3
 paths:

--- a/pkg/exporter/test-data/openapi2/EXAMPLE_SWAGGER_SPEC_WITH_ENDPOINT_PATH_WITH_DEFAULT_RESPONSE.yaml
+++ b/pkg/exporter/test-data/openapi2/EXAMPLE_SWAGGER_SPEC_WITH_ENDPOINT_PATH_WITH_DEFAULT_RESPONSE.yaml
@@ -1,6 +1,7 @@
 host: goat.example.com
 info:
-  description: No description.
+  description: |
+    No description.
   title: Goat CRUD API
   version: 1.2.3
 paths:

--- a/pkg/exporter/test-data/openapi2/EXAMPLE_SWAGGER_SPEC_WITH_ENDPOINT_PATH_WITH_ERROR_RESPONSE.yaml
+++ b/pkg/exporter/test-data/openapi2/EXAMPLE_SWAGGER_SPEC_WITH_ENDPOINT_PATH_WITH_ERROR_RESPONSE.yaml
@@ -1,6 +1,7 @@
 host: goat.example.com
 info:
-  description: No description.
+  description: |
+    No description.
   title: Goat CRUD API
   version: 1.2.3
 paths:

--- a/pkg/exporter/test-data/openapi2/EXAMPLE_SWAGGER_SPEC_WITH_ENDPOINT_PATH_WITH_X_DASH_WHATEVER_RESPONSE.yaml
+++ b/pkg/exporter/test-data/openapi2/EXAMPLE_SWAGGER_SPEC_WITH_ENDPOINT_PATH_WITH_X_DASH_WHATEVER_RESPONSE.yaml
@@ -1,6 +1,7 @@
 host: goat.example.com
 info:
-  description: No description.
+  description: |
+    No description.
   title: Goat CRUD API
   version: 1.2.3
 paths:

--- a/pkg/exporter/test-data/openapi2/EXAMPLE_SWAGGER_SPEC_WITH_ENDPOINT_RETURNING_ARRAY_OF_DEFINED_OBJECT_TYPE.yaml
+++ b/pkg/exporter/test-data/openapi2/EXAMPLE_SWAGGER_SPEC_WITH_ENDPOINT_RETURNING_ARRAY_OF_DEFINED_OBJECT_TYPE.yaml
@@ -11,7 +11,8 @@ definitions:
     type: object
 host: goat.example.com
 info:
-  description: No description.
+  description: |
+    No description.
   title: Goat CRUD API
   version: 1.2.3
 paths:

--- a/pkg/exporter/test-data/openapi2/REST_ENDPOINT_DOT.yaml
+++ b/pkg/exporter/test-data/openapi2/REST_ENDPOINT_DOT.yaml
@@ -7,7 +7,8 @@ definitions:
         type: string
     type: object
 info:
-  description: No description.
+  description: |
+    No description.
   title: Simple
   version: 0.0.0
 paths:

--- a/pkg/exporter/test-data/openapi2/SIMPLE_SWAGGER_EXAMPLE.yaml
+++ b/pkg/exporter/test-data/openapi2/SIMPLE_SWAGGER_EXAMPLE.yaml
@@ -7,7 +7,8 @@ definitions:
         type: string
     type: object
 info:
-  description: No description.
+  description: |
+    No description.
   title: Simple
   version: 0.0.0
 paths:

--- a/pkg/exporter/test-data/openapi2/SWAGGER_ENSURE_HEADER_FIELDS_IN_INSERTION_ORDER.yaml
+++ b/pkg/exporter/test-data/openapi2/SWAGGER_ENSURE_HEADER_FIELDS_IN_INSERTION_ORDER.yaml
@@ -1,5 +1,6 @@
 info:
-  description: foo
+  description: |
+    foo
   title: foo
   version: 0.0.0
 paths:

--- a/pkg/exporter/test-data/openapi2/SWAGGER_HEADER_AND_BODY_PARAM_EXAMPLE.yaml
+++ b/pkg/exporter/test-data/openapi2/SWAGGER_HEADER_AND_BODY_PARAM_EXAMPLE.yaml
@@ -7,7 +7,8 @@ definitions:
         type: string
     type: object
 info:
-  description: No description.
+  description: |
+    No description.
   title: Simple
   version: 0.0.0
 paths:

--- a/pkg/exporter/test-data/openapi2/SWAGGER_QUERY_PARAM_EXAMPLE.yaml
+++ b/pkg/exporter/test-data/openapi2/SWAGGER_QUERY_PARAM_EXAMPLE.yaml
@@ -1,5 +1,6 @@
 info:
-  description: No description.
+  description: |
+    No description.
   title: Simple
   version: 0.0.0
 paths:

--- a/pkg/exporter/test-data/openapi2/SWAGGER_REQUIRED_AND_OPTIONAL_FIELDS_EXAMPLE.yaml
+++ b/pkg/exporter/test-data/openapi2/SWAGGER_REQUIRED_AND_OPTIONAL_FIELDS_EXAMPLE.yaml
@@ -13,7 +13,8 @@ definitions:
         type: number
     type: object
 info:
-  description: No description.
+  description: |
+    No description.
   title: Simple
   version: 0.0.0
 paths: {}

--- a/pkg/exporter/test-data/openapi2/SWAGGER_TOP_LEVEL_ARRAY_EXAMPLE.yaml
+++ b/pkg/exporter/test-data/openapi2/SWAGGER_TOP_LEVEL_ARRAY_EXAMPLE.yaml
@@ -8,7 +8,8 @@ definitions:
       type: object
     type: array
 info:
-  description: No description.
+  description: |
+    No description.
   title: Simple
   version: 0.0.0
 paths: {}

--- a/pkg/exporter/test-data/openapi2/SWAGGER_WITH_EMPTY.yaml
+++ b/pkg/exporter/test-data/openapi2/SWAGGER_WITH_EMPTY.yaml
@@ -1,5 +1,6 @@
 info:
-  description: foo
+  description: |
+    foo
   title: foo
   version: 0.0.0
 paths:

--- a/pkg/exporter/test-data/openapi2/SWAGGER_WITH_ENUMS.yaml
+++ b/pkg/exporter/test-data/openapi2/SWAGGER_WITH_ENUMS.yaml
@@ -41,7 +41,8 @@ definitions:
       type: object
     type: array
 info:
-  description: foo
+  description: |
+    foo
   title: foo
   version: 0.0.0
 paths: {}

--- a/pkg/exporter/test-data/openapi2/SWAGGER_WITH_HEADER_VAR_OVERRIDDEN_IN_METHOD.yaml
+++ b/pkg/exporter/test-data/openapi2/SWAGGER_WITH_HEADER_VAR_OVERRIDDEN_IN_METHOD.yaml
@@ -1,6 +1,7 @@
 host: api.example.com
 info:
-  description: API description in Markdown.
+  description: |
+    API description in Markdown.
   title: Sample API
   version: 1.0.0
 paths:

--- a/pkg/exporter/test-data/openapi2/SWAGGER_WITH_PATHS_VAR_REFERRING_GLOBAL_PARAMS_OBJECT.yaml
+++ b/pkg/exporter/test-data/openapi2/SWAGGER_WITH_PATHS_VAR_REFERRING_GLOBAL_PARAMS_OBJECT.yaml
@@ -1,6 +1,7 @@
 host: api.example.com
 info:
-  description: API description in Markdown.
+  description: |
+    API description in Markdown.
   title: Sample API
   version: 1.0.0
 paths:

--- a/pkg/exporter/test-data/openapi2/SWAGGER_WITH_PATH_VAR_TYPE_IN_API.yaml
+++ b/pkg/exporter/test-data/openapi2/SWAGGER_WITH_PATH_VAR_TYPE_IN_API.yaml
@@ -1,6 +1,7 @@
 host: api.example.com
 info:
-  description: API description in Markdown.
+  description: |
+    API description in Markdown.
   title: Sample API
   version: 1.0.0
 paths:

--- a/pkg/exporter/test-data/openapi2/SWAGGER_WITH_PATH_VAR_TYPE_IN_GLOBAL_PARAMETERS.yaml
+++ b/pkg/exporter/test-data/openapi2/SWAGGER_WITH_PATH_VAR_TYPE_IN_GLOBAL_PARAMETERS.yaml
@@ -1,6 +1,7 @@
 host: api.example.com
 info:
-  description: API description in Markdown.
+  description: |
+    API description in Markdown.
   title: Sample API
   version: 1.0.0
 paths:

--- a/pkg/exporter/test-data/openapi2/SWAGGER_WITH_PATH_VAR_TYPE_OVERRIDDEN_IN_SECOND_METHOD.yaml
+++ b/pkg/exporter/test-data/openapi2/SWAGGER_WITH_PATH_VAR_TYPE_OVERRIDDEN_IN_SECOND_METHOD.yaml
@@ -1,6 +1,7 @@
 host: api.example.com
 info:
-  description: API description in Markdown.
+  description: |
+    API description in Markdown.
   title: Sample API
   version: 1.0.0
 paths:

--- a/pkg/parse/Parser_test.go
+++ b/pkg/parse/Parser_test.go
@@ -2,7 +2,9 @@ package parse
 
 import (
 	"bytes"
+	"flag"
 	"io"
+	"io/ioutil"
 	"os"
 	"path"
 	"strings"
@@ -23,6 +25,15 @@ import (
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/proto"
 )
+
+var (
+	update = flag.Bool("update", false, "Update golden test files")
+)
+
+func TestMain(m *testing.M) {
+	flag.Parse()
+	os.Exit(m.Run())
+}
 
 const mainTestDir = "../../tests/"
 
@@ -113,15 +124,6 @@ func parseComparable(
 		return nil, err
 	}
 
-	for _, app := range module.Apps {
-		for _, t := range app.Views {
-			for _, stmt := range t.GetExpr().GetTransform().GetStmt() {
-				nullifyType(stmt.GetAssign().GetExpr())
-				nullifyType(stmt.GetLet().GetExpr())
-			}
-		}
-	}
-
 	if stripSourceContext {
 		// remove stuff that does not match legacy.
 		for _, app := range module.Apps {
@@ -139,42 +141,6 @@ func parseComparable(
 		}
 	}
 	return module, nil
-}
-
-func nullifyType(expr *sysl.Expr) {
-	if expr == nil {
-		return
-	}
-
-	switch t := expr.Expr.(type) {
-	case *sysl.Expr_Literal:
-		switch t.Literal.Value.(type) {
-		case *sysl.Value_Null_, *sysl.Value_B:
-			return
-		}
-		expr.Type = nil
-	case *sysl.Expr_List_:
-		nullifyType(t.List.Expr[0])
-		expr.Type = nil
-	case *sysl.Expr_Ifelse:
-		nullifyType(t.Ifelse.GetIfTrue())
-		nullifyType(t.Ifelse.GetIfFalse())
-		expr.Type = nil
-	case *sysl.Expr_Binexpr:
-		nullifyType(t.Binexpr.GetLhs())
-		if t.Binexpr.GetOp().String() != "WHERE" {
-			nullifyType(t.Binexpr.GetRhs())
-		}
-		expr.Type = nil
-	case *sysl.Expr_Unexpr:
-		nullifyType(expr.GetUnexpr().GetArg())
-		expr.Type = nil
-	case *sysl.Expr_Transform_:
-		for _, stmt := range t.Transform.GetStmt() {
-			nullifyType(stmt.GetAssign().GetExpr())
-			nullifyType(stmt.GetLet().GetExpr())
-		}
-	}
 }
 
 func parseAndCompareSysl(
@@ -263,6 +229,25 @@ func parseAndCompareWithGolden(filename, root string, stripSourceContext bool) (
 	goldenFilename += ".golden.textpb"
 	golden := path.Join(root, goldenFilename)
 
+	if *update {
+		updated := bytes.Buffer{}
+		if !strings.HasSuffix(filename, syslExt) {
+			filename += syslExt
+		}
+		// update test files
+		mod, err := NewParser().Parse(filename, syslutil.NewChrootFs(afero.NewOsFs(), "."))
+		if err != nil {
+			return false, err
+		}
+		if err = pbutil.FTextPB(&updated, mod); err != nil {
+			return false, err
+		}
+		err = ioutil.WriteFile(goldenFilename, updated.Bytes(), 0644)
+		if err != nil {
+			return false, err
+		}
+	}
+
 	goldenModule, err := readSyslModule(golden)
 	if err != nil {
 		return false, err
@@ -271,7 +256,7 @@ func parseAndCompareWithGolden(filename, root string, stripSourceContext bool) (
 }
 
 func testParseAgainstGolden(t *testing.T, filename, root string) {
-	equal, err := parseAndCompareWithGolden(filename, root, true)
+	equal, err := parseAndCompareWithGolden(filename, root, false)
 	if assert.NoError(t, err) {
 		assert.True(t, equal, "%#v %#v", root, filename)
 	}
@@ -457,7 +442,7 @@ func TestForeignImports(t *testing.T) {
 func TestRootArgAndRelational(t *testing.T) {
 	t.Parallel()
 
-	testParseAgainstGolden(t, "school.sysl", "tests")
+	testParseAgainstGolden(t, "tests/school.sysl", "")
 }
 
 func TestSequenceType(t *testing.T) {

--- a/pkg/parse/listener_impl.go
+++ b/pkg/parse/listener_impl.go
@@ -164,7 +164,7 @@ func (s *TreeShapeListener) EnterDoc_string(ctx *parser.Doc_stringContext) {
 		return
 	}
 	s.prevLineEmpty = false
-	attrs[s.annotation].Attribute.(*sysl.Attribute_S).S += str
+	attrs[s.annotation].Attribute.(*sysl.Attribute_S).S += str + "\n"
 }
 
 // EnterTypes is called when production types is entered.

--- a/pkg/parse/tests/alias.sysl.golden.textpb
+++ b/pkg/parse/tests/alias.sysl.golden.textpb
@@ -1,186 +1,186 @@
-apps: <
+apps: {
   key: "Model"
-  value: <
-    name: <
+  value: {
+    name: {
       part: "Model"
-    >
-    types: <
+    }
+    types: {
       key: "Error"
-      value: <
+      value: {
         primitive: STRING
-        attrs: <
+        attrs: {
           key: "comment"
-          value: <
+          value: {
             s: "some description"
-          >
-        >
-        attrs: <
+          }
+        }
+        attrs: {
           key: "patterns"
-          value: <
-            a: <
-              elt: <
+          value: {
+            a: {
+              elt: {
                 s: "foo"
-              >
-            >
-          >
-        >
-        source_context: <
+              }
+            }
+          }
+        }
+        source_context: {
           file: "tests/alias.sysl"
-          start: <
+          start: {
             line: 3
             col: 2
-          >
-          end: <
+          }
+          end: {
             line: 6
             col: 2
-          >
-        >
-      >
-    >
-    types: <
+          }
+        }
+      }
+    }
+    types: {
       key: "Request"
-      value: <
-        tuple: <
-          attr_defs: <
+      value: {
+        tuple: {
+          attr_defs: {
             key: "requests"
-            value: <
+            value: {
               primitive: STRING
-              source_context: <
+              source_context: {
                 file: "tests/alias.sysl"
-                start: <
+                start: {
                   line: 7
                   col: 18
-                >
-                end: <
+                }
+                end: {
                   line: 7
                   col: 18
-                >
-              >
-            >
-          >
-        >
-        source_context: <
+                }
+              }
+            }
+          }
+        }
+        source_context: {
           file: "tests/alias.sysl"
-          start: <
+          start: {
             line: 6
             col: 2
-          >
-          end: <
+          }
+          end: {
             line: 9
             col: 2
-          >
-        >
-      >
-    >
-    types: <
+          }
+        }
+      }
+    }
+    types: {
       key: "Response"
-      value: <
-        tuple: <
-          attr_defs: <
+      value: {
+        tuple: {
+          attr_defs: {
             key: "error"
-            value: <
-              type_ref: <
-                context: <
-                  appname: <
+            value: {
+              type_ref: {
+                context: {
+                  appname: {
                     part: "Model"
-                  >
+                  }
                   path: "Response"
-                >
-                ref: <
+                }
+                ref: {
                   path: "Error"
-                >
-              >
-              source_context: <
+                }
+              }
+              source_context: {
                 file: "tests/alias.sysl"
-                start: <
+                start: {
                   line: 10
                   col: 15
-                >
-                end: <
+                }
+                end: {
                   line: 10
                   col: 15
-                >
-              >
-            >
-          >
-          attr_defs: <
+                }
+              }
+            }
+          }
+          attr_defs: {
             key: "response"
-            value: <
+            value: {
               primitive: STRING
-              source_context: <
+              source_context: {
                 file: "tests/alias.sysl"
-                start: <
+                start: {
                   line: 11
                   col: 18
-                >
-                end: <
+                }
+                end: {
                   line: 11
                   col: 18
-                >
-              >
-            >
-          >
-        >
-        source_context: <
+                }
+              }
+            }
+          }
+        }
+        source_context: {
           file: "tests/alias.sysl"
-          start: <
+          start: {
             line: 9
             col: 2
-          >
-          end: <
+          }
+          end: {
             line: 13
             col: 2
-          >
-        >
-      >
-    >
-    types: <
+          }
+        }
+      }
+    }
+    types: {
       key: "Terms"
-      value: <
-        sequence: <
-          type_ref: <
-            context: <
-              appname: <
+      value: {
+        sequence: {
+          type_ref: {
+            context: {
+              appname: {
                 part: "Model"
-              >
+              }
               path: "Terms"
-            >
-            ref: <
+            }
+            ref: {
               path: "Term"
-            >
-          >
-          source_context: <
+            }
+          }
+          source_context: {
             file: "tests/alias.sysl"
-            start: <
+            start: {
               line: 13
               col: 2
-            >
-            end: <
+            }
+            end: {
               line: 15
-            >
-          >
-        >
-        source_context: <
+            }
+          }
+        }
+        source_context: {
           file: "tests/alias.sysl"
-          start: <
+          start: {
             line: 13
             col: 2
-          >
-          end: <
+          }
+          end: {
             line: 15
-          >
-        >
-      >
-    >
-    source_context: <
+          }
+        }
+      }
+    }
+    source_context: {
       file: "tests/alias.sysl"
-      start: <
+      start: {
         line: 1
         col: 1
-      >
-      end: <
+      }
+      end: {
         line: 1
-      >
-    >
-  >
->
+      }
+    }
+  }
+}

--- a/pkg/parse/tests/alias_inline.sysl.golden.textpb
+++ b/pkg/parse/tests/alias_inline.sysl.golden.textpb
@@ -1,14 +1,35 @@
-apps: <
- key: "Model"
- value: <
-   name: <
-     part: "Model"
-   >
-   types: <
-     key: "FooBar"
-     value: <
-       primitive: STRING
-     >
-   >
- >
->
+apps: {
+  key: "Model"
+  value: {
+    name: {
+      part: "Model"
+    }
+    types: {
+      key: "FooBar"
+      value: {
+        primitive: STRING
+        source_context: {
+          file: "tests/alias_inline.sysl"
+          start: {
+            line: 2
+            col: 4
+          }
+          end: {
+            line: 2
+            col: 20
+          }
+        }
+      }
+    }
+    source_context: {
+      file: "tests/alias_inline.sysl"
+      start: {
+        line: 1
+        col: 1
+      }
+      end: {
+        line: 1
+      }
+    }
+  }
+}

--- a/pkg/parse/tests/args.sysl.golden.textpb
+++ b/pkg/parse/tests/args.sysl.golden.textpb
@@ -1,224 +1,224 @@
-apps: <
+apps: {
   key: "Client"
-  value: <
-    name: <
+  value: {
+    name: {
       part: "Client"
-    >
-    endpoints: <
+    }
+    endpoints: {
       key: "OnClick"
-      value: <
+      value: {
         name: "OnClick"
-        param: <
+        param: {
           name: "arg1"
-          type: <
-            type_ref: <
-              ref: <
-                appname: <
+          type: {
+            type_ref: {
+              ref: {
+                appname: {
                   part: "type1"
-                >
-              >
-            >
-          >
-        >
-        param: <
+                }
+              }
+            }
+          }
+        }
+        param: {
           name: "arg2"
-          type: <
-            type_ref: <
-              ref: <
-                appname: <
+          type: {
+            type_ref: {
+              ref: {
+                appname: {
                   part: "type2"
-                >
-              >
-            >
-          >
-        >
-        stmt: <
-          call: <
-            target: <
+                }
+              }
+            }
+          }
+        }
+        stmt: {
+          call: {
+            target: {
               part: "Server"
-            >
+            }
             endpoint: "Endpoint"
-            arg: <
+            arg: {
               name: "id"
-            >
-          >
-          attrs: <
+            }
+          }
+          attrs: {
             key: "patterns"
-            value: <
-              a: <
-                elt: <
+            value: {
+              a: {
+                elt: {
                   s: "https"
-                >
-                elt: <
+                }
+                elt: {
                   s: "soap"
-                >
-              >
-            >
-          >
-        >
-        stmt: <
-          call: <
-            target: <
+                }
+              }
+            }
+          }
+        }
+        stmt: {
+          call: {
+            target: {
               part: "Server"
-            >
+            }
             endpoint: "PUT /foo/"
-          >
-        >
-        stmt: <
-          call: <
-            target: <
+          }
+        }
+        stmt: {
+          call: {
+            target: {
               part: "Server"
-            >
+            }
             endpoint: "PUT /foo"
-            arg: <
+            arg: {
               name: "bar"
-            >
-          >
-        >
-        stmt: <
-          call: <
-            target: <
+            }
+          }
+        }
+        stmt: {
+          call: {
+            target: {
               part: "Server"
-            >
+            }
             endpoint: "PUT /foo"
-            arg: <
+            arg: {
               name: "bar <: String"
-            >
-          >
-        >
-        source_context: <
+            }
+          }
+        }
+        source_context: {
           file: "tests/args.sysl"
-          start: <
+          start: {
             line: 12
             col: 4
-          >
-          end: <
+          }
+          end: {
             line: 17
-          >
-        >
-      >
-    >
-    source_context: <
+          }
+        }
+      }
+    }
+    source_context: {
       file: "tests/args.sysl"
-      start: <
+      start: {
         line: 11
         col: 1
-      >
-      end: <
+      }
+      end: {
         line: 11
-      >
-    >
-  >
->
-apps: <
+      }
+    }
+  }
+}
+apps: {
   key: "Server"
-  value: <
-    name: <
+  value: {
+    name: {
       part: "Server"
-    >
-    endpoints: <
+    }
+    endpoints: {
       key: "Endpoint"
-      value: <
+      value: {
         name: "Endpoint"
-        stmt: <
-          action: <
+        stmt: {
+          action: {
             action: "..."
-          >
-        >
-        source_context: <
+          }
+        }
+        source_context: {
           file: "tests/args.sysl"
-          start: <
+          start: {
             line: 2
             col: 4
-          >
-          end: <
+          }
+          end: {
             line: 5
             col: 4
-          >
-        >
-      >
-    >
-    endpoints: <
+          }
+        }
+      }
+    }
+    endpoints: {
       key: "PUT /foo"
-      value: <
+      value: {
         name: "PUT /foo"
-        attrs: <
+        attrs: {
           key: "patterns"
-          value: <
-            a: <
-              elt: <
+          value: {
+            a: {
+              elt: {
                 s: "rest"
-              >
-            >
-          >
-        >
-        stmt: <
-          action: <
+              }
+            }
+          }
+        }
+        stmt: {
+          action: {
             action: "..."
-          >
-        >
-        rest_params: <
+          }
+        }
+        rest_params: {
           method: PUT
           path: "/foo"
-        >
-        source_context: <
+        }
+        source_context: {
           file: "tests/args.sysl"
-          start: <
+          start: {
             line: 6
             col: 8
-          >
-          end: <
+          }
+          end: {
             line: 8
             col: 8
-          >
-        >
-      >
-    >
-    endpoints: <
+          }
+        }
+      }
+    }
+    endpoints: {
       key: "PUT /foo/"
-      value: <
+      value: {
         name: "PUT /foo/"
-        attrs: <
+        attrs: {
           key: "patterns"
-          value: <
-            a: <
-              elt: <
+          value: {
+            a: {
+              elt: {
                 s: "rest"
-              >
-            >
-          >
-        >
-        stmt: <
-          action: <
+              }
+            }
+          }
+        }
+        stmt: {
+          action: {
             action: "..."
-          >
-        >
-        rest_params: <
+          }
+        }
+        rest_params: {
           method: PUT
           path: "/foo/"
-        >
-        source_context: <
+        }
+        source_context: {
           file: "tests/args.sysl"
-          start: <
+          start: {
             line: 9
             col: 12
-          >
-          end: <
+          }
+          end: {
             line: 11
             col: 6
-          >
-        >
-      >
-    >
-    source_context: <
+          }
+        }
+      }
+    }
+    source_context: {
       file: "tests/args.sysl"
-      start: <
+      start: {
         line: 1
         col: 1
-      >
-      end: <
+      }
+      end: {
         line: 1
-      >
-    >
-  >
->
+      }
+    }
+  }
+}

--- a/pkg/parse/tests/attribs.sysl.golden.textpb
+++ b/pkg/parse/tests/attribs.sysl.golden.textpb
@@ -1,29 +1,29 @@
-apps {
+apps: {
   key: "App"
-  value {
-    name {
+  value: {
+    name: {
       part: "App"
     }
-    attrs {
+    attrs: {
       key: "blackbox"
-      value {
-        a {
-          elt {
-            a {
-              elt {
+      value: {
+        a: {
+          elt: {
+            a: {
+              elt: {
                 s: "one"
               }
-              elt {
+              elt: {
                 s: "two"
               }
             }
           }
-          elt {
-            a {
-              elt {
+          elt: {
+            a: {
+              elt: {
                 s: "one"
               }
-              elt {
+              elt: {
                 s: "two"
               }
             }
@@ -31,15 +31,36 @@ apps {
         }
       }
     }
-    endpoints {
+    endpoints: {
       key: "Endpoint"
-      value {
+      value: {
         name: "Endpoint"
-        stmt {
-          action {
+        stmt: {
+          action: {
             action: "..."
           }
         }
+        source_context: {
+          file: "tests/attribs.sysl"
+          start: {
+            line: 2
+            col: 4
+          }
+          end: {
+            line: 4
+          }
+        }
+      }
+    }
+    source_context: {
+      file: "tests/attribs.sysl"
+      start: {
+        line: 1
+        col: 1
+      }
+      end: {
+        line: 1
+        col: 46
       }
     }
   }

--- a/pkg/parse/tests/bad_order.sysl.golden.textpb
+++ b/pkg/parse/tests/bad_order.sysl.golden.textpb
@@ -1,204 +1,204 @@
-apps: <
+apps: {
   key: "Server"
-  value: <
-    name: <
+  value: {
+    name: {
       part: "Server"
-    >
-    attrs: <
+    }
+    attrs: {
       key: "patterns"
-      value: <
-        a: <
-          elt: <
+      value: {
+        a: {
+          elt: {
             s: "rest"
-          >
-        >
-      >
-    >
-    endpoints: <
+          }
+        }
+      }
+    }
+    endpoints: {
       key: "GET /{id}"
-      value: <
+      value: {
         name: "GET /{id}"
-        attrs: <
+        attrs: {
           key: "patterns"
-          value: <
-            a: <
-              elt: <
+          value: {
+            a: {
+              elt: {
                 s: "rest"
-              >
-            >
-          >
-        >
-        stmt: <
-          action: <
+              }
+            }
+          }
+        }
+        stmt: {
+          action: {
             action: "..."
-          >
-        >
-        rest_params: <
+          }
+        }
+        rest_params: {
           method: GET
           path: "/{id}"
-          query_param: <
+          query_param: {
             name: "depth"
-            type: <
+            type: {
               primitive: INT
-              source_context: <
+              source_context: {
                 file: "tests/bad_order.sysl"
-                start: <
+                start: {
                   line: 3
                   col: 13
-                >
-                end: <
+                }
+                end: {
                   line: 3
                   col: 19
-                >
-              >
-            >
-          >
-          query_param: <
+                }
+              }
+            }
+          }
+          query_param: {
             name: "limit"
-            type: <
+            type: {
               primitive: INT
               opt: true
-              source_context: <
+              source_context: {
                 file: "tests/bad_order.sysl"
-                start: <
+                start: {
                   line: 3
                   col: 23
-                >
-                end: <
+                }
+                end: {
                   line: 3
                   col: 32
-                >
-              >
-            >
-          >
-          query_param: <
+                }
+              }
+            }
+          }
+          query_param: {
             name: "offset"
-            type: <
+            type: {
               primitive: INT
               opt: true
-              source_context: <
+              source_context: {
                 file: "tests/bad_order.sysl"
-                start: <
+                start: {
                   line: 3
                   col: 34
-                >
-                end: <
+                }
+                end: {
                   line: 3
                   col: 44
-                >
-              >
-            >
-          >
-          url_param: <
+                }
+              }
+            }
+          }
+          url_param: {
             name: "id"
-            type: <
+            type: {
               primitive: INT
-              source_context: <
+              source_context: {
                 file: "tests/bad_order.sysl"
-                start: <
+                start: {
                   line: 2
                   col: 5
-                >
-                end: <
+                }
+                end: {
                   line: 2
                   col: 13
-                >
-              >
-            >
-          >
-        >
-        source_context: <
+                }
+              }
+            }
+          }
+        }
+        source_context: {
           file: "tests/bad_order.sysl"
-          start: <
+          start: {
             line: 3
             col: 8
-          >
-          end: <
+          }
+          end: {
             line: 6
             col: 8
-          >
-        >
-      >
-    >
-    endpoints: <
+          }
+        }
+      }
+    }
+    endpoints: {
       key: "POST /{id}/third/{a-bc}"
-      value: <
+      value: {
         name: "POST /{id}/third/{a-bc}"
-        attrs: <
+        attrs: {
           key: "patterns"
-          value: <
-            a: <
-              elt: <
+          value: {
+            a: {
+              elt: {
                 s: "rest"
-              >
-            >
-          >
-        >
-        stmt: <
-          action: <
+              }
+            }
+          }
+        }
+        stmt: {
+          action: {
             action: "..."
-          >
-        >
-        rest_params: <
+          }
+        }
+        rest_params: {
           method: POST
           path: "/{id}/third/{a-bc}"
-          url_param: <
+          url_param: {
             name: "id"
-            type: <
+            type: {
               primitive: INT
-              source_context: <
+              source_context: {
                 file: "tests/bad_order.sysl"
-                start: <
+                start: {
                   line: 2
                   col: 5
-                >
-                end: <
+                }
+                end: {
                   line: 2
                   col: 13
-                >
-              >
-            >
-          >
-          url_param: <
+                }
+              }
+            }
+          }
+          url_param: {
             name: "a-bc"
-            type: <
+            type: {
               primitive: INT
-              source_context: <
+              source_context: {
                 file: "tests/bad_order.sysl"
-                start: <
+                start: {
                   line: 6
                   col: 15
-                >
-                end: <
+                }
+                end: {
                   line: 6
                   col: 25
-                >
-              >
-            >
-          >
-        >
-        source_context: <
+                }
+              }
+            }
+          }
+        }
+        source_context: {
           file: "tests/bad_order.sysl"
-          start: <
+          start: {
             line: 7
             col: 12
-          >
-          end: <
+          }
+          end: {
             line: 9
-          >
-        >
-      >
-    >
-    source_context: <
+          }
+        }
+      }
+    }
+    source_context: {
       file: "tests/bad_order.sysl"
-      start: <
+      start: {
         line: 1
         col: 1
-      >
-      end: <
+      }
+      end: {
         line: 1
         col: 13
-      >
-    >
-  >
->
+      }
+    }
+  }
+}

--- a/pkg/parse/tests/collector.sysl.golden.textpb
+++ b/pkg/parse/tests/collector.sysl.golden.textpb
@@ -1,144 +1,154 @@
-apps {
+apps: {
   key: "App"
-  value {
-    name {
+  value: {
+    name: {
       part: "App"
     }
-    endpoints {
+    endpoints: {
       key: ".. * <- *"
-      value {
+      value: {
         name: ".. * <- *"
-        stmt {
-          action {
+        stmt: {
+          action: {
             action: "Endpoint_One"
           }
-          attrs {
+          attrs: {
             key: "id"
-            value {
+            value: {
               s: "one"
             }
           }
         }
-        stmt {
-          action {
+        stmt: {
+          action: {
             action: "Endpoint_Two"
           }
-          attrs {
+          attrs: {
             key: "id"
-            value {
+            value: {
               s: "two"
             }
           }
         }
-        stmt {
-          call {
-            target {
+        stmt: {
+          call: {
+            target: {
               part: "My"
               part: "Server"
             }
             endpoint: "Endpoint_One"
           }
-          attrs {
+          attrs: {
             key: "id"
-            value {
+            value: {
               s: "three"
             }
           }
         }
-        stmt {
-          call {
-            target {
+        stmt: {
+          call: {
+            target: {
               part: "My"
               part: "Server"
             }
             endpoint: "Endpoint_Two"
           }
-          attrs {
+          attrs: {
             key: "id"
-            value {
+            value: {
               s: "four"
             }
           }
         }
-        stmt {
-          call {
-            target {
+        stmt: {
+          call: {
+            target: {
               part: "My"
               part: "Server"
             }
             endpoint: "Endpoint_Two"
           }
-          attrs {
+          attrs: {
             key: "id"
-            value {
+            value: {
               s: "final"
             }
           }
         }
-        stmt {
-          call {
-            target {
+        stmt: {
+          call: {
+            target: {
               part: "My"
               part: "Server"
             }
             endpoint: "Endpoint_Three"
           }
-          attrs {
+          attrs: {
             key: "id"
-            value {
+            value: {
               s: "final"
             }
           }
         }
+        source_context: {
+          file: "tests/collector.sysl"
+          start: {
+            line: 30
+            col: 4
+          }
+          end: {
+            line: 37
+          }
+        }
       }
     }
-    endpoints {
+    endpoints: {
       key: "Endpoint_One"
-      value {
+      value: {
         name: "Endpoint_One"
-        attrs {
+        attrs: {
           key: "id"
-          value {
+          value: {
             s: "one"
           }
         }
-        stmt {
-          call {
-            target {
+        stmt: {
+          call: {
+            target: {
               part: "My"
               part: "Server"
             }
             endpoint: "Endpoint_One"
           }
-          attrs {
+          attrs: {
             key: "id"
-            value {
+            value: {
               s: "three"
             }
           }
         }
-        stmt {
-          cond {
+        stmt: {
+          cond: {
             test: "result not ok"
-            stmt {
-              call {
-                target {
+            stmt: {
+              call: {
+                target: {
                   part: "My"
                   part: "Server"
                 }
                 endpoint: "Endpoint_Two"
               }
-              attrs {
+              attrs: {
                 key: "id"
-                value {
+                value: {
                   s: "final"
                 }
               }
-              attrs {
+              attrs: {
                 key: "patterns"
-                value {
-                  a {
-                    elt {
+                value: {
+                  a: {
+                    elt: {
                       s: "https"
                     }
                   }
@@ -147,96 +157,107 @@ apps {
             }
           }
         }
-        stmt {
-          group {
+        stmt: {
+          group: {
             title: "loop"
-            stmt {
-              call {
-                target {
+            stmt: {
+              call: {
+                target: {
                   part: "My"
                   part: "Server"
                 }
                 endpoint: "Endpoint_Two"
               }
-              attrs {
+              attrs: {
                 key: "id"
-                value {
+                value: {
                   s: "final"
                 }
               }
-              attrs {
+              attrs: {
                 key: "patterns"
-                value {
-                  a {
-                    elt {
+                value: {
+                  a: {
+                    elt: {
                       s: "https"
                     }
                   }
                 }
               }
             }
+          }
+        }
+        source_context: {
+          file: "tests/collector.sysl"
+          start: {
+            line: 13
+            col: 4
+          }
+          end: {
+            line: 21
+            col: 4
           }
         }
       }
     }
-    endpoints {
+    endpoints: {
       key: "Endpoint_Two"
-      value {
+      value: {
         name: "Endpoint_Two"
-        attrs {
+        attrs: {
           key: "id"
-          value {
+          value: {
             s: "two"
           }
         }
-        stmt {
-          call {
-            target {
+        stmt: {
+          call: {
+            target: {
               part: "My"
               part: "Server"
             }
             endpoint: "Endpoint_Two"
           }
-          attrs {
+          attrs: {
             key: "id"
-            value {
+            value: {
               s: "final"
             }
           }
-          attrs {
+          attrs: {
             key: "patterns"
-            value {
-              a {
-                elt {
+            value: {
+              a: {
+                elt: {
                   s: "https"
                 }
               }
             }
           }
         }
-        stmt {
-          alt {
-            choice {
+        stmt: {
+          alt: {
+            choice: {
               cond: "condition = one"
-              stmt {
-                call {
-                  target {
+              stmt: {
+                call: {
+                  target: {
                     part: "My"
                     part: "Server"
                   }
                   endpoint: "Endpoint_Three"
                 }
-                attrs {
+                attrs: {
                   key: "id"
-                  value {
+                  value: {
                     s: "final"
                   }
                 }
-                attrs {
+                attrs: {
                   key: "patterns"
-                  value {
-                    a {
-                      elt {
+                  value: {
+                    a: {
+                      elt: {
                         s: "https"
                       }
                     }
@@ -244,27 +265,27 @@ apps {
                 }
               }
             }
-            choice {
+            choice: {
               cond: "condition two"
-              stmt {
-                call {
-                  target {
+              stmt: {
+                call: {
+                  target: {
                     part: "My"
                     part: "Server"
                   }
                   endpoint: "Endpoint_Three"
                 }
-                attrs {
+                attrs: {
                   key: "id"
-                  value {
+                  value: {
                     s: "final"
                   }
                 }
-                attrs {
+                attrs: {
                   key: "patterns"
-                  value {
-                    a {
-                      elt {
+                  value: {
+                    a: {
+                      elt: {
                         s: "https"
                       }
                     }
@@ -272,60 +293,125 @@ apps {
                 }
               }
             }
+          }
+        }
+        source_context: {
+          file: "tests/collector.sysl"
+          start: {
+            line: 21
+            col: 4
+          }
+          end: {
+            line: 29
+            col: 3
           }
         }
       }
     }
+    source_context: {
+      file: "tests/collector.sysl"
+      start: {
+        line: 29
+        col: 1
+      }
+      end: {
+        line: 29
+      }
+    }
   }
 }
-apps {
+apps: {
   key: "My :: Server"
-  value {
-    name {
+  value: {
+    name: {
       part: "My"
       part: "Server"
     }
-    endpoints {
+    endpoints: {
       key: "Endpoint_One"
-      value {
+      value: {
         name: "Endpoint_One"
-        stmt {
-          action {
+        stmt: {
+          action: {
             action: "process request"
           }
         }
-        stmt {
-          cond {
+        stmt: {
+          cond: {
             test: "result ok"
-            stmt {
-              action {
+            stmt: {
+              action: {
                 action: "do further processing"
               }
             }
           }
         }
+        source_context: {
+          file: "tests/collector.sysl"
+          start: {
+            line: 2
+            col: 4
+          }
+          end: {
+            line: 7
+            col: 4
+          }
+        }
       }
     }
-    endpoints {
+    endpoints: {
       key: "Endpoint_Three"
-      value {
+      value: {
         name: "Endpoint_Three"
-        stmt {
-          action {
+        stmt: {
+          action: {
             action: "process request"
+          }
+        }
+        source_context: {
+          file: "tests/collector.sysl"
+          start: {
+            line: 10
+            col: 4
+          }
+          end: {
+            line: 12
+            col: 3
           }
         }
       }
     }
-    endpoints {
+    endpoints: {
       key: "Endpoint_Two"
-      value {
+      value: {
         name: "Endpoint_Two"
-        stmt {
-          action {
+        stmt: {
+          action: {
             action: "process request"
           }
         }
+        source_context: {
+          file: "tests/collector.sysl"
+          start: {
+            line: 7
+            col: 4
+          }
+          end: {
+            line: 10
+            col: 4
+          }
+        }
+      }
+    }
+    source_context: {
+      file: "tests/collector.sysl"
+      start: {
+        line: 1
+        col: 1
+      }
+      end: {
+        line: 1
+        col: 6
       }
     }
   }

--- a/pkg/parse/tests/crash.sysl.golden.textpb
+++ b/pkg/parse/tests/crash.sysl.golden.textpb
@@ -1,50 +1,92 @@
-apps {
+apps: {
   key: "Desktop"
-  value {
-    name {
+  value: {
+    name: {
       part: "Desktop"
     }
-    endpoints {
+    endpoints: {
       key: "Customer"
-      value {
+      value: {
         name: "Customer"
-        stmt {
-          action {
+        stmt: {
+          action: {
             action: "call foo"
+          }
+        }
+        source_context: {
+          file: "tests/crash.sysl"
+          start: {
+            line: 3
+            col: 4
+          }
+          end: {
+            line: 6
+            col: 4
           }
         }
       }
     }
-    endpoints {
+    endpoints: {
       key: "Endpoint"
-      value {
+      value: {
         name: "Endpoint"
-        attrs {
+        attrs: {
           key: "patterns"
-          value {
-            a {
-              elt {
+          value: {
+            a: {
+              elt: {
                 s: "button"
               }
             }
           }
         }
-        stmt {
-          action {
+        stmt: {
+          action: {
             action: "call foo"
+          }
+        }
+        source_context: {
+          file: "tests/crash.sysl"
+          start: {
+            line: 9
+            col: 4
+          }
+          end: {
+            line: 12
           }
         }
       }
     }
-    endpoints {
+    endpoints: {
       key: "Financial"
-      value {
+      value: {
         name: "Financial"
-        stmt {
-          action {
+        stmt: {
+          action: {
             action: "..."
           }
         }
+        source_context: {
+          file: "tests/crash.sysl"
+          start: {
+            line: 6
+            col: 4
+          }
+          end: {
+            line: 9
+            col: 4
+          }
+        }
+      }
+    }
+    source_context: {
+      file: "tests/crash.sysl"
+      start: {
+        line: 1
+        col: 1
+      }
+      end: {
+        line: 1
       }
     }
   }

--- a/pkg/parse/tests/docstrings.sysl.golden.textpb
+++ b/pkg/parse/tests/docstrings.sysl.golden.textpb
@@ -1,155 +1,259 @@
-apps: <
+apps: {
   key: "Another App"
-  value: <
-    name: <
+  value: {
+    name: {
       part: "Another App"
-    >
-    endpoints: <
+    }
+    endpoints: {
       key: "Endpoint"
-      value: <
+      value: {
         name: "Endpoint"
-        attrs: <
+        attrs: {
           key: "description"
-          value: <
-            s: "multi-line documentation comment use it for long comments"
-          >
-        >
-        stmt: <
-          action: <
+          value: {
+            s: "multi-line documentation comment\n use it for long comments\n"
+          }
+        }
+        stmt: {
+          action: {
             action: "..."
-          >
-        >
-      >
-    >
-  >
->
-apps: <
+          }
+        }
+        source_context: {
+          file: "tests/docstrings.sysl"
+          start: {
+            line: 8
+            col: 4
+          }
+          end: {
+            line: 14
+            col: 15
+          }
+        }
+      }
+    }
+    source_context: {
+      file: "tests/docstrings.sysl"
+      start: {
+        line: 7
+        col: 1
+      }
+      end: {
+        line: 7
+      }
+    }
+  }
+}
+apps: {
   key: "App"
-  value: <
-    name: <
+  value: {
+    name: {
       part: "App"
-    >
-    attrs: <
+    }
+    attrs: {
       key: "description"
-      value: <
-        s: "multi-line documentation comment use it for long comments"
-      >
-    >
-    endpoints: <
+      value: {
+        s: "multi-line documentation comment\n use it for long comments\n"
+      }
+    }
+    endpoints: {
       key: "..."
-      value: <
+      value: {
         name: "..."
-      >
-    >
-  >
->
-apps: <
+      }
+    }
+    source_context: {
+      file: "tests/docstrings.sysl"
+      start: {
+        line: 1
+        col: 1
+      }
+      end: {
+        line: 1
+      }
+    }
+  }
+}
+apps: {
   key: "Model"
-  value: <
-    name: <
+  value: {
+    name: {
       part: "Model"
-    >
-    types: <
+    }
+    types: {
       key: "TableName"
-      value: <
-        attrs: <
+      value: {
+        attrs: {
           key: "description"
-          value: <
-            s: "multi-line documentation comment use it for long comments"
-          >
-        >
-      >
-    >
-  >
->
-apps: <
+          value: {
+            s: "multi-line documentation comment\n use it for long comments\n"
+          }
+        }
+        source_context: {
+          file: "tests/docstrings.sysl"
+          start: {
+            line: 25
+            col: 4
+          }
+          end: {
+            line: 30
+            col: 8
+          }
+        }
+      }
+    }
+    source_context: {
+      file: "tests/docstrings.sysl"
+      start: {
+        line: 23
+        col: 1
+      }
+      end: {
+        line: 23
+      }
+    }
+  }
+}
+apps: {
   key: "ModelTwo"
-  value: <
-    name: <
+  value: {
+    name: {
       part: "ModelTwo"
-    >
-    types: <
+    }
+    types: {
       key: "TableName"
-      value: <
-        tuple: <
-          attr_defs: <
+      value: {
+        tuple: {
+          attr_defs: {
             key: "field"
-            value: <
+            value: {
               primitive: STRING
-              attrs: <
+              attrs: {
                 key: "description"
-                value: <
-                  s: "multi-line documentation comment use it for long comments"
-                >
-              >
-              source_context: <
+                value: {
+                  s: "multi-line documentation comment\n use it for long comments\n"
+                }
+              }
+              source_context: {
                 file: "tests/docstrings.sysl"
-                start: <
+                start: {
                   line: 33
                   col: 17
-                >
-                end: <
+                }
+                end: {
                   line: 36
                   col: 8
-                >
-              >
-            >
-          >
-          attr_defs: <
+                }
+              }
+            }
+          }
+          attr_defs: {
             key: "field2"
-            value: <
+            value: {
               primitive: STRING
               docstring: "short description here"
-              source_context: <
+              source_context: {
                 file: "tests/docstrings.sysl"
-                start: <
+                start: {
                   line: 36
                   col: 18
-                >
-                end: <
+                }
+                end: {
                   line: 36
                   col: 18
-                >
-              >
-            >
-          >
-        >
-      >
-    >
-  >
->
-apps: <
+                }
+              }
+            }
+          }
+        }
+        source_context: {
+          file: "tests/docstrings.sysl"
+          start: {
+            line: 31
+            col: 4
+          }
+          end: {
+            line: 37
+          }
+        }
+      }
+    }
+    source_context: {
+      file: "tests/docstrings.sysl"
+      start: {
+        line: 30
+        col: 1
+      }
+      end: {
+        line: 30
+      }
+    }
+  }
+}
+apps: {
   key: "Yet Another App"
-  value: <
-    name: <
+  value: {
+    name: {
       part: "Yet Another App"
-    >
-    endpoints: <
+    }
+    endpoints: {
       key: "AnotherEndpoint"
-      value: <
+      value: {
         name: "AnotherEndpoint"
-        stmt: <
-          action: <
+        stmt: {
+          action: {
             action: "| a multi line text statement use it to well"
-          >
-        >
-        stmt: <
-          action: <
+          }
+        }
+        stmt: {
+          action: {
             action: "another text statement"
-          >
-        >
-      >
-    >
-    endpoints: <
+          }
+        }
+        source_context: {
+          file: "tests/docstrings.sysl"
+          start: {
+            line: 18
+            col: 4
+          }
+          end: {
+            line: 23
+            col: 5
+          }
+        }
+      }
+    }
+    endpoints: {
       key: "Endpoint"
-      value: <
+      value: {
         name: "Endpoint"
-        stmt: <
-          action: <
+        stmt: {
+          action: {
             action: "a simple text statement"
-          >
-        >
-      >
-    >
-  >
->
+          }
+        }
+        source_context: {
+          file: "tests/docstrings.sysl"
+          start: {
+            line: 15
+            col: 4
+          }
+          end: {
+            line: 18
+            col: 4
+          }
+        }
+      }
+    }
+    source_context: {
+      file: "tests/docstrings.sysl"
+      start: {
+        line: 14
+        col: 1
+      }
+      end: {
+        line: 14
+      }
+    }
+  }
+}

--- a/pkg/parse/tests/duplicate.sysl.golden.textpb
+++ b/pkg/parse/tests/duplicate.sysl.golden.textpb
@@ -1,145 +1,207 @@
-apps {
+apps: {
   key: "App"
-  value {
-    name {
+  value: {
+    name: {
       part: "App"
     }
-    attrs {
+    attrs: {
       key: "iso_ctrl_118_txt"
-      value {
+      value: {
         s: ""
       }
     }
-    endpoints {
+    endpoints: {
       key: "Foo"
-      value {
+      value: {
         name: "Foo"
-        stmt {
-          action {
+        stmt: {
+          action: {
             action: "text statement"
           }
         }
-        stmt {
-          call {
-            target {
+        stmt: {
+          call: {
+            target: {
               part: "Server"
             }
             endpoint: "GET /first"
           }
         }
-        stmt {
-          ret {
+        stmt: {
+          ret: {
             payload: "ok"
+          }
+        }
+        source_context: {
+          file: "tests/duplicate.sysl"
+          start: {
+            line: 10
+            col: 4
+          }
+          end: {
+            line: 14
+            col: 6
           }
         }
       }
     }
-    endpoints {
+    endpoints: {
       key: "endpoint"
-      value {
+      value: {
         name: "endpoint"
-        attrs {
+        attrs: {
           key: "patterns"
-          value {
-            a {
-              elt {
+          value: {
+            a: {
+              elt: {
                 s: "foo"
               }
-              elt {
+              elt: {
                 s: "foo"
               }
-              elt {
+              elt: {
                 s: "bar"
               }
             }
           }
         }
-        attrs {
+        attrs: {
           key: "version"
-          value {
+          value: {
             s: "1.1"
           }
         }
+        source_context: {
+          file: "tests/duplicate.sysl"
+          start: {
+            line: 6
+            col: 4
+          }
+          end: {
+            line: 6
+            col: 21
+          }
+        }
+      }
+    }
+    source_context: {
+      file: "tests/duplicate.sysl"
+      start: {
+        line: 1
+        col: 1
+      }
+      end: {
+        line: 1
       }
     }
   }
 }
-apps {
+apps: {
   key: "FooApp"
-  value {
-    name {
+  value: {
+    name: {
       part: "FooApp"
     }
-    attrs {
+    attrs: {
       key: "patterns"
-      value {
-        a {
-          elt {
+      value: {
+        a: {
+          elt: {
             s: "foo"
           }
-          elt {
+          elt: {
             s: "foo"
           }
         }
       }
     }
-    endpoints {
+    endpoints: {
       key: "..."
-      value {
+      value: {
         name: "..."
+      }
+    }
+    source_context: {
+      file: "tests/duplicate.sysl"
+      start: {
+        line: 27
+        col: 1
+      }
+      end: {
+        line: 27
+        col: 12
       }
     }
   }
 }
-apps {
+apps: {
   key: "Server"
-  value {
-    name {
+  value: {
+    name: {
       part: "Server"
     }
-    endpoints {
+    endpoints: {
       key: "GET /first"
-      value {
+      value: {
         name: "GET /first"
-        attrs {
+        attrs: {
           key: "patterns"
-          value {
-            a {
-              elt {
+          value: {
+            a: {
+              elt: {
                 s: "rest"
               }
-              elt {
+              elt: {
                 s: "rest"
               }
             }
           }
         }
-        stmt {
-          ret {
+        param: {}
+        param: {}
+        stmt: {
+          ret: {
             payload: "200 ok"
           }
         }
-        stmt {
-          call {
-            target {
+        stmt: {
+          call: {
+            target: {
               part: "App"
             }
             endpoint: "endpoint"
           }
         }
-        stmt {
-          ret {
+        stmt: {
+          ret: {
             payload: "200 ok"
           }
         }
-        rest_params {
+        rest_params: {
           method: GET
           path: "/first"
         }
-        param {
+        source_context: {
+          file: "tests/duplicate.sysl"
+          start: {
+            line: 20
+            col: 8
+          }
+          end: {
+            line: 24
+            col: 6
+          }
         }
-        param {
-        }
+      }
+    }
+    source_context: {
+      file: "tests/duplicate.sysl"
+      start: {
+        line: 14
+        col: 1
+      }
+      end: {
+        line: 14
       }
     }
   }

--- a/pkg/parse/tests/endpoints.sysl.golden.textpb
+++ b/pkg/parse/tests/endpoints.sysl.golden.textpb
@@ -1,266 +1,352 @@
-apps: <
+apps: {
   key: "App"
-  value: <
-    name: <
+  value: {
+    name: {
       part: "App"
-    >
-    endpoints: <
+    }
+    endpoints: {
       key: ".. * <- *"
-      value: <
+      value: {
         name: ".. * <- *"
-        stmt: <
-          action: <
+        stmt: {
+          action: {
             action: "POST /more/stuff.endpoint/{id}"
-          >
-          attrs: <
+          }
+          attrs: {
             key: "id"
-            value: <
+            value: {
               s: "one"
-            >
-          >
-        >
-        stmt: <
-          call: <
-            target: <
+            }
+          }
+        }
+        stmt: {
+          call: {
+            target: {
               part: "App"
-            >
+            }
             endpoint: "GET /serve.html"
-          >
-          attrs: <
+          }
+          attrs: {
             key: "id"
-            value: <
+            value: {
               s: "doesn't matter"
-            >
-          >
-        >
-        stmt: <
-          call: <
-            target: <
+            }
+          }
+        }
+        stmt: {
+          call: {
+            target: {
               part: "My"
               part: "Server"
-            >
+            }
             endpoint: "GET /serve.html"
-          >
-          attrs: <
+          }
+          attrs: {
             key: "id"
-            value: <
+            value: {
               s: "doesn't matter"
-            >
-          >
-        >
-      >
-    >
-    endpoints: <
+            }
+          }
+        }
+        source_context: {
+          file: "tests/endpoints.sysl"
+          start: {
+            line: 24
+            col: 4
+          }
+          end: {
+            line: 28
+          }
+        }
+      }
+    }
+    endpoints: {
       key: "GET /serve.html"
-      value: <
+      value: {
         name: "GET /serve.html"
-        attrs: <
+        attrs: {
           key: "patterns"
-          value: <
-            a: <
-              elt: <
+          value: {
+            a: {
+              elt: {
                 s: "rest"
-              >
-            >
-          >
-        >
-        stmt: <
-          call: <
-            target: <
+              }
+            }
+          }
+        }
+        stmt: {
+          call: {
+            target: {
               part: "My"
               part: "Server"
-            >
+            }
             endpoint: "GET /serve.html"
-          >
-          attrs: <
+          }
+          attrs: {
             key: "id"
-            value: <
+            value: {
               s: "doesn't matter"
-            >
-          >
-          attrs: <
+            }
+          }
+          attrs: {
             key: "patterns"
-            value: <
-              a: <
-                elt: <
+            value: {
+              a: {
+                elt: {
                   s: "https"
-                >
-              >
-            >
-          >
-        >
-        stmt: <
-          ret: <
+                }
+              }
+            }
+          }
+        }
+        stmt: {
+          ret: {
             payload: "ok <: Response"
-          >
-        >
-        rest_params: <
+          }
+        }
+        rest_params: {
           method: GET
           path: "/serve.html"
-        >
-      >
-    >
-    endpoints: <
+        }
+        source_context: {
+          file: "tests/endpoints.sysl"
+          start: {
+            line: 17
+            col: 8
+          }
+          end: {
+            line: 21
+            col: 4
+          }
+        }
+      }
+    }
+    endpoints: {
       key: "POST /more/stuff.endpoint/{id}"
-      value: <
+      value: {
         name: "POST /more/stuff.endpoint/{id}"
-        attrs: <
+        attrs: {
           key: "id"
-          value: <
+          value: {
             s: "one"
-          >
-        >
-        attrs: <
+          }
+        }
+        attrs: {
           key: "patterns"
-          value: <
-            a: <
-              elt: <
+          value: {
+            a: {
+              elt: {
                 s: "rest"
-              >
-            >
-          >
-        >
-        stmt: <
-          call: <
-            target: <
+              }
+            }
+          }
+        }
+        stmt: {
+          call: {
+            target: {
               part: "App"
-            >
+            }
             endpoint: "GET /serve.html"
-          >
-          attrs: <
+          }
+          attrs: {
             key: "id"
-            value: <
+            value: {
               s: "doesn't matter"
-            >
-          >
-        >
-        stmt: <
-          ret: <
+            }
+          }
+        }
+        stmt: {
+          ret: {
             payload: "ok <: Response"
-          >
-        >
-        rest_params: <
+          }
+        }
+        rest_params: {
           method: POST
           path: "/more/stuff.endpoint/{id}"
-          url_param: <
+          url_param: {
             name: "id"
-            type: <
+            type: {
               primitive: STRING
-              source_context: <
+              source_context: {
                 file: "tests/endpoints.sysl"
-                start: <
+                start: {
                   line: 11
                   col: 27
-                >
-                end: <
+                }
+                end: {
                   line: 11
                   col: 40
-                >
-              >
-            >
-          >
-        >
-      >
-    >
-    types: <
+                }
+              }
+            }
+          }
+        }
+        source_context: {
+          file: "tests/endpoints.sysl"
+          start: {
+            line: 12
+            col: 8
+          }
+          end: {
+            line: 16
+            col: 4
+          }
+        }
+      }
+    }
+    types: {
       key: "Response"
-      value: <
-        tuple: <
-          attr_defs: <
+      value: {
+        tuple: {
+          attr_defs: {
             key: "response"
-            value: <
+            value: {
               primitive: STRING
-              source_context: <
+              source_context: {
                 file: "tests/endpoints.sysl"
-                start: <
+                start: {
                   line: 22
                   col: 20
-                >
-                end: <
+                }
+                end: {
                   line: 22
                   col: 20
-                >
-              >
-            >
-          >
-        >
-      >
-    >
-  >
->
-apps: <
+                }
+              }
+            }
+          }
+        }
+        source_context: {
+          file: "tests/endpoints.sysl"
+          start: {
+            line: 21
+            col: 4
+          }
+          end: {
+            line: 23
+            col: 3
+          }
+        }
+      }
+    }
+    source_context: {
+      file: "tests/endpoints.sysl"
+      start: {
+        line: 23
+        col: 1
+      }
+      end: {
+        line: 23
+      }
+    }
+  }
+}
+apps: {
   key: "My :: Server"
-  value: <
-    name: <
+  value: {
+    name: {
       part: "My"
       part: "Server"
-    >
-    endpoints: <
+    }
+    endpoints: {
       key: "GET /serve.html"
-      value: <
+      value: {
         name: "GET /serve.html"
-        attrs: <
+        attrs: {
           key: "patterns"
-          value: <
-            a: <
-              elt: <
+          value: {
+            a: {
+              elt: {
                 s: "rest"
-              >
-            >
-          >
-        >
-        stmt: <
-          ret: <
+              }
+            }
+          }
+        }
+        stmt: {
+          ret: {
             payload: "ok <: App.Response"
-          >
-        >
-        rest_params: <
+          }
+        }
+        rest_params: {
           method: GET
           path: "/serve.html"
-        >
-      >
-    >
-    endpoints: <
+        }
+        source_context: {
+          file: "tests/endpoints.sysl"
+          start: {
+            line: 3
+            col: 8
+          }
+          end: {
+            line: 6
+            col: 4
+          }
+        }
+      }
+    }
+    endpoints: {
       key: "POST /more/stuff.endpoint/{id}"
-      value: <
+      value: {
         name: "POST /more/stuff.endpoint/{id}"
-        attrs: <
+        attrs: {
           key: "patterns"
-          value: <
-            a: <
-              elt: <
+          value: {
+            a: {
+              elt: {
                 s: "rest"
-              >
-            >
-          >
-        >
-        stmt: <
-          ret: <
+              }
+            }
+          }
+        }
+        stmt: {
+          ret: {
             payload: "ok <: App.Response"
-          >
-        >
-        rest_params: <
+          }
+        }
+        rest_params: {
           method: POST
           path: "/more/stuff.endpoint/{id}"
-          url_param: <
+          url_param: {
             name: "id"
-            type: <
+            type: {
               primitive: STRING
-              source_context: <
+              source_context: {
                 file: "tests/endpoints.sysl"
-                start: <
+                start: {
                   line: 6
                   col: 27
-                >
-                end: <
+                }
+                end: {
                   line: 6
                   col: 40
-                >
-              >
-            >
-          >
-        >
-      >
-    >
-  >
->
+                }
+              }
+            }
+          }
+        }
+        source_context: {
+          file: "tests/endpoints.sysl"
+          start: {
+            line: 7
+            col: 8
+          }
+          end: {
+            line: 10
+            col: 3
+          }
+        }
+      }
+    }
+    source_context: {
+      file: "tests/endpoints.sysl"
+      start: {
+        line: 1
+        col: 1
+      }
+      end: {
+        line: 1
+        col: 6
+      }
+    }
+  }
+}

--- a/pkg/parse/tests/enum.sysl.golden.textpb
+++ b/pkg/parse/tests/enum.sysl.golden.textpb
@@ -1,81 +1,81 @@
-apps: <
+apps: {
   key: "app"
-  value: <
-    name: <
+  value: {
+    name: {
       part: "app"
-    >
-    types: <
+    }
+    types: {
       key: "enum3"
-      value: <
-        enum: <
-          items: <
+      value: {
+        enum: {
+          items: {
             key: "bar"
             value: 2
-          >
-          items: <
+          }
+          items: {
             key: "foo"
             value: 1
-          >
-        >
-        source_context: <
+          }
+        }
+        source_context: {
           file: "tests/enum.sysl"
-          start: <
+          start: {
             line: 5
             col: 4
-          >
-          end: <
+          }
+          end: {
             line: 8
             col: 4
-          >
-        >
-      >
-    >
-    types: <
+          }
+        }
+      }
+    }
+    types: {
       key: "enum4"
-      value: <
-        enum: <
-          items: <
+      value: {
+        enum: {
+          items: {
             key: "baz"
             value: 1
-          >
-        >
-        attrs: <
+          }
+        }
+        attrs: {
           key: "attr"
-          value: <
+          value: {
             s: "val"
-          >
-        >
-        attrs: <
+          }
+        }
+        attrs: {
           key: "patterns"
-          value: <
-            a: <
-              elt: <
+          value: {
+            a: {
+              elt: {
                 s: "pattern"
-              >
-            >
-          >
-        >
-        source_context: <
+              }
+            }
+          }
+        }
+        source_context: {
           file: "tests/enum.sysl"
-          start: <
+          start: {
             line: 8
             col: 4
-          >
-          end: <
+          }
+          end: {
             line: 10
-          >
-        >
-      >
-    >
-    source_context: <
+          }
+        }
+      }
+    }
+    source_context: {
       file: "tests/enum.sysl"
-      start: <
+      start: {
         line: 1
         col: 1
-      >
-      end: <
+      }
+      end: {
         line: 1
-      >
-    >
-  >
->
+      }
+    }
+  }
+}

--- a/pkg/parse/tests/ep_params.sysl.golden.textpb
+++ b/pkg/parse/tests/ep_params.sysl.golden.textpb
@@ -1,19 +1,19 @@
-apps {
+apps: {
   key: "Some App"
-  value {
-    name {
+  value: {
+    name: {
       part: "Some App"
     }
-    endpoints {
+    endpoints: {
       key: "EP1"
-      value {
+      value: {
         name: "EP1"
-        param {
+        param: {
           name: "p1"
-          type {
-            type_ref {
-              ref {
-                appname {
+          type: {
+            type_ref: {
+              ref: {
+                appname: {
                   part: "My"
                   part: "Sample"
                   part: "Todo App"
@@ -24,18 +24,29 @@ apps {
             }
           }
         }
+        source_context: {
+          file: "tests/ep_params.sysl"
+          start: {
+            line: 2
+            col: 4
+          }
+          end: {
+            line: 2
+            col: 54
+          }
+        }
       }
     }
-    endpoints {
+    endpoints: {
       key: "EP2"
-      value {
+      value: {
         name: "EP2"
-        param {
+        param: {
           name: "p1"
-          type {
-            type_ref {
-              ref {
-                appname {
+          type: {
+            type_ref: {
+              ref: {
+                appname: {
                   part: "My"
                   part: "Sample"
                   part: "Todo App"
@@ -45,18 +56,29 @@ apps {
             }
           }
         }
+        source_context: {
+          file: "tests/ep_params.sysl"
+          start: {
+            line: 3
+            col: 4
+          }
+          end: {
+            line: 3
+            col: 51
+          }
+        }
       }
     }
-    endpoints {
+    endpoints: {
       key: "EP3"
-      value {
+      value: {
         name: "EP3"
-        param {
+        param: {
           name: "p2"
-          type {
-            type_ref {
-              ref {
-                appname {
+          type: {
+            type_ref: {
+              ref: {
+                appname: {
                   part: "Sample"
                   part: "Todo App"
                 }
@@ -65,18 +87,29 @@ apps {
             }
           }
         }
+        source_context: {
+          file: "tests/ep_params.sysl"
+          start: {
+            line: 4
+            col: 4
+          }
+          end: {
+            line: 4
+            col: 43
+          }
+        }
       }
     }
-    endpoints {
+    endpoints: {
       key: "EP4"
-      value {
+      value: {
         name: "EP4"
-        param {
+        param: {
           name: "p3"
-          type {
-            type_ref {
-              ref {
-                appname {
+          type: {
+            type_ref: {
+              ref: {
+                appname: {
                   part: "Todo App"
                 }
                 path: "id"
@@ -84,37 +117,59 @@ apps {
             }
           }
         }
+        source_context: {
+          file: "tests/ep_params.sysl"
+          start: {
+            line: 5
+            col: 4
+          }
+          end: {
+            line: 5
+            col: 30
+          }
+        }
       }
     }
-    endpoints {
+    endpoints: {
       key: "EP5"
-      value {
+      value: {
         name: "EP5"
-        param {
+        param: {
           name: "p4"
-          type {
-            type_ref {
-              ref {
-                appname {
+          type: {
+            type_ref: {
+              ref: {
+                appname: {
                   part: "id"
                 }
               }
             }
           }
         }
+        source_context: {
+          file: "tests/ep_params.sysl"
+          start: {
+            line: 6
+            col: 4
+          }
+          end: {
+            line: 6
+            col: 20
+          }
+        }
       }
     }
-    endpoints {
+    endpoints: {
       key: "EP6"
-      value {
+      value: {
         name: "EP6"
-        param {
+        param: {
           name: "p4"
-          type {
-            set {
-              type_ref {
-                ref {
-                  appname {
+          type: {
+            set: {
+              type_ref: {
+                ref: {
+                  appname: {
                     part: "id"
                   }
                 }
@@ -122,6 +177,27 @@ apps {
             }
           }
         }
+        source_context: {
+          file: "tests/ep_params.sysl"
+          start: {
+            line: 7
+            col: 4
+          }
+          end: {
+            line: 7
+            col: 27
+          }
+        }
+      }
+    }
+    source_context: {
+      file: "tests/ep_params.sysl"
+      start: {
+        line: 1
+        col: 1
+      }
+      end: {
+        line: 1
       }
     }
   }

--- a/pkg/parse/tests/eventing.sysl.golden.textpb
+++ b/pkg/parse/tests/eventing.sysl.golden.textpb
@@ -1,79 +1,141 @@
-apps {
+apps: {
   key: "NotifierApp"
-  value {
-    name {
+  value: {
+    name: {
       part: "NotifierApp"
     }
-    endpoints {
+    endpoints: {
       key: "Endpoint"
-      value {
+      value: {
         name: "Endpoint"
-        stmt {
-          call {
-            target {
+        stmt: {
+          call: {
+            target: {
               part: "PublishingApp"
             }
             endpoint: "BusinessEvent"
           }
         }
+        source_context: {
+          file: "tests/eventing.sysl"
+          start: {
+            line: 17
+            col: 2
+          }
+          end: {
+            line: 20
+          }
+        }
+      }
+    }
+    source_context: {
+      file: "tests/eventing.sysl"
+      start: {
+        line: 16
+        col: 1
+      }
+      end: {
+        line: 16
       }
     }
   }
 }
-apps {
+apps: {
   key: "PublishingApp"
-  value {
-    name {
+  value: {
+    name: {
       part: "PublishingApp"
     }
-    endpoints {
+    endpoints: {
       key: "BusinessEvent"
-      value {
+      value: {
         name: "BusinessEvent"
-        attrs {
+        attrs: {
           key: "patterns"
-          value {
-            a {
-              elt {
+          value: {
+            a: {
+              elt: {
                 s: "async"
               }
-              elt {
+              elt: {
                 s: "mq"
               }
             }
           }
         }
         is_pubsub: true
-        stmt {
-          call {
-            target {
+        stmt: {
+          call: {
+            target: {
               part: "SubscriberApp1"
             }
             endpoint: "PublishingApp -> BusinessEvent"
           }
         }
+        source_context: {
+          file: "tests/eventing.sysl"
+          start: {
+            line: 2
+            col: 4
+          }
+          end: {
+            line: 2
+            col: 37
+          }
+        }
+      }
+    }
+    source_context: {
+      file: "tests/eventing.sysl"
+      start: {
+        line: 1
+        col: 1
+      }
+      end: {
+        line: 1
       }
     }
   }
 }
-apps {
+apps: {
   key: "SubscriberApp1"
-  value {
-    name {
+  value: {
+    name: {
       part: "SubscriberApp1"
     }
-    endpoints {
+    endpoints: {
       key: "PublishingApp -> BusinessEvent"
-      value {
+      value: {
         name: "PublishingApp -> BusinessEvent"
-        source {
+        source: {
           part: "PublishingApp"
         }
-        stmt {
-          action {
+        stmt: {
+          action: {
             action: "app1 got the BusinessEvent"
           }
         }
+        source_context: {
+          file: "tests/eventing.sysl"
+          start: {
+            line: 5
+            col: 4
+          }
+          end: {
+            line: 16
+            col: 11
+          }
+        }
+      }
+    }
+    source_context: {
+      file: "tests/eventing.sysl"
+      start: {
+        line: 4
+        col: 1
+      }
+      end: {
+        line: 4
       }
     }
   }

--- a/pkg/parse/tests/for_loop.sysl.golden.textpb
+++ b/pkg/parse/tests/for_loop.sysl.golden.textpb
@@ -1,139 +1,198 @@
-apps {
+apps: {
   key: "Car Models"
-  value {
-    name {
+  value: {
+    name: {
       part: "Car Models"
     }
-    endpoints {
+    endpoints: {
       key: "Get All Makes"
-      value {
+      value: {
         name: "Get All Makes"
-        param {
+        param: {
           name: "year"
-          type {
-            no_type {
-            }
+          type: {
+            no_type: {}
+          }
+        }
+        source_context: {
+          file: "tests/for_loop.sysl"
+          start: {
+            line: 3
+            col: 4
+          }
+          end: {
+            line: 3
+            col: 26
           }
         }
       }
     }
-    endpoints {
+    endpoints: {
       key: "Get All Models"
-      value {
+      value: {
         name: "Get All Models"
-        param {
+        param: {
           name: "year"
-          type {
-            no_type {
-            }
+          type: {
+            no_type: {}
           }
         }
-        param {
+        param: {
           name: "make"
-          type {
-            no_type {
-            }
+          type: {
+            no_type: {}
+          }
+        }
+        source_context: {
+          file: "tests/for_loop.sysl"
+          start: {
+            line: 4
+            col: 4
+          }
+          end: {
+            line: 4
+            col: 33
           }
         }
       }
     }
-    endpoints {
+    endpoints: {
       key: "Get All Series"
-      value {
+      value: {
         name: "Get All Series"
-        param {
+        param: {
           name: "year"
-          type {
-            no_type {
-            }
+          type: {
+            no_type: {}
           }
         }
-        param {
+        param: {
           name: "make"
-          type {
-            no_type {
-            }
+          type: {
+            no_type: {}
           }
         }
-        param {
+        param: {
           name: "model"
-          type {
-            no_type {
-            }
+          type: {
+            no_type: {}
+          }
+        }
+        source_context: {
+          file: "tests/for_loop.sysl"
+          start: {
+            line: 5
+            col: 4
+          }
+          end: {
+            line: 5
+            col: 40
           }
         }
       }
     }
-    endpoints {
+    endpoints: {
       key: "Get All Years"
-      value {
+      value: {
         name: "Get All Years"
+        source_context: {
+          file: "tests/for_loop.sysl"
+          start: {
+            line: 2
+            col: 4
+          }
+          end: {
+            line: 2
+            col: 19
+          }
+        }
+      }
+    }
+    source_context: {
+      file: "tests/for_loop.sysl"
+      start: {
+        line: 1
+        col: 1
+      }
+      end: {
+        line: 1
       }
     }
   }
 }
-apps {
+apps: {
   key: "Other App"
-  value {
-    name {
+  value: {
+    name: {
       part: "Other App"
     }
-    endpoints {
+    endpoints: {
       key: "FOO"
-      value {
+      value: {
         name: "FOO"
-        stmt {
-          call {
-            target {
+        stmt: {
+          call: {
+            target: {
               part: "Car Models"
             }
             endpoint: "Get All Years"
           }
         }
-        stmt {
-          group {
+        stmt: {
+          group: {
             title: "for all series"
-            stmt {
-              action {
+            stmt: {
+              action: {
                 action: "evaluate series pricing"
               }
             }
-            stmt {
-              cond {
+            stmt: {
+              cond: {
                 test: "has pricing"
-                stmt {
-                  action {
+                stmt: {
+                  action: {
                     action: "select series"
                   }
                 }
               }
             }
-            stmt {
-              action {
+            stmt: {
+              action: {
                 action: "dump pricing information"
               }
             }
           }
         }
+        source_context: {
+          file: "tests/for_loop.sysl"
+          start: {
+            line: 8
+            col: 4
+          }
+          end: {
+            line: 15
+            col: 4
+          }
+        }
       }
     }
-    endpoints {
+    endpoints: {
       key: "Profit"
-      value {
+      value: {
         name: "Profit"
-        stmt {
-          foreach {
+        stmt: {
+          foreach: {
             collection: "year"
-            stmt {
-              action {
+            stmt: {
+              action: {
                 action: "calculate profit"
               }
             }
-            stmt {
-              group {
+            stmt: {
+              group: {
                 title: "Loop \"n times\""
-                stmt {
-                  action {
+                stmt: {
+                  action: {
                     action: "run simulation"
                   }
                 }
@@ -141,23 +200,54 @@ apps {
             }
           }
         }
+        source_context: {
+          file: "tests/for_loop.sysl"
+          start: {
+            line: 15
+            col: 4
+          }
+          end: {
+            line: 20
+            col: 4
+          }
+        }
       }
     }
-    endpoints {
+    endpoints: {
       key: "WhileTest"
-      value {
+      value: {
         name: "WhileTest"
-        stmt {
-          loop {
+        stmt: {
+          loop: {
             mode: WHILE
             criterion: "condition not true"
-            stmt {
-              action {
+            stmt: {
+              action: {
                 action: "\"wait for 5 secs\""
               }
             }
           }
         }
+        source_context: {
+          file: "tests/for_loop.sysl"
+          start: {
+            line: 20
+            col: 4
+          }
+          end: {
+            line: 23
+          }
+        }
+      }
+    }
+    source_context: {
+      file: "tests/for_loop.sysl"
+      start: {
+        line: 7
+        col: 1
+      }
+      end: {
+        line: 7
       }
     }
   }

--- a/pkg/parse/tests/foreign_import_swagger.sysl.golden.textpb
+++ b/pkg/parse/tests/foreign_import_swagger.sysl.golden.textpb
@@ -1,222 +1,286 @@
-apps: <
+apps: {
   key: "app"
-  value: <
-    name: <
+  value: {
+    name: {
       part: "app"
-    >
+    }
     long_name: "Simple"
-    attrs: <
+    attrs: {
       key: "description"
-      value: <
-        s: "No description."
-      >
-    >
-    attrs: <
+      value: {
+        s: "No description.\n"
+      }
+    }
+    attrs: {
       key: "package"
-      value: <
+      value: {
         s: "com.foo.bar"
-      >
-    >
-    endpoints: <
+      }
+    }
+    endpoints: {
       key: "GET /test"
-      value: <
+      value: {
         name: "GET /test"
         docstring: "No description."
-        attrs: <
+        attrs: {
           key: "patterns"
-          value: <
-            a: <
-              elt: <
+          value: {
+            a: {
+              elt: {
                 s: "rest"
-              >
-            >
-          >
-        >
-        stmt: <
-          ret: <
+              }
+            }
+          }
+        }
+        stmt: {
+          ret: {
             payload: "ok <: SimpleObj"
-          >
-        >
-        rest_params: <
+          }
+        }
+        rest_params: {
           method: GET
           path: "/test"
-        >
-      >
-    >
-    types: <
+        }
+        source_context: {
+          file: "tests/foreign_import_swagger.yaml"
+          start: {
+            line: 12
+            col: 8
+          }
+          end: {
+            line: 19
+            col: 4
+          }
+        }
+      }
+    }
+    types: {
       key: "SimpleObj"
-      value: <
-        tuple: <
-          attr_defs: <
+      value: {
+        tuple: {
+          attr_defs: {
             key: "name"
-            value: <
+            value: {
               primitive: STRING
-              attrs: <
+              attrs: {
                 key: "json_tag"
-                value: <
+                value: {
                   s: "name"
-                >
-              >
+                }
+              }
               opt: true
-              source_context: <
+              source_context: {
                 file: "tests/foreign_import_swagger.yaml"
-                start: <
+                start: {
                   line: 21
                   col: 16
-                >
-                end: <
+                }
+                end: {
                   line: 22
-                >
-              >
-            >
-          >
-        >
-      >
-    >
-  >
->
-apps: <
+                }
+              }
+            }
+          }
+        }
+        source_context: {
+          file: "tests/foreign_import_swagger.yaml"
+          start: {
+            line: 19
+            col: 4
+          }
+          end: {
+            line: 22
+          }
+        }
+      }
+    }
+    source_context: {
+      file: "tests/foreign_import_swagger.yaml"
+      start: {
+        line: 7
+        col: 1
+      }
+      end: {
+        line: 7
+        col: 35
+      }
+    }
+  }
+}
+apps: {
   key: "testapp"
-  value: <
-    name: <
+  value: {
+    name: {
       part: "testapp"
-    >
+    }
     long_name: "Goat CRUD API"
-    attrs: <
+    attrs: {
       key: "description"
-      value: <
-        s: "No description."
-      >
-    >
-    attrs: <
+      value: {
+        s: "No description.\n"
+      }
+    }
+    attrs: {
       key: "host"
-      value: <
+      value: {
         s: "goat.example.com"
-      >
-    >
-    attrs: <
+      }
+    }
+    attrs: {
       key: "package"
-      value: <
+      value: {
         s: "package_foo"
-      >
-    >
-    attrs: <
+      }
+    }
+    attrs: {
       key: "version"
-      value: <
+      value: {
         s: "1.2.3"
-      >
-    >
-    endpoints: <
+      }
+    }
+    endpoints: {
       key: "GET /first"
-      value: <
+      value: {
         name: "GET /first"
-        attrs: <
+        attrs: {
           key: "patterns"
-          value: <
-            a: <
-              elt: <
+          value: {
+            a: {
+              elt: {
                 s: "rest"
-              >
-            >
-          >
-        >
-        stmt: <
-          action: <
+              }
+            }
+          }
+        }
+        stmt: {
+          action: {
             action: "..."
-          >
-        >
-        rest_params: <
+          }
+        }
+        rest_params: {
           method: GET
           path: "/first"
-          query_param: <
+          query_param: {
             name: "depth"
-            type: <
-              source_context: <
+            type: {
+              source_context: {
                 file: "tests/foreign_import_swagger.sysl"
-                start: <
+                start: {
                   line: 19
                   col: 13
-                >
-                end: <
+                }
+                end: {
                   line: 19
                   col: 19
-                >
-              >
-            >
-          >
-          query_param: <
+                }
+              }
+            }
+          }
+          query_param: {
             name: "limit"
-            type: <
+            type: {
               primitive: INT
               opt: true
-              source_context: <
+              source_context: {
                 file: "tests/foreign_import_swagger.sysl"
-                start: <
+                start: {
                   line: 19
                   col: 29
-                >
-                end: <
+                }
+                end: {
                   line: 19
                   col: 38
-                >
-              >
-            >
-          >
-          query_param: <
+                }
+              }
+            }
+          }
+          query_param: {
             name: "offset"
-            type: <
+            type: {
               primitive: INT
               opt: true
-              source_context: <
+              source_context: {
                 file: "tests/foreign_import_swagger.sysl"
-                start: <
+                start: {
                   line: 19
                   col: 40
-                >
-                end: <
+                }
+                end: {
                   line: 19
                   col: 50
-                >
-              >
-            >
-          >
-        >
-      >
-    >
-    types: <
+                }
+              }
+            }
+          }
+        }
+        source_context: {
+          file: "tests/foreign_import_swagger.sysl"
+          start: {
+            line: 19
+            col: 8
+          }
+          end: {
+            line: 22
+          }
+        }
+      }
+    }
+    types: {
       key: "Something"
-      value: <
-        tuple: <
-          attr_defs: <
+      value: {
+        tuple: {
+          attr_defs: {
             key: "import"
-            value: <
-              type_ref: <
-                context: <
-                  appname: <
+            value: {
+              type_ref: {
+                context: {
+                  appname: {
                     part: "testapp"
-                  >
+                  }
                   path: "Something"
-                >
-                ref: <
+                }
+                ref: {
                   path: "FooBar"
-                >
-              >
+                }
+              }
               opt: true
-              source_context: <
+              source_context: {
                 file: "tests/foreign_import_swagger.sysl"
-                start: <
+                start: {
                   line: 16
                   col: 18
-                >
-                end: <
+                }
+                end: {
                   line: 16
                   col: 24
-                >
-              >
-            >
-          >
-        >
-      >
-    >
-  >
->
+                }
+              }
+            }
+          }
+        }
+        source_context: {
+          file: "tests/foreign_import_swagger.sysl"
+          start: {
+            line: 15
+            col: 4
+          }
+          end: {
+            line: 18
+            col: 4
+          }
+        }
+      }
+    }
+    source_context: {
+      file: "tests/foreign_import_swagger.sysl"
+      start: {
+        line: 9
+        col: 1
+      }
+      end: {
+        line: 9
+        col: 46
+      }
+    }
+  }
+}

--- a/pkg/parse/tests/funcs.sysl.golden.textpb
+++ b/pkg/parse/tests/funcs.sysl.golden.textpb
@@ -1,415 +1,1211 @@
-apps {
+apps: {
   key: "TransformationTest"
-  value {
-    name {
+  value: {
+    name: {
       part: "TransformationTest"
     }
-    attrs {
+    attrs: {
       key: "package"
-      value {
+      value: {
         s: "io.sysl.test.views"
       }
     }
-    views {
+    views: {
       key: "TestInbuiltFuncs"
-      value {
-        param {
+      value: {
+        param: {
           name: "number"
-          type {
+          type: {
             primitive: INT
           }
         }
-        ret_type {
+        ret_type: {
           primitive: INT
         }
-        expr {
-          transform {
-            arg {
+        expr: {
+          transform: {
+            arg: {
               name: "number"
+              source_context: {
+                file: "tests/funcs.sysl"
+                start: {
+                  line: 3
+                  col: 4
+                }
+                end: {
+                  line: 3
+                  col: 4
+                }
+              }
             }
             scopevar: "."
-            stmt {
-              assign {
+            stmt: {
+              assign: {
                 name: "AppOrderId2"
-                expr {
-                  call {
+                expr: {
+                  call: {
                     func: "int"
-                    arg {
-                      get_attr {
-                        arg {
+                    arg: {
+                      get_attr: {
+                        arg: {
                           name: "."
+                          source_context: {
+                            file: "tests/funcs.sysl"
+                            start: {
+                              line: 4
+                              col: 24
+                            }
+                            end: {
+                              line: 4
+                              col: 25
+                            }
+                          }
                         }
                         attr: "orderId"
                       }
-                    }
-                    arg {
-                      literal {
-                        null {
+                      source_context: {
+                        file: "tests/funcs.sysl"
+                        start: {
+                          line: 4
+                          col: 24
+                        }
+                        end: {
+                          line: 4
+                          col: 25
                         }
                       }
-                      type {
+                    }
+                    arg: {
+                      literal: {
+                        null: {}
+                      }
+                      type: {
                         primitive: EMPTY
                       }
-                    }
-                  }
-                }
-              }
-            }
-            stmt {
-              let {
-                name: "out"
-                expr {
-                  call {
-                    func: "autoinc"
-                  }
-                }
-              }
-            }
-            stmt {
-              let {
-                name: "out"
-                expr {
-                  call {
-                    func: ".any"
-                    arg {
-                      name: "foo"
-                    }
-                    arg {
-                      literal {
-                        i: 1
+                      source_context: {
+                        file: "tests/funcs.sysl"
+                        start: {
+                          line: 4
+                          col: 34
+                        }
+                        end: {
+                          line: 4
+                          col: 34
+                        }
                       }
                     }
                   }
+                  source_context: {
+                    file: "tests/funcs.sysl"
+                    start: {
+                      line: 4
+                      col: 6
+                    }
+                    end: {
+                      line: 4
+                      col: 38
+                    }
+                    text: "AppOrderId2 = int(.orderId, null)"
+                  }
                 }
               }
             }
-            stmt {
-              let {
+            stmt: {
+              let: {
                 name: "out"
-                expr {
-                  relexpr {
-                    op: MAX
-                    target {
-                      name: "foo"
+                expr: {
+                  call: {
+                    func: "autoinc"
+                  }
+                  source_context: {
+                    file: "tests/funcs.sysl"
+                    start: {
+                      line: 5
+                      col: 6
                     }
-                    arg {
-                      get_attr {
-                        arg {
+                    end: {
+                      line: 5
+                      col: 24
+                    }
+                    text: "let out = autoinc()"
+                  }
+                }
+              }
+            }
+            stmt: {
+              let: {
+                name: "out"
+                expr: {
+                  call: {
+                    func: ".any"
+                    arg: {
+                      name: "foo"
+                      source_context: {
+                        file: "tests/funcs.sysl"
+                        start: {
+                          line: 6
+                          col: 16
+                        }
+                        end: {
+                          line: 6
+                          col: 16
+                        }
+                      }
+                    }
+                    arg: {
+                      literal: {
+                        i: 1
+                      }
+                      source_context: {
+                        file: "tests/funcs.sysl"
+                        start: {
+                          line: 6
+                          col: 24
+                        }
+                        end: {
+                          line: 6
+                          col: 24
+                        }
+                      }
+                    }
+                  }
+                  source_context: {
+                    file: "tests/funcs.sysl"
+                    start: {
+                      line: 6
+                      col: 6
+                    }
+                    end: {
+                      line: 6
+                      col: 25
+                    }
+                    text: "let out = foo any(1)"
+                  }
+                }
+              }
+            }
+            stmt: {
+              let: {
+                name: "out"
+                expr: {
+                  relexpr: {
+                    op: MAX
+                    target: {
+                      name: "foo"
+                      source_context: {
+                        file: "tests/funcs.sysl"
+                        start: {
+                          line: 7
+                          col: 16
+                        }
+                        end: {
+                          line: 7
+                          col: 16
+                        }
+                      }
+                    }
+                    arg: {
+                      get_attr: {
+                        arg: {
                           name: "."
+                          source_context: {
+                            file: "tests/funcs.sysl"
+                            start: {
+                              line: 7
+                              col: 24
+                            }
+                            end: {
+                              line: 7
+                              col: 25
+                            }
+                          }
                         }
                         attr: "bar"
                       }
-                    }
-                    scopevar: "."
-                  }
-                }
-              }
-            }
-            stmt {
-              let {
-                name: "out"
-                expr {
-                  relexpr {
-                    op: MAX
-                    target {
-                      name: "foo"
-                    }
-                    arg {
-                      get_attr {
-                        arg {
-                          name: "bar"
+                      source_context: {
+                        file: "tests/funcs.sysl"
+                        start: {
+                          line: 7
+                          col: 24
                         }
-                        attr: "baz"
+                        end: {
+                          line: 7
+                          col: 25
+                        }
                       }
                     }
                     scopevar: "."
                   }
+                  source_context: {
+                    file: "tests/funcs.sysl"
+                    start: {
+                      line: 7
+                      col: 6
+                    }
+                    end: {
+                      line: 7
+                      col: 28
+                    }
+                    text: "let out = foo max(.bar)"
+                  }
                 }
               }
             }
-            stmt {
-              let {
+            stmt: {
+              let: {
                 name: "out"
-                expr {
-                  relexpr {
+                expr: {
+                  relexpr: {
                     op: MAX
-                    target {
-                      binexpr {
-                        op: WHERE
-                        lhs {
-                          name: "foo"
+                    target: {
+                      name: "foo"
+                      source_context: {
+                        file: "tests/funcs.sysl"
+                        start: {
+                          line: 8
+                          col: 16
                         }
-                        rhs {
-                          binexpr {
+                        end: {
+                          line: 8
+                          col: 16
+                        }
+                      }
+                    }
+                    arg: {
+                      get_attr: {
+                        arg: {
+                          name: "bar"
+                          source_context: {
+                            file: "tests/funcs.sysl"
+                            start: {
+                              line: 8
+                              col: 24
+                            }
+                            end: {
+                              line: 8
+                              col: 24
+                            }
+                          }
+                        }
+                        attr: "baz"
+                      }
+                      source_context: {
+                        file: "tests/funcs.sysl"
+                        start: {
+                          line: 8
+                          col: 27
+                        }
+                        end: {
+                          line: 8
+                          col: 28
+                        }
+                      }
+                    }
+                    scopevar: "."
+                  }
+                  source_context: {
+                    file: "tests/funcs.sysl"
+                    start: {
+                      line: 8
+                      col: 6
+                    }
+                    end: {
+                      line: 8
+                      col: 31
+                    }
+                    text: "let out = foo max(bar.baz)"
+                  }
+                }
+              }
+            }
+            stmt: {
+              let: {
+                name: "out"
+                expr: {
+                  relexpr: {
+                    op: MAX
+                    target: {
+                      binexpr: {
+                        op: WHERE
+                        lhs: {
+                          name: "foo"
+                          source_context: {
+                            file: "tests/funcs.sysl"
+                            start: {
+                              line: 9
+                              col: 16
+                            }
+                            end: {
+                              line: 9
+                              col: 16
+                            }
+                          }
+                        }
+                        rhs: {
+                          binexpr: {
                             op: GT
-                            lhs {
-                              get_attr {
-                                arg {
+                            lhs: {
+                              get_attr: {
+                                arg: {
                                   name: "."
+                                  source_context: {
+                                    file: "tests/funcs.sysl"
+                                    start: {
+                                      line: 9
+                                      col: 26
+                                    }
+                                    end: {
+                                      line: 9
+                                      col: 27
+                                    }
+                                  }
                                 }
                                 attr: "x"
                               }
+                              source_context: {
+                                file: "tests/funcs.sysl"
+                                start: {
+                                  line: 9
+                                  col: 26
+                                }
+                                end: {
+                                  line: 9
+                                  col: 27
+                                }
+                              }
                             }
-                            rhs {
-                              literal {
+                            rhs: {
+                              literal: {
                                 i: 0
                               }
+                              source_context: {
+                                file: "tests/funcs.sysl"
+                                start: {
+                                  line: 9
+                                  col: 31
+                                }
+                                end: {
+                                  line: 9
+                                  col: 31
+                                }
+                              }
+                            }
+                          }
+                          source_context: {
+                            file: "tests/funcs.sysl"
+                            start: {
+                              line: 9
+                              col: 26
+                            }
+                            end: {
+                              line: 9
+                              col: 31
                             }
                           }
                         }
                         scopevar: "."
                       }
+                      source_context: {
+                        file: "tests/funcs.sysl"
+                        start: {
+                          line: 9
+                          col: 20
+                        }
+                        end: {
+                          line: 9
+                          col: 20
+                        }
+                      }
                     }
-                    arg {
-                      get_attr {
-                        arg {
-                          get_attr {
-                            arg {
+                    arg: {
+                      get_attr: {
+                        arg: {
+                          get_attr: {
+                            arg: {
                               name: "."
+                              source_context: {
+                                file: "tests/funcs.sysl"
+                                start: {
+                                  line: 9
+                                  col: 38
+                                }
+                                end: {
+                                  line: 9
+                                  col: 39
+                                }
+                              }
                             }
                             attr: "bar"
                           }
+                          source_context: {
+                            file: "tests/funcs.sysl"
+                            start: {
+                              line: 9
+                              col: 38
+                            }
+                            end: {
+                              line: 9
+                              col: 39
+                            }
+                          }
                         }
                         attr: "baz"
+                      }
+                      source_context: {
+                        file: "tests/funcs.sysl"
+                        start: {
+                          line: 9
+                          col: 42
+                        }
+                        end: {
+                          line: 9
+                          col: 43
+                        }
                       }
                     }
                     scopevar: "."
                   }
+                  source_context: {
+                    file: "tests/funcs.sysl"
+                    start: {
+                      line: 9
+                      col: 6
+                    }
+                    end: {
+                      line: 9
+                      col: 46
+                    }
+                    text: "let out = foo where(.x > 0) max(.bar.baz)"
+                  }
                 }
               }
             }
-            stmt {
-              let {
+            stmt: {
+              let: {
                 name: "out"
-                expr {
-                  call {
+                expr: {
+                  call: {
                     func: ".count"
-                    arg {
-                      binexpr {
+                    arg: {
+                      binexpr: {
                         op: WHERE
-                        lhs {
+                        lhs: {
                           name: "foo"
+                          source_context: {
+                            file: "tests/funcs.sysl"
+                            start: {
+                              line: 10
+                              col: 16
+                            }
+                            end: {
+                              line: 10
+                              col: 16
+                            }
+                          }
                         }
-                        rhs {
-                          binexpr {
+                        rhs: {
+                          binexpr: {
                             op: GT
-                            lhs {
-                              get_attr {
-                                arg {
+                            lhs: {
+                              get_attr: {
+                                arg: {
                                   name: "."
+                                  source_context: {
+                                    file: "tests/funcs.sysl"
+                                    start: {
+                                      line: 10
+                                      col: 26
+                                    }
+                                    end: {
+                                      line: 10
+                                      col: 27
+                                    }
+                                  }
                                 }
                                 attr: "x"
                               }
+                              source_context: {
+                                file: "tests/funcs.sysl"
+                                start: {
+                                  line: 10
+                                  col: 26
+                                }
+                                end: {
+                                  line: 10
+                                  col: 27
+                                }
+                              }
                             }
-                            rhs {
-                              literal {
+                            rhs: {
+                              literal: {
                                 i: 0
                               }
+                              source_context: {
+                                file: "tests/funcs.sysl"
+                                start: {
+                                  line: 10
+                                  col: 31
+                                }
+                                end: {
+                                  line: 10
+                                  col: 31
+                                }
+                              }
+                            }
+                          }
+                          source_context: {
+                            file: "tests/funcs.sysl"
+                            start: {
+                              line: 10
+                              col: 26
+                            }
+                            end: {
+                              line: 10
+                              col: 31
                             }
                           }
                         }
                         scopevar: "."
                       }
+                      source_context: {
+                        file: "tests/funcs.sysl"
+                        start: {
+                          line: 10
+                          col: 20
+                        }
+                        end: {
+                          line: 10
+                          col: 20
+                        }
+                      }
                     }
+                  }
+                  source_context: {
+                    file: "tests/funcs.sysl"
+                    start: {
+                      line: 10
+                      col: 6
+                    }
+                    end: {
+                      line: 10
+                      col: 34
+                    }
+                    text: "let out = foo where(.x > 0) count"
                   }
                 }
               }
             }
-            stmt {
-              let {
+            stmt: {
+              let: {
                 name: "out"
-                expr {
-                  unexpr {
+                expr: {
+                  unexpr: {
                     op: SINGLE
-                    arg {
-                      relexpr {
+                    arg: {
+                      relexpr: {
                         op: FIRST_BY
-                        target {
-                          navigate {
-                            arg {
+                        target: {
+                          navigate: {
+                            arg: {
                               name: "."
+                              source_context: {
+                                file: "tests/funcs.sysl"
+                                start: {
+                                  line: 11
+                                  col: 16
+                                }
+                                end: {
+                                  line: 11
+                                  col: 26
+                                }
+                              }
                             }
                             attr: "fo"
                             setof: true
                           }
-                        }
-                        arg {
-                          literal {
-                            i: 1
+                          source_context: {
+                            file: "tests/funcs.sysl"
+                            start: {
+                              line: 11
+                              col: 16
+                            }
+                            end: {
+                              line: 11
+                              col: 26
+                            }
                           }
                         }
-                        arg {
-                          get_attr {
-                            arg {
+                        arg: {
+                          literal: {
+                            i: 1
+                          }
+                          source_context: {
+                            file: "tests/funcs.sysl"
+                            start: {
+                              line: 11
+                              col: 35
+                            }
+                            end: {
+                              line: 11
+                              col: 35
+                            }
+                          }
+                        }
+                        arg: {
+                          get_attr: {
+                            arg: {
                               name: "."
+                              source_context: {
+                                file: "tests/funcs.sysl"
+                                start: {
+                                  line: 11
+                                  col: 41
+                                }
+                                end: {
+                                  line: 11
+                                  col: 42
+                                }
+                              }
                             }
                             attr: "id"
                           }
-                        }
-                        arg {
-                          literal {
-                            i: 1
+                          source_context: {
+                            file: "tests/funcs.sysl"
+                            start: {
+                              line: 11
+                              col: 41
+                            }
+                            end: {
+                              line: 11
+                              col: 42
+                            }
                           }
                         }
-                        arg {
-                          get_attr {
-                            arg {
+                        arg: {
+                          literal: {
+                            i: 1
+                          }
+                          source_context: {
+                            file: "tests/funcs.sysl"
+                            start: {
+                              line: 11
+                              col: 35
+                            }
+                            end: {
+                              line: 11
+                              col: 35
+                            }
+                          }
+                        }
+                        arg: {
+                          get_attr: {
+                            arg: {
                               name: "."
+                              source_context: {
+                                file: "tests/funcs.sysl"
+                                start: {
+                                  line: 11
+                                  col: 41
+                                }
+                                end: {
+                                  line: 11
+                                  col: 42
+                                }
+                              }
                             }
                             attr: "id"
+                          }
+                          source_context: {
+                            file: "tests/funcs.sysl"
+                            start: {
+                              line: 11
+                              col: 41
+                            }
+                            end: {
+                              line: 11
+                              col: 42
+                            }
                           }
                         }
                         scopevar: "."
                         descending: false
                       }
+                      source_context: {
+                        file: "tests/funcs.sysl"
+                        start: {
+                          line: 11
+                          col: 29
+                        }
+                        end: {
+                          line: 11
+                          col: 44
+                        }
+                      }
                     }
+                  }
+                  source_context: {
+                    file: "tests/funcs.sysl"
+                    start: {
+                      line: 11
+                      col: 6
+                    }
+                    end: {
+                      line: 11
+                      col: 46
+                    }
+                    text: "let out = -> set of fo first 1 by (.id) single"
                   }
                 }
               }
             }
-            stmt {
-              assign {
+            stmt: {
+              assign: {
                 name: "AppDate"
-                expr {
-                  call {
+                expr: {
+                  call: {
                     func: "to_date"
-                    arg {
-                      binexpr {
+                    arg: {
+                      binexpr: {
                         op: COALESCE
-                        lhs {
-                          get_attr {
-                            arg {
+                        lhs: {
+                          get_attr: {
+                            arg: {
                               name: "."
+                              source_context: {
+                                file: "tests/funcs.sysl"
+                                start: {
+                                  line: 12
+                                  col: 24
+                                }
+                                end: {
+                                  line: 12
+                                  col: 25
+                                }
+                              }
                             }
                             attr: "createdDate"
                           }
+                          source_context: {
+                            file: "tests/funcs.sysl"
+                            start: {
+                              line: 12
+                              col: 24
+                            }
+                            end: {
+                              line: 12
+                              col: 25
+                            }
+                          }
                         }
-                        rhs {
-                          call {
+                        rhs: {
+                          call: {
                             func: "now"
                           }
+                          source_context: {
+                            file: "tests/funcs.sysl"
+                            start: {
+                              line: 12
+                              col: 40
+                            }
+                            end: {
+                              line: 12
+                              col: 44
+                            }
+                            text: "now()"
+                          }
+                        }
+                      }
+                      source_context: {
+                        file: "tests/funcs.sysl"
+                        start: {
+                          line: 12
+                          col: 24
+                        }
+                        end: {
+                          line: 12
+                          col: 44
                         }
                       }
                     }
                   }
+                  source_context: {
+                    file: "tests/funcs.sysl"
+                    start: {
+                      line: 12
+                      col: 6
+                    }
+                    end: {
+                      line: 12
+                      col: 45
+                    }
+                    text: "AppDate = to_date(.createdDate ?? now())"
+                  }
                 }
               }
             }
-            stmt {
-              assign {
+            stmt: {
+              assign: {
                 name: "AppOrderId"
-                expr {
-                  call {
+                expr: {
+                  call: {
                     func: "str"
-                    arg {
-                      get_attr {
-                        arg {
+                    arg: {
+                      get_attr: {
+                        arg: {
                           name: "."
+                          source_context: {
+                            file: "tests/funcs.sysl"
+                            start: {
+                              line: 13
+                              col: 23
+                            }
+                            end: {
+                              line: 13
+                              col: 24
+                            }
+                          }
                         }
                         attr: "orderId"
                       }
+                      source_context: {
+                        file: "tests/funcs.sysl"
+                        start: {
+                          line: 13
+                          col: 23
+                        }
+                        end: {
+                          line: 13
+                          col: 24
+                        }
+                      }
                     }
+                  }
+                  source_context: {
+                    file: "tests/funcs.sysl"
+                    start: {
+                      line: 13
+                      col: 6
+                    }
+                    end: {
+                      line: 13
+                      col: 31
+                    }
+                    text: "AppOrderId = str(.orderId)"
                   }
                 }
               }
             }
-            stmt {
-              assign {
+            stmt: {
+              assign: {
                 name: "foo"
-                expr {
-                  call {
+                expr: {
+                  call: {
                     func: "bar"
-                    arg {
+                    arg: {
                       name: "."
+                      source_context: {
+                        file: "tests/funcs.sysl"
+                        start: {
+                          line: 14
+                          col: 16
+                        }
+                        end: {
+                          line: 14
+                          col: 16
+                        }
+                      }
                     }
+                  }
+                  source_context: {
+                    file: "tests/funcs.sysl"
+                    start: {
+                      line: 14
+                      col: 6
+                    }
+                    end: {
+                      line: 14
+                      col: 17
+                    }
+                    text: "foo = bar(.)"
                   }
                 }
               }
             }
-            stmt {
-              assign {
+            stmt: {
+              assign: {
                 name: "foo"
-                expr {
-                  call {
+                expr: {
+                  call: {
                     func: "concat"
-                    arg {
-                      list {
-                        expr {
-                          literal {
+                    arg: {
+                      list: {
+                        expr: {
+                          literal: {
                             i: 1
                           }
+                          source_context: {
+                            file: "tests/funcs.sysl"
+                            start: {
+                              line: 15
+                              col: 20
+                            }
+                            end: {
+                              line: 15
+                              col: 20
+                            }
+                          }
                         }
-                        expr {
-                          literal {
+                        expr: {
+                          literal: {
                             i: 2
+                          }
+                          source_context: {
+                            file: "tests/funcs.sysl"
+                            start: {
+                              line: 15
+                              col: 22
+                            }
+                            end: {
+                              line: 15
+                              col: 22
+                            }
                           }
                         }
                       }
-                    }
-                    arg {
-                      literal {
-                        i: 3
+                      source_context: {
+                        file: "tests/funcs.sysl"
+                        start: {
+                          line: 15
+                          col: 19
+                        }
+                        end: {
+                          line: 15
+                          col: 23
+                        }
                       }
                     }
+                    arg: {
+                      literal: {
+                        i: 3
+                      }
+                      source_context: {
+                        file: "tests/funcs.sysl"
+                        start: {
+                          line: 15
+                          col: 26
+                        }
+                        end: {
+                          line: 15
+                          col: 26
+                        }
+                      }
+                    }
+                  }
+                  source_context: {
+                    file: "tests/funcs.sysl"
+                    start: {
+                      line: 15
+                      col: 6
+                    }
+                    end: {
+                      line: 15
+                      col: 27
+                    }
+                    text: "foo = concat([1,2], 3)"
                   }
                 }
               }
             }
-            stmt {
-              assign {
+            stmt: {
+              assign: {
                 name: "foo"
-                expr {
-                  call {
+                expr: {
+                  call: {
                     func: "regsub"
-                    arg {
-                      literal {
+                    arg: {
+                      literal: {
                         s: "\\D+"
                       }
-                    }
-                    arg {
-                      literal {
-                        s: ""
+                      source_context: {
+                        file: "tests/funcs.sysl"
+                        start: {
+                          line: 16
+                          col: 19
+                        }
+                        end: {
+                          line: 16
+                          col: 19
+                        }
                       }
                     }
-                    arg {
-                      get_attr {
-                        arg {
+                    arg: {
+                      literal: {
+                        s: ""
+                      }
+                      source_context: {
+                        file: "tests/funcs.sysl"
+                        start: {
+                          line: 16
+                          col: 27
+                        }
+                        end: {
+                          line: 16
+                          col: 27
+                        }
+                      }
+                    }
+                    arg: {
+                      get_attr: {
+                        arg: {
                           name: "."
+                          source_context: {
+                            file: "tests/funcs.sysl"
+                            start: {
+                              line: 16
+                              col: 31
+                            }
+                            end: {
+                              line: 16
+                              col: 32
+                            }
+                          }
                         }
                         attr: "a"
                       }
+                      source_context: {
+                        file: "tests/funcs.sysl"
+                        start: {
+                          line: 16
+                          col: 31
+                        }
+                        end: {
+                          line: 16
+                          col: 32
+                        }
+                      }
                     }
+                  }
+                  source_context: {
+                    file: "tests/funcs.sysl"
+                    start: {
+                      line: 16
+                      col: 6
+                    }
+                    end: {
+                      line: 16
+                      col: 33
+                    }
+                    text: "foo = regsub(\"\\\\D+\", \"\", .a)"
                   }
                 }
               }
             }
-            stmt {
-              assign {
+            stmt: {
+              assign: {
                 name: "foo"
-                expr {
-                  literal {
+                expr: {
+                  literal: {
                     s: "\r\n"
                   }
+                  source_context: {
+                    file: "tests/funcs.sysl"
+                    start: {
+                      line: 17
+                      col: 6
+                    }
+                    end: {
+                      line: 17
+                      col: 12
+                    }
+                    text: "foo = \"\\r\\n\""
+                  }
                 }
               }
             }
-            stmt {
-              inject {
-                call {
+            stmt: {
+              inject: {
+                call: {
                   func: "withAnonymousSetOfReturnType"
-                  arg {
-                    literal {
+                  arg: {
+                    literal: {
                       i: 10
                     }
+                    source_context: {
+                      file: "tests/funcs.sysl"
+                      start: {
+                        line: 18
+                        col: 35
+                      }
+                      end: {
+                        line: 18
+                        col: 35
+                      }
+                    }
                   }
-                  arg {
+                  arg: {
                     name: "out"
+                    source_context: {
+                      file: "tests/funcs.sysl"
+                      start: {
+                        line: 18
+                        col: 6
+                      }
+                      end: {
+                        line: 18
+                        col: 40
+                      }
+                    }
                   }
+                }
+                source_context: {
+                  file: "tests/funcs.sysl"
+                  start: {
+                    line: 18
+                    col: 6
+                  }
+                  end: {
+                    line: 18
+                    col: 37
+                  }
+                  text: "withAnonymousSetOfReturnType(10)"
                 }
               }
             }
           }
+          source_context: {
+            file: "tests/funcs.sysl"
+            start: {
+              line: 3
+              col: 4
+            }
+            end: {
+              line: 19
+              col: 5
+            }
+          }
         }
+        source_context: {
+          file: "tests/funcs.sysl"
+          start: {
+            line: 2
+            col: 2
+          }
+          end: {
+            line: 20
+          }
+          text: "!view TestInbuiltFuncs(number <: int) -> int:"
+        }
+      }
+    }
+    source_context: {
+      file: "tests/funcs.sysl"
+      start: {
+        line: 1
+        col: 1
+      }
+      end: {
+        line: 1
+        col: 47
       }
     }
   }

--- a/pkg/parse/tests/group_stmt.sysl.golden.textpb
+++ b/pkg/parse/tests/group_stmt.sysl.golden.textpb
@@ -1,28 +1,48 @@
-apps {
+apps: {
   key: "App"
-  value {
-    name {
+  value: {
+    name: {
       part: "App"
     }
-    endpoints {
+    endpoints: {
       key: "Endpoint"
-      value {
+      value: {
         name: "Endpoint"
-        stmt {
-          group {
+        stmt: {
+          group: {
             title: "group in series"
-            stmt {
-              action {
+            stmt: {
+              action: {
                 action: "do something"
               }
             }
-            stmt {
-              action {
+            stmt: {
+              action: {
                 action: "do another thing"
               }
             }
           }
         }
+        source_context: {
+          file: "tests/group_stmt.sysl"
+          start: {
+            line: 2
+            col: 4
+          }
+          end: {
+            line: 6
+          }
+        }
+      }
+    }
+    source_context: {
+      file: "tests/group_stmt.sysl"
+      start: {
+        line: 1
+        col: 1
+      }
+      end: {
+        line: 1
       }
     }
   }

--- a/pkg/parse/tests/if_else.sysl.golden.textpb
+++ b/pkg/parse/tests/if_else.sysl.golden.textpb
@@ -1,76 +1,76 @@
-apps {
+apps: {
   key: "Test - App"
-  value {
-    name {
+  value: {
+    name: {
       part: "Test - App"
     }
-    endpoints {
+    endpoints: {
       key: "Test - Endpoint"
-      value {
+      value: {
         name: "Test - Endpoint"
-        stmt {
-          cond {
+        stmt: {
+          cond: {
             test: "value == one"
-            stmt {
-              action {
+            stmt: {
+              action: {
                 action: "do something"
               }
             }
           }
         }
-        stmt {
-          group {
+        stmt: {
+          group: {
             title: "else if value == two"
-            stmt {
-              action {
+            stmt: {
+              action: {
                 action: "do something else"
               }
             }
           }
         }
-        stmt {
-          group {
+        stmt: {
+          group: {
             title: "else"
-            stmt {
-              ret {
+            stmt: {
+              ret: {
                 payload: "ok"
               }
             }
           }
         }
-        stmt {
-          group {
+        stmt: {
+          group: {
             title: "alt condition one"
-            stmt {
-              action {
+            stmt: {
+              action: {
                 action: "handle one"
               }
             }
           }
         }
-        stmt {
-          group {
+        stmt: {
+          group: {
             title: "alt condition two"
-            stmt {
-              action {
+            stmt: {
+              action: {
                 action: "check more details"
               }
             }
-            stmt {
-              group {
+            stmt: {
+              group: {
                 title: "alt condition three"
-                stmt {
-                  action {
+                stmt: {
+                  action: {
                     action: "handle three"
                   }
                 }
               }
             }
-            stmt {
-              group {
+            stmt: {
+              group: {
                 title: "alt condition four"
-                stmt {
-                  action {
+                stmt: {
+                  action: {
                     action: "handle four"
                   }
                 }
@@ -78,6 +78,26 @@ apps {
             }
           }
         }
+        source_context: {
+          file: "tests/if_else.sysl"
+          start: {
+            line: 2
+            col: 4
+          }
+          end: {
+            line: 18
+          }
+        }
+      }
+    }
+    source_context: {
+      file: "tests/if_else.sysl"
+      start: {
+        line: 1
+        col: 1
+      }
+      end: {
+        line: 1
       }
     }
   }

--- a/pkg/parse/tests/implied.sysl.golden.textpb
+++ b/pkg/parse/tests/implied.sysl.golden.textpb
@@ -1,451 +1,1298 @@
-apps {
+apps: {
   key: "TransformationTest"
-  value {
-    name {
+  value: {
+    name: {
       part: "TransformationTest"
     }
-    attrs {
+    attrs: {
       key: "package"
-      value {
+      value: {
         s: "io.sysl.test.views"
       }
     }
-    views {
+    views: {
       key: "impliedTest"
-      value {
-        param {
+      value: {
+        param: {
           name: "number"
-          type {
+          type: {
             primitive: INT
           }
         }
-        ret_type {
+        ret_type: {
           primitive: INT
         }
-        expr {
-          transform {
-            arg {
+        expr: {
+          transform: {
+            arg: {
               name: "number"
+              source_context: {
+                file: "tests/implied.sysl"
+                start: {
+                  line: 3
+                  col: 4
+                }
+                end: {
+                  line: 3
+                  col: 4
+                }
+              }
             }
             scopevar: "."
-            stmt {
-              assign {
+            stmt: {
+              assign: {
                 name: "abc2"
-                expr {
-                  binexpr {
+                expr: {
+                  binexpr: {
                     op: MUL
-                    lhs {
-                    }
-                    rhs {
-                      literal {
-                        i: 2
+                    lhs: {
+                      source_context: {
+                        file: "tests/implied.sysl"
+                        start: {
+                          line: 4
+                          col: 13
+                        }
+                        end: {
+                          line: 4
+                          col: 13
+                        }
                       }
                     }
+                    rhs: {
+                      literal: {
+                        i: 2
+                      }
+                      type: {
+                        primitive: INT
+                      }
+                      source_context: {
+                        file: "tests/implied.sysl"
+                        start: {
+                          line: 4
+                          col: 19
+                        }
+                        end: {
+                          line: 4
+                          col: 19
+                        }
+                      }
+                    }
+                  }
+                  type: {
+                    primitive: INT
+                  }
+                  source_context: {
+                    file: "tests/implied.sysl"
+                    start: {
+                      line: 4
+                      col: 6
+                    }
+                    end: {
+                      line: 4
+                      col: 19
+                    }
+                    text: "abc2 = ... * 2"
                   }
                 }
               }
             }
-            stmt {
-              assign {
+            stmt: {
+              assign: {
                 name: "abc3a"
-                expr {
-                  get_attr {
-                    arg {
+                expr: {
+                  get_attr: {
+                    arg: {
                       name: "."
+                      source_context: {
+                        file: "tests/implied.sysl"
+                        start: {
+                          line: 5
+                          col: 14
+                        }
+                        end: {
+                          line: 5
+                          col: 16
+                        }
+                      }
                     }
                     attr: "abc"
                     nullsafe: true
                   }
-                }
-              }
-            }
-            stmt {
-              assign {
-                name: "abc3b1"
-                expr {
-                  navigate {
-                    arg {
-                      name: "."
+                  source_context: {
+                    file: "tests/implied.sysl"
+                    start: {
+                      line: 5
+                      col: 6
                     }
-                    attr: "abc"
+                    end: {
+                      line: 5
+                      col: 16
+                    }
+                    text: "abc3a = ?.abc"
                   }
                 }
               }
             }
-            stmt {
-              assign {
-                name: "abc3b2"
-                expr {
-                  navigate {
-                    arg {
+            stmt: {
+              assign: {
+                name: "abc3b1"
+                expr: {
+                  navigate: {
+                    arg: {
                       name: "."
+                      source_context: {
+                        file: "tests/implied.sysl"
+                        start: {
+                          line: 6
+                          col: 15
+                        }
+                        end: {
+                          line: 6
+                          col: 18
+                        }
+                      }
+                    }
+                    attr: "abc"
+                  }
+                  source_context: {
+                    file: "tests/implied.sysl"
+                    start: {
+                      line: 6
+                      col: 6
+                    }
+                    end: {
+                      line: 6
+                      col: 18
+                    }
+                    text: "abc3b1 = -> abc"
+                  }
+                }
+              }
+            }
+            stmt: {
+              assign: {
+                name: "abc3b2"
+                expr: {
+                  navigate: {
+                    arg: {
+                      name: "."
+                      source_context: {
+                        file: "tests/implied.sysl"
+                        start: {
+                          line: 7
+                          col: 15
+                        }
+                        end: {
+                          line: 7
+                          col: 33
+                        }
+                      }
                     }
                     attr: "abc"
                     setof: true
                     via: "foo"
                   }
+                  source_context: {
+                    file: "tests/implied.sysl"
+                    start: {
+                      line: 7
+                      col: 6
+                    }
+                    end: {
+                      line: 7
+                      col: 33
+                    }
+                    text: "abc3b2 = -> set of abc via foo"
+                  }
                 }
               }
             }
-            stmt {
-              assign {
+            stmt: {
+              assign: {
                 name: "abc3b3"
-                expr {
-                  navigate {
-                    arg {
+                expr: {
+                  navigate: {
+                    arg: {
                       name: "."
+                      source_context: {
+                        file: "tests/implied.sysl"
+                        start: {
+                          line: 8
+                          col: 15
+                        }
+                        end: {
+                          line: 8
+                          col: 34
+                        }
+                      }
                     }
                     attr: ".abc"
                     setof: true
                     via: "foo"
                   }
-                }
-              }
-            }
-            stmt {
-              assign {
-                name: "abc3c"
-                expr {
-                  unexpr {
-                    op: INV
-                    arg {
-                      binexpr {
-                        op: TO_MATCHING
-                        lhs {
-                          name: "."
-                        }
-                        rhs {
-                          name: "abc"
-                        }
-                        attr_name: "*"
-                      }
+                  source_context: {
+                    file: "tests/implied.sysl"
+                    start: {
+                      line: 8
+                      col: 6
                     }
+                    end: {
+                      line: 8
+                      col: 34
+                    }
+                    text: "abc3b3 = -> set of .abc via foo"
                   }
                 }
               }
             }
-            stmt {
-              assign {
-                name: "abc3c1"
-                expr {
-                  unexpr {
+            stmt: {
+              assign: {
+                name: "abc3c"
+                expr: {
+                  unexpr: {
                     op: INV
-                    arg {
-                      binexpr {
+                    arg: {
+                      binexpr: {
                         op: TO_MATCHING
-                        lhs {
+                        lhs: {
                           name: "."
-                        }
-                        rhs {
-                          get_attr {
-                            arg {
-                              name: "."
+                          source_context: {
+                            file: "tests/implied.sysl"
+                            start: {
+                              line: 9
+                              col: 15
                             }
-                            attr: "abc"
+                            end: {
+                              line: 9
+                              col: 18
+                            }
+                          }
+                        }
+                        rhs: {
+                          name: "abc"
+                          source_context: {
+                            file: "tests/implied.sysl"
+                            start: {
+                              line: 9
+                              col: 18
+                            }
+                            end: {
+                              line: 9
+                              col: 18
+                            }
                           }
                         }
                         attr_name: "*"
                       }
+                      type: {
+                        no_type: {}
+                      }
+                      source_context: {
+                        file: "tests/implied.sysl"
+                        start: {
+                          line: 9
+                          col: 15
+                        }
+                        end: {
+                          line: 9
+                          col: 18
+                        }
+                      }
                     }
+                  }
+                  type: {
+                    primitive: BOOL
+                  }
+                  source_context: {
+                    file: "tests/implied.sysl"
+                    start: {
+                      line: 9
+                      col: 6
+                    }
+                    end: {
+                      line: 9
+                      col: 18
+                    }
+                    text: "abc3c = ~~> abc"
                   }
                 }
               }
             }
-            stmt {
-              assign {
-                name: "abc3d"
-                expr {
-                  unexpr {
+            stmt: {
+              assign: {
+                name: "abc3c1"
+                expr: {
+                  unexpr: {
                     op: INV
-                    arg {
-                      binexpr {
+                    arg: {
+                      binexpr: {
                         op: TO_MATCHING
-                        lhs {
+                        lhs: {
                           name: "."
+                          source_context: {
+                            file: "tests/implied.sysl"
+                            start: {
+                              line: 10
+                              col: 16
+                            }
+                            end: {
+                              line: 10
+                              col: 20
+                            }
+                          }
                         }
-                        rhs {
-                          name: "abc"
-                        }
-                        attr_name: "abc"
-                      }
-                    }
-                  }
-                }
-              }
-            }
-            stmt {
-              assign {
-                name: "abc3e"
-                expr {
-                  unexpr {
-                    op: INV
-                    arg {
-                      binexpr {
-                        op: TO_NOT_MATCHING
-                        lhs {
-                          name: "."
-                        }
-                        rhs {
-                          name: "abc"
-                        }
-                        attr_name: "abc"
-                      }
-                    }
-                  }
-                }
-              }
-            }
-            stmt {
-              assign {
-                name: "abc3f"
-                expr {
-                  unexpr {
-                    op: INV
-                    arg {
-                      binexpr {
-                        op: TO_MATCHING
-                        lhs {
-                          name: "."
-                        }
-                        rhs {
-                          name: "abc"
-                        }
-                        attr_name: "abc"
-                        attr_name: "def"
-                      }
-                    }
-                  }
-                }
-              }
-            }
-            stmt {
-              assign {
-                name: "abc3g"
-                expr {
-                  unexpr {
-                    op: INV
-                    arg {
-                      binexpr {
-                        op: TO_NOT_MATCHING
-                        lhs {
-                          name: "."
-                        }
-                        rhs {
-                          name: "abc"
-                        }
-                        attr_name: "abc"
-                        attr_name: "def"
-                      }
-                    }
-                  }
-                }
-              }
-            }
-            stmt {
-              assign {
-                name: "abc3h"
-                expr {
-                  unexpr {
-                    op: INV
-                    arg {
-                      get_attr {
-                        arg {
-                          get_attr {
-                            arg {
-                              binexpr {
-                                op: TO_MATCHING
-                                lhs {
-                                  name: "."
+                        rhs: {
+                          get_attr: {
+                            arg: {
+                              name: "."
+                              source_context: {
+                                file: "tests/implied.sysl"
+                                start: {
+                                  line: 10
+                                  col: 19
                                 }
-                                rhs {
-                                  name: "foo"
+                                end: {
+                                  line: 10
+                                  col: 20
                                 }
-                                attr_name: "*"
                               }
                             }
                             attr: "abc"
                           }
+                          source_context: {
+                            file: "tests/implied.sysl"
+                            start: {
+                              line: 10
+                              col: 19
+                            }
+                            end: {
+                              line: 10
+                              col: 20
+                            }
+                          }
                         }
-                        attr: "def"
+                        attr_name: "*"
+                      }
+                      type: {
+                        no_type: {}
+                      }
+                      source_context: {
+                        file: "tests/implied.sysl"
+                        start: {
+                          line: 10
+                          col: 16
+                        }
+                        end: {
+                          line: 10
+                          col: 20
+                        }
                       }
                     }
+                  }
+                  type: {
+                    primitive: BOOL
+                  }
+                  source_context: {
+                    file: "tests/implied.sysl"
+                    start: {
+                      line: 10
+                      col: 6
+                    }
+                    end: {
+                      line: 10
+                      col: 20
+                    }
+                    text: "abc3c1 = ~~> .abc"
                   }
                 }
               }
             }
-            stmt {
-              assign {
-                name: "abc4a"
-                expr {
-                  binexpr {
-                    op: WHERE
-                    lhs {
-                      name: "."
-                    }
-                    rhs {
-                      literal {
-                        b: true
-                      }
-                      type {
-                        primitive: BOOL
-                      }
-                    }
-                    scopevar: "abcdef"
-                  }
-                }
-              }
-            }
-            stmt {
-              assign {
-                name: "abc5a"
-                expr {
-                  get_attr {
-                    arg {
-                      name: "."
-                    }
-                    attr: "abc"
-                    setof: true
-                  }
-                }
-              }
-            }
-            stmt {
-              assign {
-                name: "abc5a1"
-                expr {
-                  get_attr {
-                    arg {
-                      get_attr {
-                        arg {
+            stmt: {
+              assign: {
+                name: "abc3d"
+                expr: {
+                  unexpr: {
+                    op: INV
+                    arg: {
+                      binexpr: {
+                        op: TO_MATCHING
+                        lhs: {
                           name: "."
+                          source_context: {
+                            file: "tests/implied.sysl"
+                            start: {
+                              line: 11
+                              col: 15
+                            }
+                            end: {
+                              line: 11
+                              col: 23
+                            }
+                          }
                         }
-                        attr: "abc"
-                        setof: true
+                        rhs: {
+                          name: "abc"
+                          source_context: {
+                            file: "tests/implied.sysl"
+                            start: {
+                              line: 11
+                              col: 23
+                            }
+                            end: {
+                              line: 11
+                              col: 23
+                            }
+                          }
+                        }
+                        attr_name: "abc"
+                      }
+                      type: {
+                        no_type: {}
+                      }
+                      source_context: {
+                        file: "tests/implied.sysl"
+                        start: {
+                          line: 11
+                          col: 15
+                        }
+                        end: {
+                          line: 11
+                          col: 23
+                        }
                       }
                     }
-                    attr: "def"
+                  }
+                  type: {
+                    primitive: BOOL
+                  }
+                  source_context: {
+                    file: "tests/implied.sysl"
+                    start: {
+                      line: 11
+                      col: 6
+                    }
+                    end: {
+                      line: 11
+                      col: 23
+                    }
+                    text: "abc3d = ~~[abc]> abc"
                   }
                 }
               }
             }
-            stmt {
-              assign {
-                name: "abc5b"
-                expr {
-                  get_attr {
-                    arg {
-                      get_attr {
-                        arg {
-                          get_attr {
-                            arg {
-                              name: "."
+            stmt: {
+              assign: {
+                name: "abc3e"
+                expr: {
+                  unexpr: {
+                    op: INV
+                    arg: {
+                      binexpr: {
+                        op: TO_NOT_MATCHING
+                        lhs: {
+                          name: "."
+                          source_context: {
+                            file: "tests/implied.sysl"
+                            start: {
+                              line: 12
+                              col: 15
+                            }
+                            end: {
+                              line: 12
+                              col: 24
+                            }
+                          }
+                        }
+                        rhs: {
+                          name: "abc"
+                          source_context: {
+                            file: "tests/implied.sysl"
+                            start: {
+                              line: 12
+                              col: 24
+                            }
+                            end: {
+                              line: 12
+                              col: 24
+                            }
+                          }
+                        }
+                        attr_name: "abc"
+                      }
+                      type: {
+                        no_type: {}
+                      }
+                      source_context: {
+                        file: "tests/implied.sysl"
+                        start: {
+                          line: 12
+                          col: 15
+                        }
+                        end: {
+                          line: 12
+                          col: 24
+                        }
+                      }
+                    }
+                  }
+                  type: {
+                    primitive: BOOL
+                  }
+                  source_context: {
+                    file: "tests/implied.sysl"
+                    start: {
+                      line: 12
+                      col: 6
+                    }
+                    end: {
+                      line: 12
+                      col: 24
+                    }
+                    text: "abc3e = ~!~[abc]> abc"
+                  }
+                }
+              }
+            }
+            stmt: {
+              assign: {
+                name: "abc3f"
+                expr: {
+                  unexpr: {
+                    op: INV
+                    arg: {
+                      binexpr: {
+                        op: TO_MATCHING
+                        lhs: {
+                          name: "."
+                          source_context: {
+                            file: "tests/implied.sysl"
+                            start: {
+                              line: 13
+                              col: 15
+                            }
+                            end: {
+                              line: 13
+                              col: 27
+                            }
+                          }
+                        }
+                        rhs: {
+                          name: "abc"
+                          source_context: {
+                            file: "tests/implied.sysl"
+                            start: {
+                              line: 13
+                              col: 27
+                            }
+                            end: {
+                              line: 13
+                              col: 27
+                            }
+                          }
+                        }
+                        attr_name: "abc"
+                        attr_name: "def"
+                      }
+                      type: {
+                        no_type: {}
+                      }
+                      source_context: {
+                        file: "tests/implied.sysl"
+                        start: {
+                          line: 13
+                          col: 15
+                        }
+                        end: {
+                          line: 13
+                          col: 27
+                        }
+                      }
+                    }
+                  }
+                  type: {
+                    primitive: BOOL
+                  }
+                  source_context: {
+                    file: "tests/implied.sysl"
+                    start: {
+                      line: 13
+                      col: 6
+                    }
+                    end: {
+                      line: 13
+                      col: 27
+                    }
+                    text: "abc3f = ~~[abc,def]> abc"
+                  }
+                }
+              }
+            }
+            stmt: {
+              assign: {
+                name: "abc3g"
+                expr: {
+                  unexpr: {
+                    op: INV
+                    arg: {
+                      binexpr: {
+                        op: TO_NOT_MATCHING
+                        lhs: {
+                          name: "."
+                          source_context: {
+                            file: "tests/implied.sysl"
+                            start: {
+                              line: 14
+                              col: 15
+                            }
+                            end: {
+                              line: 14
+                              col: 28
+                            }
+                          }
+                        }
+                        rhs: {
+                          name: "abc"
+                          source_context: {
+                            file: "tests/implied.sysl"
+                            start: {
+                              line: 14
+                              col: 28
+                            }
+                            end: {
+                              line: 14
+                              col: 28
+                            }
+                          }
+                        }
+                        attr_name: "abc"
+                        attr_name: "def"
+                      }
+                      type: {
+                        no_type: {}
+                      }
+                      source_context: {
+                        file: "tests/implied.sysl"
+                        start: {
+                          line: 14
+                          col: 15
+                        }
+                        end: {
+                          line: 14
+                          col: 28
+                        }
+                      }
+                    }
+                  }
+                  type: {
+                    primitive: BOOL
+                  }
+                  source_context: {
+                    file: "tests/implied.sysl"
+                    start: {
+                      line: 14
+                      col: 6
+                    }
+                    end: {
+                      line: 14
+                      col: 28
+                    }
+                    text: "abc3g = ~!~[abc,def]> abc"
+                  }
+                }
+              }
+            }
+            stmt: {
+              assign: {
+                name: "abc3h"
+                expr: {
+                  unexpr: {
+                    op: INV
+                    arg: {
+                      get_attr: {
+                        arg: {
+                          get_attr: {
+                            arg: {
+                              binexpr: {
+                                op: TO_MATCHING
+                                lhs: {
+                                  name: "."
+                                  source_context: {
+                                    file: "tests/implied.sysl"
+                                    start: {
+                                      line: 15
+                                      col: 15
+                                    }
+                                    end: {
+                                      line: 15
+                                      col: 18
+                                    }
+                                  }
+                                }
+                                rhs: {
+                                  name: "foo"
+                                  source_context: {
+                                    file: "tests/implied.sysl"
+                                    start: {
+                                      line: 15
+                                      col: 18
+                                    }
+                                    end: {
+                                      line: 15
+                                      col: 18
+                                    }
+                                  }
+                                }
+                                attr_name: "*"
+                              }
+                              source_context: {
+                                file: "tests/implied.sysl"
+                                start: {
+                                  line: 15
+                                  col: 15
+                                }
+                                end: {
+                                  line: 15
+                                  col: 18
+                                }
+                              }
                             }
                             attr: "abc"
-                            setof: true
+                          }
+                          source_context: {
+                            file: "tests/implied.sysl"
+                            start: {
+                              line: 15
+                              col: 21
+                            }
+                            end: {
+                              line: 15
+                              col: 22
+                            }
                           }
                         }
                         attr: "def"
                       }
+                      source_context: {
+                        file: "tests/implied.sysl"
+                        start: {
+                          line: 15
+                          col: 25
+                        }
+                        end: {
+                          line: 15
+                          col: 26
+                        }
+                      }
                     }
-                    attr: "ghi"
+                  }
+                  type: {
+                    primitive: BOOL
+                  }
+                  source_context: {
+                    file: "tests/implied.sysl"
+                    start: {
+                      line: 15
+                      col: 6
+                    }
+                    end: {
+                      line: 15
+                      col: 26
+                    }
+                    text: "abc3h = ~~> foo.abc.def"
                   }
                 }
               }
             }
-            stmt {
-              assign {
-                name: "abc5c"
-                expr {
-                  get_attr {
-                    arg {
-                      get_attr {
-                        arg {
+            stmt: {
+              assign: {
+                name: "abc4a"
+                expr: {
+                  binexpr: {
+                    op: WHERE
+                    lhs: {
+                      name: "."
+                      source_context: {
+                        file: "tests/implied.sysl"
+                        start: {
+                          line: 16
+                          col: 14
+                        }
+                        end: {
+                          line: 16
+                          col: 34
+                        }
+                      }
+                    }
+                    rhs: {
+                      literal: {
+                        b: true
+                      }
+                      type: {
+                        primitive: BOOL
+                      }
+                      source_context: {
+                        file: "tests/implied.sysl"
+                        start: {
+                          line: 16
+                          col: 30
+                        }
+                        end: {
+                          line: 16
+                          col: 30
+                        }
+                      }
+                    }
+                    scopevar: "abcdef"
+                  }
+                  type: {
+                    primitive: BOOL
+                  }
+                  source_context: {
+                    file: "tests/implied.sysl"
+                    start: {
+                      line: 16
+                      col: 6
+                    }
+                    end: {
+                      line: 16
+                      col: 34
+                    }
+                    text: "abc4a = . where(abcdef: true)"
+                  }
+                }
+              }
+            }
+            stmt: {
+              assign: {
+                name: "abc5a"
+                expr: {
+                  get_attr: {
+                    arg: {
+                      name: "."
+                      source_context: {
+                        file: "tests/implied.sysl"
+                        start: {
+                          line: 18
+                          col: 14
+                        }
+                        end: {
+                          line: 18
+                          col: 24
+                        }
+                      }
+                    }
+                    attr: "abc"
+                    setof: true
+                  }
+                  source_context: {
+                    file: "tests/implied.sysl"
+                    start: {
+                      line: 18
+                      col: 6
+                    }
+                    end: {
+                      line: 18
+                      col: 24
+                    }
+                    text: "abc5a = .table of abc"
+                  }
+                }
+              }
+            }
+            stmt: {
+              assign: {
+                name: "abc5a1"
+                expr: {
+                  get_attr: {
+                    arg: {
+                      get_attr: {
+                        arg: {
                           name: "."
+                          source_context: {
+                            file: "tests/implied.sysl"
+                            start: {
+                              line: 19
+                              col: 15
+                            }
+                            end: {
+                              line: 19
+                              col: 25
+                            }
+                          }
+                        }
+                        attr: "abc"
+                        setof: true
+                      }
+                      source_context: {
+                        file: "tests/implied.sysl"
+                        start: {
+                          line: 19
+                          col: 15
+                        }
+                        end: {
+                          line: 19
+                          col: 25
+                        }
+                      }
+                    }
+                    attr: "def"
+                  }
+                  source_context: {
+                    file: "tests/implied.sysl"
+                    start: {
+                      line: 19
+                      col: 6
+                    }
+                    end: {
+                      line: 19
+                      col: 29
+                    }
+                    text: "abc5a1 = .table of abc.def"
+                  }
+                }
+              }
+            }
+            stmt: {
+              assign: {
+                name: "abc5b"
+                expr: {
+                  get_attr: {
+                    arg: {
+                      get_attr: {
+                        arg: {
+                          get_attr: {
+                            arg: {
+                              name: "."
+                              source_context: {
+                                file: "tests/implied.sysl"
+                                start: {
+                                  line: 20
+                                  col: 14
+                                }
+                                end: {
+                                  line: 20
+                                  col: 24
+                                }
+                              }
+                            }
+                            attr: "abc"
+                            setof: true
+                          }
+                          source_context: {
+                            file: "tests/implied.sysl"
+                            start: {
+                              line: 20
+                              col: 14
+                            }
+                            end: {
+                              line: 20
+                              col: 24
+                            }
+                          }
+                        }
+                        attr: "def"
+                      }
+                      source_context: {
+                        file: "tests/implied.sysl"
+                        start: {
+                          line: 20
+                          col: 27
+                        }
+                        end: {
+                          line: 20
+                          col: 28
+                        }
+                      }
+                    }
+                    attr: "ghi"
+                  }
+                  source_context: {
+                    file: "tests/implied.sysl"
+                    start: {
+                      line: 20
+                      col: 6
+                    }
+                    end: {
+                      line: 20
+                      col: 32
+                    }
+                    text: "abc5b = .table of abc.def.ghi"
+                  }
+                }
+              }
+            }
+            stmt: {
+              assign: {
+                name: "abc5c"
+                expr: {
+                  get_attr: {
+                    arg: {
+                      get_attr: {
+                        arg: {
+                          name: "."
+                          source_context: {
+                            file: "tests/implied.sysl"
+                            start: {
+                              line: 21
+                              col: 14
+                            }
+                            end: {
+                              line: 21
+                              col: 25
+                            }
+                          }
                         }
                         attr: "abc"
                         nullsafe: true
                         setof: true
                       }
+                      source_context: {
+                        file: "tests/implied.sysl"
+                        start: {
+                          line: 21
+                          col: 14
+                        }
+                        end: {
+                          line: 21
+                          col: 25
+                        }
+                      }
                     }
                     attr: "def"
+                  }
+                  source_context: {
+                    file: "tests/implied.sysl"
+                    start: {
+                      line: 21
+                      col: 6
+                    }
+                    end: {
+                      line: 21
+                      col: 29
+                    }
+                    text: "abc5c = ?.table of abc.def"
                   }
                 }
               }
             }
-            stmt {
-              assign {
+            stmt: {
+              assign: {
                 name: "abc5d"
-                expr {
-                  get_attr {
-                    arg {
+                expr: {
+                  get_attr: {
+                    arg: {
                       name: "abc"
+                      source_context: {
+                        file: "tests/implied.sysl"
+                        start: {
+                          line: 22
+                          col: 14
+                        }
+                        end: {
+                          line: 22
+                          col: 14
+                        }
+                      }
                     }
                     attr: "def"
+                  }
+                  source_context: {
+                    file: "tests/implied.sysl"
+                    start: {
+                      line: 22
+                      col: 6
+                    }
+                    end: {
+                      line: 22
+                      col: 18
+                    }
+                    text: "abc5d = abc.def"
                   }
                 }
               }
             }
-            stmt {
-              assign {
+            stmt: {
+              assign: {
                 name: "abc5e"
-                expr {
-                  get_attr {
-                    arg {
-                      get_attr {
-                        arg {
+                expr: {
+                  get_attr: {
+                    arg: {
+                      get_attr: {
+                        arg: {
                           name: "abc"
+                          source_context: {
+                            file: "tests/implied.sysl"
+                            start: {
+                              line: 23
+                              col: 14
+                            }
+                            end: {
+                              line: 23
+                              col: 14
+                            }
+                          }
                         }
                         attr: "def"
+                      }
+                      source_context: {
+                        file: "tests/implied.sysl"
+                        start: {
+                          line: 23
+                          col: 17
+                        }
+                        end: {
+                          line: 23
+                          col: 18
+                        }
                       }
                     }
                     attr: "ghi"
                   }
+                  source_context: {
+                    file: "tests/implied.sysl"
+                    start: {
+                      line: 23
+                      col: 6
+                    }
+                    end: {
+                      line: 23
+                      col: 22
+                    }
+                    text: "abc5e = abc.def.ghi"
+                  }
                 }
               }
             }
-            stmt {
-              assign {
+            stmt: {
+              assign: {
                 name: "abc5f"
-                expr {
-                  get_attr {
-                    arg {
-                      get_attr {
-                        arg {
+                expr: {
+                  get_attr: {
+                    arg: {
+                      get_attr: {
+                        arg: {
                           name: "."
+                          source_context: {
+                            file: "tests/implied.sysl"
+                            start: {
+                              line: 24
+                              col: 14
+                            }
+                            end: {
+                              line: 24
+                              col: 15
+                            }
+                          }
                         }
                         attr: "abc"
+                      }
+                      source_context: {
+                        file: "tests/implied.sysl"
+                        start: {
+                          line: 24
+                          col: 14
+                        }
+                        end: {
+                          line: 24
+                          col: 15
+                        }
                       }
                     }
                     attr: "def"
                   }
+                  source_context: {
+                    file: "tests/implied.sysl"
+                    start: {
+                      line: 24
+                      col: 6
+                    }
+                    end: {
+                      line: 24
+                      col: 19
+                    }
+                    text: "abc5f = .abc.def"
+                  }
                 }
               }
             }
-            stmt {
-              assign {
+            stmt: {
+              assign: {
                 name: "abc6"
-                expr {
-                  set {
-                    expr {
-                      type {
-                        tuple {
-                        }
+                expr: {
+                  set: {
+                    expr: {
+                      tuple: {}
+                      type: {
+                        tuple: {}
                       }
-                      tuple {
+                      source_context: {
+                        file: "tests/implied.sysl"
+                        start: {
+                          line: 25
+                          col: 14
+                        }
+                        end: {
+                          line: 25
+                          col: 14
+                        }
                       }
                     }
                   }
-                  type {
-                    set {
-                      tuple {
-                      }
+                  type: {
+                    set: {
+                      tuple: {}
                     }
+                  }
+                  source_context: {
+                    file: "tests/implied.sysl"
+                    start: {
+                      line: 25
+                      col: 6
+                    }
+                    end: {
+                      line: 25
+                      col: 17
+                    }
+                    text: "abc6 = {{:}}"
                   }
                 }
               }
             }
           }
+          source_context: {
+            file: "tests/implied.sysl"
+            start: {
+              line: 3
+              col: 4
+            }
+            end: {
+              line: 26
+              col: 5
+            }
+          }
         }
+        source_context: {
+          file: "tests/implied.sysl"
+          start: {
+            line: 2
+            col: 2
+          }
+          end: {
+            line: 27
+          }
+          text: "!view impliedTest(number <: int ) -> int:"
+        }
+      }
+    }
+    source_context: {
+      file: "tests/implied.sysl"
+      start: {
+        line: 1
+        col: 1
+      }
+      end: {
+        line: 1
+        col: 47
       }
     }
   }

--- a/pkg/parse/tests/inplace_tuple.sysl.golden.textpb
+++ b/pkg/parse/tests/inplace_tuple.sysl.golden.textpb
@@ -1,1284 +1,1403 @@
-apps: <
+apps: {
   key: "Model"
-  value: <
-    name: <
+  value: {
+    name: {
       part: "Model"
-    >
-    types: <
+    }
+    types: {
       key: "Request"
-      value: <
-        tuple: <
-          attr_defs: <
+      value: {
+        tuple: {
+          attr_defs: {
             key: "bar"
-            value: <
+            value: {
               primitive: DECIMAL
-              constraint: <
-                length: <
+              constraint: {
+                length: {
                   min: 10
                   max: 9999
-                >
-              >
-              source_context: <
+                }
+              }
+              source_context: {
                 file: "tests/inplace_tuple.sysl"
-                start: <
+                start: {
                   line: 19
                   col: 15
-                >
-                end: <
+                }
+                end: {
                   line: 19
                   col: 31
-                >
-              >
-            >
-          >
-        >
-      >
-    >
-  >
->
-apps: <
+                }
+              }
+            }
+          }
+        }
+        source_context: {
+          file: "tests/inplace_tuple.sysl"
+          start: {
+            line: 18
+            col: 4
+          }
+          end: {
+            line: 21
+            col: 2
+          }
+        }
+      }
+    }
+    source_context: {
+      file: "tests/inplace_tuple.sysl"
+      start: {
+        line: 17
+        col: 1
+      }
+      end: {
+        line: 17
+      }
+    }
+  }
+}
+apps: {
   key: "My :: Browser :: Client Model"
-  value: <
-    name: <
+  value: {
+    name: {
       part: "My"
       part: "Browser"
       part: "Client Model"
-    >
-    types: <
+    }
+    types: {
       key: "Request"
-      value: <
-        tuple: <
-          attr_defs: <
+      value: {
+        tuple: {
+          attr_defs: {
             key: "bar"
-            value: <
+            value: {
               primitive: DECIMAL
-              constraint: <
-                length: <
+              constraint: {
+                length: {
                   min: 10
                   max: 9999
-                >
-              >
-              source_context: <
+                }
+              }
+              source_context: {
                 file: "tests/inplace_tuple.sysl"
-                start: <
+                start: {
                   line: 14
                   col: 15
-                >
-                end: <
+                }
+                end: {
                   line: 14
                   col: 31
-                >
-              >
-            >
-          >
-          attr_defs: <
+                }
+              }
+            }
+          }
+          attr_defs: {
             key: "baz"
-            value: <
+            value: {
               primitive: DECIMAL
-              constraint: <
-                length: <
+              constraint: {
+                length: {
                   max: 10
-                >
+                }
                 precision: 10
                 scale: 2
-              >
-              source_context: <
+              }
+              source_context: {
                 file: "tests/inplace_tuple.sysl"
-                start: <
+                start: {
                   line: 15
                   col: 15
-                >
-                end: <
+                }
+                end: {
                   line: 15
                   col: 27
-                >
-              >
-            >
-          >
-          attr_defs: <
+                }
+              }
+            }
+          }
+          attr_defs: {
             key: "foo"
-            value: <
+            value: {
               primitive: DECIMAL
-              constraint: <
-                length: <
+              constraint: {
+                length: {
                   max: 10
-                >
-              >
-              source_context: <
+                }
+              }
+              source_context: {
                 file: "tests/inplace_tuple.sysl"
-                start: <
+                start: {
                   line: 13
                   col: 15
-                >
-                end: <
+                }
+                end: {
                   line: 13
                   col: 25
-                >
-              >
-            >
-          >
-        >
-      >
-    >
-  >
->
-apps: <
+                }
+              }
+            }
+          }
+        }
+        source_context: {
+          file: "tests/inplace_tuple.sysl"
+          start: {
+            line: 12
+            col: 4
+          }
+          end: {
+            line: 17
+            col: 5
+          }
+        }
+      }
+    }
+    source_context: {
+      file: "tests/inplace_tuple.sysl"
+      start: {
+        line: 11
+        col: 1
+      }
+      end: {
+        line: 11
+        col: 17
+      }
+    }
+  }
+}
+apps: {
   key: "My :: Client Model"
-  value: <
-    name: <
+  value: {
+    name: {
       part: "My"
       part: "Client Model"
-    >
+    }
     long_name: "My client Model"
-    types: <
+    types: {
       key: "Request"
-      value: <
-        tuple: <
-          attr_defs: <
+      value: {
+        tuple: {
+          attr_defs: {
             key: "bar"
-            value: <
+            value: {
               primitive: DECIMAL
-              constraint: <
-                length: <
+              constraint: {
+                length: {
                   min: 10
                   max: 9999
-                >
-              >
-              source_context: <
+                }
+              }
+              source_context: {
                 file: "tests/inplace_tuple.sysl"
-                start: <
+                start: {
                   line: 9
                   col: 15
-                >
-                end: <
+                }
+                end: {
                   line: 9
                   col: 31
-                >
-              >
-            >
-          >
-        >
-      >
-    >
-    types: <
+                }
+              }
+            }
+          }
+        }
+        source_context: {
+          file: "tests/inplace_tuple.sysl"
+          start: {
+            line: 8
+            col: 4
+          }
+          end: {
+            line: 11
+            col: 2
+          }
+        }
+      }
+    }
+    types: {
       key: "Response"
-      value: <
-        tuple: <
-          attr_defs: <
+      value: {
+        tuple: {
+          attr_defs: {
             key: "id"
-            value: <
-              list: <
-                type: <
+            value: {
+              list: {
+                type: {
                   primitive: INT
-                  constraint: <
-                    range: <
-                      min: <
+                  constraint: {
+                    range: {
+                      min: {
                         i: -2147483648
-                      >
-                      max: <
+                      }
+                      max: {
                         i: 2147483647
-                      >
-                    >
-                  >
-                  source_context: <
+                      }
+                    }
+                  }
+                  source_context: {
                     file: "tests/inplace_tuple.sysl"
-                    start: <
+                    start: {
                       line: 5
                       col: 22
-                    >
-                    end: <
+                    }
+                    end: {
                       line: 5
                       col: 22
-                    >
-                  >
-                >
-              >
-            >
-          >
-          attr_defs: <
+                    }
+                  }
+                }
+              }
+            }
+          }
+          attr_defs: {
             key: "id2"
-            value: <
-              list: <
-                type: <
+            value: {
+              list: {
+                type: {
                   primitive: INT
-                  constraint: <
-                    range: <
-                      min: <
+                  constraint: {
+                    range: {
+                      min: {
                         i: -9223372036854775808
-                      >
-                      max: <
+                      }
+                      max: {
                         i: 9223372036854775807
-                      >
-                    >
-                  >
-                  source_context: <
+                      }
+                    }
+                  }
+                  source_context: {
                     file: "tests/inplace_tuple.sysl"
-                    start: <
+                    start: {
                       line: 6
                       col: 23
-                    >
-                    end: <
+                    }
+                    end: {
                       line: 6
                       col: 23
-                    >
-                  >
-                >
-              >
-            >
-          >
-          attr_defs: <
+                    }
+                  }
+                }
+              }
+            }
+          }
+          attr_defs: {
             key: "list"
-            value: <
-              list: <
-                type: <
-                  type_ref: <
-                    context: <
-                      appname: <
+            value: {
+              list: {
+                type: {
+                  type_ref: {
+                    context: {
+                      appname: {
                         part: "My"
                         part: "Client Model"
-                      >
+                      }
                       path: "Response"
-                    >
-                    ref: <
+                    }
+                    ref: {
                       path: "Request"
-                    >
-                  >
-                  source_context: <
+                    }
+                  }
+                  source_context: {
                     file: "tests/inplace_tuple.sysl"
-                    start: <
+                    start: {
                       line: 4
                       col: 24
-                    >
-                    end: <
+                    }
+                    end: {
                       line: 4
                       col: 24
-                    >
-                  >
-                >
-              >
-            >
-          >
-          attr_defs: <
+                    }
+                  }
+                }
+              }
+            }
+          }
+          attr_defs: {
             key: "requests"
-            value: <
-              set: <
-                type_ref: <
-                  context: <
-                    appname: <
+            value: {
+              set: {
+                type_ref: {
+                  context: {
+                    appname: {
                       part: "My"
                       part: "Client Model"
-                    >
+                    }
                     path: "Response"
-                  >
-                  ref: <
+                  }
+                  ref: {
                     path: "Request"
-                  >
-                >
-                source_context: <
+                  }
+                }
+                source_context: {
                   file: "tests/inplace_tuple.sysl"
-                  start: <
+                  start: {
                     line: 3
                     col: 20
-                  >
-                  end: <
+                  }
+                  end: {
                     line: 3
                     col: 27
-                  >
-                >
-              >
-              source_context: <
+                  }
+                }
+              }
+              source_context: {
                 file: "tests/inplace_tuple.sysl"
-                start: <
+                start: {
                   line: 3
                   col: 20
-                >
-                end: <
+                }
+                end: {
                   line: 3
                   col: 27
-                >
-              >
-            >
-          >
-        >
-      >
-    >
-  >
->
-apps: <
+                }
+              }
+            }
+          }
+        }
+        source_context: {
+          file: "tests/inplace_tuple.sysl"
+          start: {
+            line: 2
+            col: 4
+          }
+          end: {
+            line: 8
+            col: 4
+          }
+        }
+      }
+    }
+    source_context: {
+      file: "tests/inplace_tuple.sysl"
+      start: {
+        line: 1
+        col: 1
+      }
+      end: {
+        line: 1
+        col: 19
+      }
+    }
+  }
+}
+apps: {
   key: "My :: Tuple Model"
-  value: <
-    name: <
+  value: {
+    name: {
       part: "My"
       part: "Tuple Model"
-    >
-    types: <
+    }
+    types: {
       key: "Req"
-      value: <
-        tuple: <
-          attr_defs: <
+      value: {
+        tuple: {
+          attr_defs: {
             key: "Application"
-            value: <
-              type_ref: <
-                ref: <
+            value: {
+              type_ref: {
+                ref: {
                   path: "Application"
-                >
-              >
-              source_context: <
+                }
+              }
+              source_context: {
                 file: "tests/inplace_tuple.sysl"
-                start: <
+                start: {
                   line: 56
                   col: 8
-                >
-                end: <
+                }
+                end: {
                   line: 67
-                >
-              >
-            >
-          >
-          attr_defs: <
+                }
+              }
+            }
+          }
+          attr_defs: {
             key: "Header"
-            value: <
-              type_ref: <
-                ref: <
+            value: {
+              type_ref: {
+                ref: {
                   path: "Header"
-                >
-              >
-              source_context: <
+                }
+              }
+              source_context: {
                 file: "tests/inplace_tuple.sysl"
-                start: <
+                start: {
                   line: 49
                   col: 8
-                >
-                end: <
+                }
+                end: {
                   line: 56
                   col: 8
-                >
-              >
-            >
-          >
-        >
-      >
-    >
-    types: <
+                }
+              }
+            }
+          }
+        }
+        source_context: {
+          file: "tests/inplace_tuple.sysl"
+          start: {
+            line: 48
+            col: 4
+          }
+          end: {
+            line: 67
+          }
+        }
+      }
+    }
+    types: {
       key: "Req.Application"
-      value: <
-        tuple: <
-          attr_defs: <
+      value: {
+        tuple: {
+          attr_defs: {
             key: "AccountType"
-            value: <
-              no_type: <
-              >
-              source_context: <
+            value: {
+              no_type: {}
+              source_context: {
                 file: "tests/inplace_tuple.sysl"
-                start: <
+                start: {
                   line: 58
                   col: 12
-                >
-                end: <
+                }
+                end: {
                   line: 58
                   col: 12
-                >
-              >
-            >
-          >
-          attr_defs: <
+                }
+              }
+            }
+          }
+          attr_defs: {
             key: "Applicable"
-            value: <
+            value: {
               primitive: BOOL
-              source_context: <
+              source_context: {
                 file: "tests/inplace_tuple.sysl"
-                start: <
+                start: {
                   line: 59
                   col: 26
-                >
-                end: <
+                }
+                end: {
                   line: 59
                   col: 26
-                >
-              >
-            >
-          >
-          attr_defs: <
+                }
+              }
+            }
+          }
+          attr_defs: {
             key: "ApplicationType"
-            value: <
-              no_type: <
-              >
-              source_context: <
+            value: {
+              no_type: {}
+              source_context: {
                 file: "tests/inplace_tuple.sysl"
-                start: <
+                start: {
                   line: 57
                   col: 12
-                >
-                end: <
+                }
+                end: {
                   line: 57
                   col: 12
-                >
-              >
-            >
-          >
-          attr_defs: <
+                }
+              }
+            }
+          }
+          attr_defs: {
             key: "Detail"
-            value: <
-              list: <
-                type: <
-                  type_ref: <
-                    ref: <
+            value: {
+              list: {
+                type: {
+                  type_ref: {
+                    ref: {
                       path: "Detail"
-                    >
-                  >
-                  source_context: <
+                    }
+                  }
+                  source_context: {
                     file: "tests/inplace_tuple.sysl"
-                    start: <
+                    start: {
                       line: 60
                       col: 12
-                    >
-                    end: <
+                    }
+                    end: {
                       line: 64
                       col: 12
-                    >
-                  >
-                >
-              >
-            >
-          >
-          attr_defs: <
+                    }
+                  }
+                }
+              }
+            }
+          }
+          attr_defs: {
             key: "Purpose"
-            value: <
-              list: <
-                type: <
-                  type_ref: <
-                    ref: <
+            value: {
+              list: {
+                type: {
+                  type_ref: {
+                    ref: {
                       path: "Purpose"
-                    >
-                  >
-                  source_context: <
+                    }
+                  }
+                  source_context: {
                     file: "tests/inplace_tuple.sysl"
-                    start: <
+                    start: {
                       line: 64
                       col: 12
-                    >
-                    end: <
+                    }
+                    end: {
                       line: 67
-                    >
-                  >
-                >
-              >
-            >
-          >
-        >
-      >
-    >
-    types: <
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+    types: {
       key: "Req.Application.Detail"
-      value: <
-        tuple: <
-          attr_defs: <
+      value: {
+        tuple: {
+          attr_defs: {
             key: "Code"
-            value: <
-              no_type: <
-              >
-              source_context: <
+            value: {
+              no_type: {}
+              source_context: {
                 file: "tests/inplace_tuple.sysl"
-                start: <
+                start: {
                   line: 62
                   col: 16
-                >
-                end: <
+                }
+                end: {
                   line: 62
                   col: 16
-                >
-              >
-            >
-          >
-          attr_defs: <
+                }
+              }
+            }
+          }
+          attr_defs: {
             key: "ObjectID"
-            value: <
-              no_type: <
-              >
-              source_context: <
+            value: {
+              no_type: {}
+              source_context: {
                 file: "tests/inplace_tuple.sysl"
-                start: <
+                start: {
                   line: 61
                   col: 16
-                >
-                end: <
+                }
+                end: {
                   line: 61
                   col: 16
-                >
-              >
-            >
-          >
-          attr_defs: <
+                }
+              }
+            }
+          }
+          attr_defs: {
             key: "Status"
-            value: <
-              no_type: <
-              >
-              source_context: <
+            value: {
+              no_type: {}
+              source_context: {
                 file: "tests/inplace_tuple.sysl"
-                start: <
+                start: {
                   line: 63
                   col: 16
-                >
-                end: <
+                }
+                end: {
                   line: 63
                   col: 16
-                >
-              >
-            >
-          >
-        >
-      >
-    >
-    types: <
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+    types: {
       key: "Req.Application.Purpose"
-      value: <
-        tuple: <
-          attr_defs: <
+      value: {
+        tuple: {
+          attr_defs: {
             key: "PurposeCode"
-            value: <
-              no_type: <
-              >
-              source_context: <
+            value: {
+              no_type: {}
+              source_context: {
                 file: "tests/inplace_tuple.sysl"
-                start: <
+                start: {
                   line: 65
                   col: 16
-                >
-                end: <
+                }
+                end: {
                   line: 65
                   col: 16
-                >
-              >
-            >
-          >
-          attr_defs: <
+                }
+              }
+            }
+          }
+          attr_defs: {
             key: "RemainDays"
-            value: <
-              no_type: <
-              >
-              source_context: <
+            value: {
+              no_type: {}
+              source_context: {
                 file: "tests/inplace_tuple.sysl"
-                start: <
+                start: {
                   line: 66
                   col: 16
-                >
-                end: <
+                }
+                end: {
                   line: 66
                   col: 16
-                >
-              >
-            >
-          >
-        >
-      >
-    >
-    types: <
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+    types: {
       key: "Req.Header"
-      value: <
-        tuple: <
-          attr_defs: <
+      value: {
+        tuple: {
+          attr_defs: {
             key: "Action"
-            value: <
-              no_type: <
-              >
-              source_context: <
+            value: {
+              no_type: {}
+              source_context: {
                 file: "tests/inplace_tuple.sysl"
-                start: <
+                start: {
                   line: 51
                   col: 12
-                >
-                end: <
+                }
+                end: {
                   line: 51
                   col: 12
-                >
-              >
-            >
-          >
-          attr_defs: <
+                }
+              }
+            }
+          }
+          attr_defs: {
             key: "AppDate"
-            value: <
+            value: {
               primitive: DATE
-              source_context: <
+              source_context: {
                 file: "tests/inplace_tuple.sysl"
-                start: <
+                start: {
                   line: 53
                   col: 23
-                >
-                end: <
+                }
+                end: {
                   line: 53
                   col: 23
-                >
-              >
-            >
-          >
-          attr_defs: <
+                }
+              }
+            }
+          }
+          attr_defs: {
             key: "AppHostSystem"
-            value: <
-              no_type: <
-              >
-              source_context: <
+            value: {
+              no_type: {}
+              source_context: {
                 file: "tests/inplace_tuple.sysl"
-                start: <
+                start: {
                   line: 52
                   col: 12
-                >
-                end: <
+                }
+                end: {
                   line: 52
                   col: 12
-                >
-              >
-            >
-          >
-          attr_defs: <
+                }
+              }
+            }
+          }
+          attr_defs: {
             key: "AppNbr"
-            value: <
-              no_type: <
-              >
-              source_context: <
+            value: {
+              no_type: {}
+              source_context: {
                 file: "tests/inplace_tuple.sysl"
-                start: <
+                start: {
                   line: 54
                   col: 12
-                >
-                end: <
+                }
+                end: {
                   line: 54
                   col: 12
-                >
-              >
-            >
-          >
-          attr_defs: <
+                }
+              }
+            }
+          }
+          attr_defs: {
             key: "Data"
-            value: <
-              type_ref: <
-                context: <
-                  appname: <
+            value: {
+              type_ref: {
+                context: {
+                  appname: {
                     part: "My"
                     part: "Tuple Model"
-                  >
+                  }
                   path: "Req"
                   path: "Header"
-                >
-                ref: <
-                  appname: <
+                }
+                ref: {
+                  appname: {
                     part: "My"
-                  >
+                  }
                   path: "Tuple Model"
                   path: "TopLevelPayload"
-                >
-              >
-              source_context: <
+                }
+              }
+              source_context: {
                 file: "tests/inplace_tuple.sysl"
-                start: <
+                start: {
                   line: 50
                   col: 20
-                >
-                end: <
+                }
+                end: {
                   line: 50
                   col: 38
-                >
-              >
-            >
-          >
-          attr_defs: <
+                }
+              }
+            }
+          }
+          attr_defs: {
             key: "responseList"
-            value: <
-              list: <
-                type: <
-                  type_ref: <
-                    context: <
-                      appname: <
+            value: {
+              list: {
+                type: {
+                  type_ref: {
+                    context: {
+                      appname: {
                         part: "My"
                         part: "Tuple Model"
-                      >
+                      }
                       path: "Req"
                       path: "Header"
-                    >
-                    ref: <
-                      appname: <
+                    }
+                    ref: {
+                      appname: {
                         part: "My"
-                      >
+                      }
                       path: "Tuple Model"
                       path: "Response"
-                    >
-                  >
-                  source_context: <
+                    }
+                  }
+                  source_context: {
                     file: "tests/inplace_tuple.sysl"
-                    start: <
+                    start: {
                       line: 55
                       col: 36
-                    >
-                    end: <
+                    }
+                    end: {
                       line: 55
                       col: 54
-                    >
-                  >
-                >
-              >
-            >
-          >
-        >
-      >
-    >
-    types: <
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+    types: {
       key: "Response"
-      value: <
-        tuple: <
-          attr_defs: <
+      value: {
+        tuple: {
+          attr_defs: {
             key: "bar"
-            value: <
+            value: {
               primitive: DECIMAL
-              constraint: <
-                length: <
+              constraint: {
+                length: {
                   min: 10
-                >
-              >
-              source_context: <
+                }
+              }
+              source_context: {
                 file: "tests/inplace_tuple.sysl"
-                start: <
+                start: {
                   line: 26
                   col: 15
-                >
-                end: <
+                }
+                end: {
                   line: 26
                   col: 27
-                >
-              >
-            >
-          >
-          attr_defs: <
+                }
+              }
+            }
+          }
+          attr_defs: {
             key: "baz"
-            value: <
+            value: {
               primitive: DECIMAL
-              constraint: <
-                length: <
+              constraint: {
+                length: {
                   max: 9999
-                >
-              >
-              source_context: <
+                }
+              }
+              source_context: {
                 file: "tests/inplace_tuple.sysl"
-                start: <
+                start: {
                   line: 27
                   col: 15
-                >
-                end: <
+                }
+                end: {
                   line: 27
                   col: 30
-                >
-              >
-            >
-          >
-          attr_defs: <
+                }
+              }
+            }
+          }
+          attr_defs: {
             key: "code"
-            value: <
+            value: {
               primitive: INT
-              constraint: <
-                length: <
+              constraint: {
+                length: {
                   max: 9999
-                >
-              >
-              source_context: <
+                }
+              }
+              source_context: {
                 file: "tests/inplace_tuple.sysl"
-                start: <
+                start: {
                   line: 24
                   col: 16
-                >
-                end: <
+                }
+                end: {
                   line: 24
                   col: 27
-                >
-              >
-            >
-          >
-          attr_defs: <
+                }
+              }
+            }
+          }
+          attr_defs: {
             key: "foo"
-            value: <
+            value: {
               primitive: DECIMAL
-              constraint: <
-                length: <
+              constraint: {
+                length: {
                   min: 10
                   max: 9999
-                >
-              >
-              source_context: <
+                }
+              }
+              source_context: {
                 file: "tests/inplace_tuple.sysl"
-                start: <
+                start: {
                   line: 25
                   col: 15
-                >
-                end: <
+                }
+                end: {
                   line: 25
                   col: 31
-                >
-              >
-            >
-          >
-          attr_defs: <
+                }
+              }
+            }
+          }
+          attr_defs: {
             key: "nested"
-            value: <
-              type_ref: <
-                context: <
-                  appname: <
+            value: {
+              type_ref: {
+                context: {
+                  appname: {
                     part: "My"
                     part: "Tuple Model"
-                  >
+                  }
                   path: "Response"
-                >
-                ref: <
+                }
+                ref: {
                   path: "Payload"
-                >
-              >
-              source_context: <
+                }
+              }
+              source_context: {
                 file: "tests/inplace_tuple.sysl"
-                start: <
+                start: {
                   line: 29
                   col: 18
-                >
-                end: <
+                }
+                end: {
                   line: 29
                   col: 18
-                >
-              >
-            >
-          >
-          attr_defs: <
+                }
+              }
+            }
+          }
+          attr_defs: {
             key: "status"
-            value: <
+            value: {
               primitive: STRING
-              constraint: <
-                length: <
+              constraint: {
+                length: {
                   max: 30
-                >
-              >
-              source_context: <
+                }
+              }
+              source_context: {
                 file: "tests/inplace_tuple.sysl"
-                start: <
+                start: {
                   line: 23
                   col: 18
-                >
-                end: <
+                }
+                end: {
                   line: 23
                   col: 31
-                >
-              >
-            >
-          >
-          attr_defs: <
+                }
+              }
+            }
+          }
+          attr_defs: {
             key: "toplevel"
-            value: <
-              type_ref: <
-                context: <
-                  appname: <
+            value: {
+              type_ref: {
+                context: {
+                  appname: {
                     part: "My"
                     part: "Tuple Model"
-                  >
+                  }
                   path: "Response"
-                >
-                ref: <
+                }
+                ref: {
                   path: "TopLevelPayload"
-                >
-              >
-              source_context: <
+                }
+              }
+              source_context: {
                 file: "tests/inplace_tuple.sysl"
-                start: <
+                start: {
                   line: 28
                   col: 20
-                >
-                end: <
+                }
+                end: {
                   line: 28
                   col: 20
-                >
-              >
-            >
-          >
-        >
-      >
-    >
-    types: <
+                }
+              }
+            }
+          }
+        }
+        source_context: {
+          file: "tests/inplace_tuple.sysl"
+          start: {
+            line: 22
+            col: 4
+          }
+          end: {
+            line: 38
+            col: 4
+          }
+        }
+      }
+    }
+    types: {
       key: "Response.Payload"
-      value: <
-        tuple: <
-          attr_defs: <
+      value: {
+        tuple: {
+          attr_defs: {
             key: "XMLDoc"
-            value: <
+            value: {
               primitive: XML
-              source_context: <
+              source_context: {
                 file: "tests/inplace_tuple.sysl"
-                start: <
+                start: {
                   line: 36
                   col: 22
-                >
-                end: <
+                }
+                end: {
                   line: 36
                   col: 22
-                >
-              >
-            >
-          >
-          attr_defs: <
+                }
+              }
+            }
+          }
+          attr_defs: {
             key: "code"
-            value: <
+            value: {
               primitive: INT
-              source_context: <
+              source_context: {
                 file: "tests/inplace_tuple.sysl"
-                start: <
+                start: {
                   line: 32
                   col: 20
-                >
-                end: <
+                }
+                end: {
                   line: 32
                   col: 20
-                >
-              >
-            >
-          >
-          attr_defs: <
+                }
+              }
+            }
+          }
+          attr_defs: {
             key: "data"
-            value: <
-              type_ref: <
-                context: <
-                  appname: <
+            value: {
+              type_ref: {
+                context: {
+                  appname: {
                     part: "My"
                     part: "Tuple Model"
-                  >
+                  }
                   path: "Response"
                   path: "Payload"
-                >
-                ref: <
+                }
+                ref: {
                   path: "string_8"
-                >
-              >
-              source_context: <
+                }
+              }
+              source_context: {
                 file: "tests/inplace_tuple.sysl"
-                start: <
+                start: {
                   line: 34
                   col: 20
-                >
-                end: <
+                }
+                end: {
                   line: 34
                   col: 34
-                >
-              >
-            >
-          >
-          attr_defs: <
+                }
+              }
+            }
+          }
+          attr_defs: {
             key: "footer"
-            value: <
+            value: {
               primitive: STRING
-              constraint: <
-                length: <
-                >
-              >
-              source_context: <
+              constraint: {
+                length: {}
+              }
+              source_context: {
                 file: "tests/inplace_tuple.sysl"
-                start: <
+                start: {
                   line: 35
                   col: 22
-                >
-                end: <
+                }
+                end: {
                   line: 35
                   col: 32
-                >
-              >
-            >
-          >
-          attr_defs: <
+                }
+              }
+            }
+          }
+          attr_defs: {
             key: "value"
-            value: <
+            value: {
               primitive: INT
-              constraint: <
-                length: <
+              constraint: {
+                length: {
                   min: 1
-                >
-              >
-              source_context: <
+                }
+              }
+              source_context: {
                 file: "tests/inplace_tuple.sysl"
-                start: <
+                start: {
                   line: 33
                   col: 21
-                >
-                end: <
+                }
+                end: {
                   line: 33
                   col: 28
-                >
-              >
-            >
-          >
-        >
-      >
-    >
-    types: <
+                }
+              }
+            }
+          }
+        }
+        source_context: {
+          file: "tests/inplace_tuple.sysl"
+          start: {
+            line: 31
+            col: 8
+          }
+          end: {
+            line: 38
+            col: 4
+          }
+        }
+      }
+    }
+    types: {
       key: "TopLevelPayload"
-      value: <
-        tuple: <
-          attr_defs: <
+      value: {
+        tuple: {
+          attr_defs: {
             key: "bars"
-            value: <
-              type_ref: <
-                context: <
-                  appname: <
+            value: {
+              type_ref: {
+                context: {
+                  appname: {
                     part: "My"
                     part: "Tuple Model"
-                  >
+                  }
                   path: "TopLevelPayload"
-                >
-                ref: <
-                  appname: <
+                }
+                ref: {
+                  appname: {
                     part: "My"
-                  >
+                  }
                   path: "Client Model"
                   path: "Request"
                   path: "status"
-                >
-              >
-              source_context: <
+                }
+              }
+              source_context: {
                 file: "tests/inplace_tuple.sysl"
-                start: <
+                start: {
                   line: 44
                   col: 16
-                >
-                end: <
+                }
+                end: {
                   line: 44
                   col: 45
-                >
-              >
-            >
-          >
-          attr_defs: <
+                }
+              }
+            }
+          }
+          attr_defs: {
             key: "data"
-            value: <
+            value: {
               primitive: STRING
-              constraint: <
-                length: <
+              constraint: {
+                length: {
                   max: 500
-                >
-              >
-              source_context: <
+                }
+              }
+              source_context: {
                 file: "tests/inplace_tuple.sysl"
-                start: <
+                start: {
                   line: 39
                   col: 16
-                >
-                end: <
+                }
+                end: {
                   line: 39
                   col: 26
-                >
-              >
-            >
-          >
-          attr_defs: <
+                }
+              }
+            }
+          }
+          attr_defs: {
             key: "data2"
-            value: <
-              set: <
+            value: {
+              set: {
                 primitive: STRING
-                constraint: <
-                  length: <
+                constraint: {
+                  length: {
                     max: 500
-                  >
-                >
-                source_context: <
+                  }
+                }
+                source_context: {
                   file: "tests/inplace_tuple.sysl"
-                  start: <
+                  start: {
                     line: 40
                     col: 17
-                  >
-                  end: <
+                  }
+                  end: {
                     line: 40
                     col: 34
-                  >
-                >
-              >
-              source_context: <
+                  }
+                }
+              }
+              source_context: {
                 file: "tests/inplace_tuple.sysl"
-                start: <
+                start: {
                   line: 40
                   col: 17
-                >
-                end: <
+                }
+                end: {
                   line: 40
                   col: 34
-                >
-              >
-            >
-          >
-          attr_defs: <
+                }
+              }
+            }
+          }
+          attr_defs: {
             key: "field1"
-            value: <
-              type_ref: <
-                context: <
-                  appname: <
+            value: {
+              type_ref: {
+                context: {
+                  appname: {
                     part: "My"
                     part: "Tuple Model"
-                  >
+                  }
                   path: "TopLevelPayload"
-                >
-                ref: <
+                }
+                ref: {
                   path: "Model"
                   path: "Request"
                   path: "status"
-                >
-              >
-              source_context: <
+                }
+              }
+              source_context: {
                 file: "tests/inplace_tuple.sysl"
-                start: <
+                start: {
                   line: 42
                   col: 18
-                >
-                end: <
+                }
+                end: {
                   line: 42
                   col: 32
-                >
-              >
-            >
-          >
-          attr_defs: <
+                }
+              }
+            }
+          }
+          attr_defs: {
             key: "field2"
-            value: <
-              type_ref: <
-                context: <
-                  appname: <
+            value: {
+              type_ref: {
+                context: {
+                  appname: {
                     part: "My"
                     part: "Tuple Model"
-                  >
+                  }
                   path: "TopLevelPayload"
-                >
-                ref: <
-                  appname: <
+                }
+                ref: {
+                  appname: {
                     part: "My"
                     part: "Browser"
-                  >
+                  }
                   path: "Client Model"
                   path: "Request"
                   path: "status"
-                >
-              >
-              source_context: <
+                }
+              }
+              source_context: {
                 file: "tests/inplace_tuple.sysl"
-                start: <
+                start: {
                   line: 43
                   col: 18
-                >
-                end: <
+                }
+                end: {
                   line: 43
                   col: 59
-                >
-              >
-            >
-          >
-          attr_defs: <
+                }
+              }
+            }
+          }
+          attr_defs: {
             key: "foos"
-            value: <
-              set: <
-                type_ref: <
-                  context: <
-                    appname: <
+            value: {
+              set: {
+                type_ref: {
+                  context: {
+                    appname: {
                       part: "My"
                       part: "Tuple Model"
-                    >
+                    }
                     path: "TopLevelPayload"
-                  >
-                  ref: <
+                  }
+                  ref: {
                     path: "Response"
                     path: "foo"
-                  >
-                >
-                source_context: <
+                  }
+                }
+                source_context: {
                   file: "tests/inplace_tuple.sysl"
-                  start: <
+                  start: {
                     line: 45
                     col: 16
-                  >
-                  end: <
+                  }
+                  end: {
                     line: 45
                     col: 32
-                  >
-                >
-              >
-              source_context: <
+                  }
+                }
+              }
+              source_context: {
                 file: "tests/inplace_tuple.sysl"
-                start: <
+                start: {
                   line: 45
                   col: 16
-                >
-                end: <
+                }
+                end: {
                   line: 45
                   col: 32
-                >
-              >
-            >
-          >
-          attr_defs: <
+                }
+              }
+            }
+          }
+          attr_defs: {
             key: "responseSet"
-            value: <
-              set: <
-                type_ref: <
-                  context: <
-                    appname: <
+            value: {
+              set: {
+                type_ref: {
+                  context: {
+                    appname: {
                       part: "My"
                       part: "Tuple Model"
-                    >
+                    }
                     path: "TopLevelPayload"
-                  >
-                  ref: <
+                  }
+                  ref: {
                     path: "Response"
-                  >
-                >
-                source_context: <
+                  }
+                }
+                source_context: {
                   file: "tests/inplace_tuple.sysl"
-                  start: <
+                  start: {
                     line: 46
                     col: 23
-                  >
-                  end: <
+                  }
+                  end: {
                     line: 46
                     col: 30
-                  >
-                >
-              >
-              source_context: <
+                  }
+                }
+              }
+              source_context: {
                 file: "tests/inplace_tuple.sysl"
-                start: <
+                start: {
                   line: 46
                   col: 23
-                >
-                end: <
+                }
+                end: {
                   line: 46
                   col: 30
-                >
-              >
-            >
-          >
-          attr_defs: <
+                }
+              }
+            }
+          }
+          attr_defs: {
             key: "status"
-            value: <
-              type_ref: <
-                context: <
-                  appname: <
+            value: {
+              type_ref: {
+                context: {
+                  appname: {
                     part: "My"
                     part: "Tuple Model"
-                  >
+                  }
                   path: "TopLevelPayload"
-                >
-                ref: <
+                }
+                ref: {
                   path: "Response"
                   path: "status"
-                >
-              >
-              source_context: <
+                }
+              }
+              source_context: {
                 file: "tests/inplace_tuple.sysl"
-                start: <
+                start: {
                   line: 41
                   col: 18
-                >
-                end: <
+                }
+                end: {
                   line: 41
                   col: 27
-                >
-              >
-            >
-          >
-        >
-      >
-    >
-  >
->
+                }
+              }
+            }
+          }
+        }
+        source_context: {
+          file: "tests/inplace_tuple.sysl"
+          start: {
+            line: 38
+            col: 4
+          }
+          end: {
+            line: 48
+            col: 4
+          }
+        }
+      }
+    }
+    source_context: {
+      file: "tests/inplace_tuple.sysl"
+      start: {
+        line: 21
+        col: 1
+      }
+      end: {
+        line: 21
+        col: 6
+      }
+    }
+  }
+}

--- a/pkg/parse/tests/library.sysl.golden.textpb
+++ b/pkg/parse/tests/library.sysl.golden.textpb
@@ -1,421 +1,494 @@
-apps: <
+apps: {
   key: "School"
-  value: <
-    name: <
+  value: {
+    name: {
       part: "School"
-    >
-    types: <
+    }
+    types: {
       key: "Class"
-      value: <
-        relation: <
-          attr_defs: <
+      value: {
+        relation: {
+          attr_defs: {
             key: "Id"
-            value: <
+            value: {
               primitive: INT
-              attrs: <
+              attrs: {
                 key: "patterns"
-                value: <
-                  a: <
-                    elt: <
+                value: {
+                  a: {
+                    elt: {
                       s: "pk"
-                    >
-                    elt: <
+                    }
+                    elt: {
                       s: "autoinc"
-                    >
-                  >
-                >
-              >
-              source_context: <
+                    }
+                  }
+                }
+              }
+              source_context: {
                 file: "tests/school.sysl"
-                start: <
+                start: {
                   line: 3
                   col: 14
-                >
-                end: <
+                }
+                end: {
                   line: 3
                   col: 32
-                >
-              >
-            >
-          >
-          primary_key: <
+                }
+              }
+            }
+          }
+          primary_key: {
             attr_name: "Id"
-          >
-        >
-      >
-    >
-    types: <
+          }
+        }
+        source_context: {
+          file: "tests/school.sysl"
+          start: {
+            line: 2
+            col: 4
+          }
+          end: {
+            line: 4
+            col: 4
+          }
+        }
+      }
+    }
+    types: {
       key: "Student"
-      value: <
-        relation: <
-          attr_defs: <
+      value: {
+        relation: {
+          attr_defs: {
             key: "ClassId"
-            value: <
-              type_ref: <
-                context: <
-                  appname: <
+            value: {
+              type_ref: {
+                context: {
+                  appname: {
                     part: "School"
-                  >
+                  }
                   path: "Student"
-                >
-                ref: <
+                }
+                ref: {
                   path: "Class"
                   path: "Idd"
-                >
-              >
-              attrs: <
+                }
+              }
+              attrs: {
                 key: "description"
-                value: <
+                value: {
                   s: "describe the table"
-                >
-              >
-              source_context: <
+                }
+              }
+              source_context: {
                 file: "tests/school.sysl"
-                start: <
+                start: {
                   line: 7
                   col: 19
-                >
-                end: <
+                }
+                end: {
                   line: 7
                   col: 25
-                >
-              >
-            >
-          >
-          attr_defs: <
+                }
+              }
+            }
+          }
+          attr_defs: {
             key: "Id"
-            value: <
+            value: {
               primitive: INT
-              attrs: <
+              attrs: {
                 key: "description"
-                value: <
+                value: {
                   s: "describe the table"
-                >
-              >
-              attrs: <
+                }
+              }
+              attrs: {
                 key: "patterns"
-                value: <
-                  a: <
-                    elt: <
+                value: {
+                  a: {
+                    elt: {
                       s: "pk"
-                    >
-                  >
-                >
-              >
-              source_context: <
+                    }
+                  }
+                }
+              }
+              source_context: {
                 file: "tests/school.sysl"
-                start: <
+                start: {
                   line: 6
                   col: 14
-                >
-                end: <
+                }
+                end: {
                   line: 6
                   col: 22
-                >
-              >
-            >
-          >
-          primary_key: <
+                }
+              }
+            }
+          }
+          primary_key: {
             attr_name: "Id"
-          >
-        >
-        attrs: <
+          }
+        }
+        attrs: {
           key: "description"
-          value: <
+          value: {
             s: "describe the table"
-          >
-        >
-      >
-    >
-  >
->
-apps: <
+          }
+        }
+        source_context: {
+          file: "tests/school.sysl"
+          start: {
+            line: 5
+            col: 4
+          }
+          end: {
+            line: 8
+          }
+        }
+      }
+    }
+    source_context: {
+      file: "tests/school.sysl"
+      start: {
+        line: 1
+        col: 1
+      }
+      end: {
+        line: 1
+      }
+    }
+  }
+}
+apps: {
   key: "SchoolLibrary"
-  value: <
-    name: <
+  value: {
+    name: {
       part: "SchoolLibrary"
-    >
-    types: <
+    }
+    types: {
       key: "Book"
-      value: <
-        relation: <
-          attr_defs: <
+      value: {
+        relation: {
+          attr_defs: {
             key: "Author"
-            value: <
+            value: {
               primitive: STRING
-              source_context: <
+              source_context: {
                 file: "tests/library.sysl"
-                start: <
+                start: {
                   line: 13
                   col: 18
-                >
-                end: <
+                }
+                end: {
                   line: 13
                   col: 18
-                >
-              >
-            >
-          >
-          attr_defs: <
+                }
+              }
+            }
+          }
+          attr_defs: {
             key: "BookId"
-            value: <
+            value: {
               primitive: INT
-              attrs: <
+              attrs: {
                 key: "patterns"
-                value: <
-                  a: <
-                    elt: <
+                value: {
+                  a: {
+                    elt: {
                       s: "pk"
-                    >
-                    elt: <
+                    }
+                    elt: {
                       s: "autoinc"
-                    >
-                  >
-                >
-              >
-              source_context: <
+                    }
+                  }
+                }
+              }
+              source_context: {
                 file: "tests/library.sysl"
-                start: <
+                start: {
                   line: 11
                   col: 18
-                >
-                end: <
+                }
+                end: {
                   line: 11
                   col: 36
-                >
-              >
-            >
-          >
-          attr_defs: <
+                }
+              }
+            }
+          }
+          attr_defs: {
             key: "name"
-            value: <
+            value: {
               primitive: STRING
-              source_context: <
+              source_context: {
                 file: "tests/library.sysl"
-                start: <
+                start: {
                   line: 12
                   col: 16
-                >
-                end: <
+                }
+                end: {
                   line: 12
                   col: 16
-                >
-              >
-            >
-          >
-          primary_key: <
+                }
+              }
+            }
+          }
+          primary_key: {
             attr_name: "BookId"
-          >
-        >
-      >
-    >
-    types: <
+          }
+        }
+        source_context: {
+          file: "tests/library.sysl"
+          start: {
+            line: 10
+            col: 4
+          }
+          end: {
+            line: 14
+            col: 4
+          }
+        }
+      }
+    }
+    types: {
       key: "Borrow"
-      value: <
-        relation: <
-          attr_defs: <
+      value: {
+        relation: {
+          attr_defs: {
             key: "BookId"
-            value: <
-              type_ref: <
-                context: <
-                  appname: <
+            value: {
+              type_ref: {
+                context: {
+                  appname: {
                     part: "SchoolLibrary"
-                  >
+                  }
                   path: "Borrow"
-                >
-                ref: <
+                }
+                ref: {
                   path: "Book"
                   path: "BookId"
-                >
-              >
-              attrs: <
+                }
+              }
+              attrs: {
                 key: "patterns"
-                value: <
-                  a: <
-                    elt: <
+                value: {
+                  a: {
+                    elt: {
                       s: "pk"
-                    >
-                  >
-                >
-              >
-              source_context: <
+                    }
+                  }
+                }
+              }
+              source_context: {
                 file: "tests/library.sysl"
-                start: <
+                start: {
                   line: 16
                   col: 18
-                >
-                end: <
+                }
+                end: {
                   line: 16
                   col: 34
-                >
-              >
-            >
-          >
-          attr_defs: <
+                }
+              }
+            }
+          }
+          attr_defs: {
             key: "DueDate"
-            value: <
+            value: {
               primitive: DATE
-              source_context: <
+              source_context: {
                 file: "tests/library.sysl"
-                start: <
+                start: {
                   line: 17
                   col: 19
-                >
-                end: <
+                }
+                end: {
                   line: 17
                   col: 19
-                >
-              >
-            >
-          >
-          attr_defs: <
+                }
+              }
+            }
+          }
+          attr_defs: {
             key: "MemberId"
-            value: <
-              type_ref: <
-                context: <
-                  appname: <
+            value: {
+              type_ref: {
+                context: {
+                  appname: {
                     part: "SchoolLibrary"
-                  >
+                  }
                   path: "Borrow"
-                >
-                ref: <
+                }
+                ref: {
                   path: "Member"
                   path: "MemberId"
-                >
-              >
-              attrs: <
+                }
+              }
+              attrs: {
                 key: "patterns"
-                value: <
-                  a: <
-                    elt: <
+                value: {
+                  a: {
+                    elt: {
                       s: "pk"
-                    >
-                  >
-                >
-              >
-              source_context: <
+                    }
+                  }
+                }
+              }
+              source_context: {
                 file: "tests/library.sysl"
-                start: <
+                start: {
                   line: 15
                   col: 20
-                >
-                end: <
+                }
+                end: {
                   line: 15
                   col: 40
-                >
-              >
-            >
-          >
-          primary_key: <
+                }
+              }
+            }
+          }
+          primary_key: {
             attr_name: "MemberId"
             attr_name: "BookId"
-          >
-        >
-      >
-    >
-    types: <
+          }
+        }
+        source_context: {
+          file: "tests/library.sysl"
+          start: {
+            line: 14
+            col: 4
+          }
+          end: {
+            line: 18
+          }
+        }
+      }
+    }
+    types: {
       key: "Member"
-      value: <
-        relation: <
-          attr_defs: <
+      value: {
+        relation: {
+          attr_defs: {
             key: "MemberId"
-            value: <
-              type_ref: <
-                context: <
-                  appname: <
+            value: {
+              type_ref: {
+                context: {
+                  appname: {
                     part: "SchoolLibrary"
-                  >
+                  }
                   path: "Member"
-                >
-                ref: <
+                }
+                ref: {
                   path: "Student"
                   path: "Id"
-                >
-              >
-              attrs: <
+                }
+              }
+              attrs: {
                 key: "description"
-                value: <
+                value: {
                   s: "\n"
-                >
-              >
-              source_context: <
+                }
+              }
+              source_context: {
                 file: "tests/library.sysl"
-                start: <
+                start: {
                   line: 6
                   col: 20
-                >
-                end: <
+                }
+                end: {
                   line: 7
                   col: 8
-                >
-              >
-            >
-          >
-          attr_defs: <
+                }
+              }
+            }
+          }
+          attr_defs: {
             key: "amount"
-            value: <
+            value: {
               primitive: DECIMAL
-              constraint: <
-                length: <
+              constraint: {
+                length: {
                   max: 14
-                >
+                }
                 precision: 14
                 scale: 2
-              >
-              source_context: <
+              }
+              source_context: {
                 file: "tests/library.sysl"
-                start: <
+                start: {
                   line: 9
                   col: 18
-                >
-                end: <
+                }
+                end: {
                   line: 9
                   col: 30
-                >
-              >
-            >
-          >
-          attr_defs: <
+                }
+              }
+            }
+          }
+          attr_defs: {
             key: "city"
-            value: <
+            value: {
               primitive: STRING
-              constraint: <
-                length: <
+              constraint: {
+                length: {
                   max: 100
-                >
-              >
-              source_context: <
+                }
+              }
+              source_context: {
                 file: "tests/library.sysl"
-                start: <
+                start: {
                   line: 8
                   col: 16
-                >
-                end: <
+                }
+                end: {
                   line: 8
                   col: 26
-                >
-              >
-            >
-          >
-          attr_defs: <
+                }
+              }
+            }
+          }
+          attr_defs: {
             key: "name"
-            value: <
+            value: {
               primitive: STRING
-              source_context: <
+              source_context: {
                 file: "tests/library.sysl"
-                start: <
+                start: {
                   line: 7
                   col: 16
-                >
-                end: <
+                }
+                end: {
                   line: 7
                   col: 16
-                >
-              >
-            >
-          >
-        >
-      >
-    >
-  >
->
+                }
+              }
+            }
+          }
+        }
+        source_context: {
+          file: "tests/library.sysl"
+          start: {
+            line: 4
+            col: 4
+          }
+          end: {
+            line: 10
+            col: 4
+          }
+        }
+      }
+    }
+    source_context: {
+      file: "tests/library.sysl"
+      start: {
+        line: 3
+        col: 1
+      }
+      end: {
+        line: 3
+      }
+    }
+  }
+}

--- a/pkg/parse/tests/matching.sysl.golden.textpb
+++ b/pkg/parse/tests/matching.sysl.golden.textpb
@@ -1,512 +1,1564 @@
-apps {
+apps: {
   key: "TransformationTest"
-  value {
-    name {
+  value: {
+    name: {
       part: "TransformationTest"
     }
-    attrs {
+    attrs: {
       key: "package"
-      value {
+      value: {
         s: "io.sysl.test.views"
       }
     }
-    views {
+    views: {
       key: "TestMatching"
-      value {
-        param {
+      value: {
+        param: {
           name: "number"
-          type {
+          type: {
             primitive: INT
           }
         }
-        ret_type {
+        ret_type: {
           primitive: INT
         }
-        expr {
-          transform {
-            arg {
+        expr: {
+          transform: {
+            arg: {
               name: "number"
+              source_context: {
+                file: "tests/matching.sysl"
+                start: {
+                  line: 3
+                  col: 4
+                }
+                end: {
+                  line: 3
+                  col: 4
+                }
+              }
             }
             scopevar: "."
-            stmt {
-              let {
+            stmt: {
+              let: {
                 name: "out"
-                expr {
-                  unexpr {
+                expr: {
+                  unexpr: {
                     op: INV
-                    arg {
-                      binexpr {
+                    arg: {
+                      binexpr: {
                         op: TO_MATCHING
-                        lhs {
+                        lhs: {
                           name: "."
+                          source_context: {
+                            file: "tests/matching.sysl"
+                            start: {
+                              line: 4
+                              col: 17
+                            }
+                            end: {
+                              line: 4
+                              col: 20
+                            }
+                          }
                         }
-                        rhs {
+                        rhs: {
                           name: "foo1"
+                          source_context: {
+                            file: "tests/matching.sysl"
+                            start: {
+                              line: 4
+                              col: 20
+                            }
+                            end: {
+                              line: 4
+                              col: 20
+                            }
+                          }
                         }
                         attr_name: "*"
                       }
+                      type: {
+                        no_type: {}
+                      }
+                      source_context: {
+                        file: "tests/matching.sysl"
+                        start: {
+                          line: 4
+                          col: 17
+                        }
+                        end: {
+                          line: 4
+                          col: 20
+                        }
+                      }
                     }
+                  }
+                  type: {
+                    primitive: BOOL
+                  }
+                  source_context: {
+                    file: "tests/matching.sysl"
+                    start: {
+                      line: 4
+                      col: 6
+                    }
+                    end: {
+                      line: 4
+                      col: 20
+                    }
+                    text: "let out = ~~> foo1"
                   }
                 }
               }
             }
-            stmt {
-              let {
+            stmt: {
+              let: {
                 name: "out1"
-                expr {
-                  binexpr {
+                expr: {
+                  binexpr: {
                     op: TO_MATCHING
-                    lhs {
+                    lhs: {
                       name: "."
+                      source_context: {
+                        file: "tests/matching.sysl"
+                        start: {
+                          line: 5
+                          col: 17
+                        }
+                        end: {
+                          line: 5
+                          col: 22
+                        }
+                      }
                     }
-                    rhs {
+                    rhs: {
                       name: "foo1"
+                      source_context: {
+                        file: "tests/matching.sysl"
+                        start: {
+                          line: 5
+                          col: 22
+                        }
+                        end: {
+                          line: 5
+                          col: 22
+                        }
+                      }
                     }
                     attr_name: "*"
+                  }
+                  type: {
+                    no_type: {}
+                  }
+                  source_context: {
+                    file: "tests/matching.sysl"
+                    start: {
+                      line: 5
+                      col: 6
+                    }
+                    end: {
+                      line: 5
+                      col: 22
+                    }
+                    text: "let out1 = . ~> foo1"
                   }
                 }
               }
             }
-            stmt {
-              let {
+            stmt: {
+              let: {
                 name: "out2"
-                expr {
-                  binexpr {
+                expr: {
+                  binexpr: {
                     op: TO_MATCHING
-                    lhs {
+                    lhs: {
                       name: "abc"
+                      source_context: {
+                        file: "tests/matching.sysl"
+                        start: {
+                          line: 6
+                          col: 17
+                        }
+                        end: {
+                          line: 6
+                          col: 17
+                        }
+                      }
                     }
-                    rhs {
+                    rhs: {
                       name: "foo1"
+                      source_context: {
+                        file: "tests/matching.sysl"
+                        start: {
+                          line: 6
+                          col: 24
+                        }
+                        end: {
+                          line: 6
+                          col: 24
+                        }
+                      }
                     }
                     attr_name: "*"
+                  }
+                  type: {
+                    no_type: {}
+                  }
+                  source_context: {
+                    file: "tests/matching.sysl"
+                    start: {
+                      line: 6
+                      col: 6
+                    }
+                    end: {
+                      line: 6
+                      col: 24
+                    }
+                    text: "let out2 = abc ~> foo1"
                   }
                 }
               }
             }
-            stmt {
-              let {
+            stmt: {
+              let: {
                 name: "out3"
-                expr {
-                  binexpr {
+                expr: {
+                  binexpr: {
                     op: TO_MATCHING
-                    lhs {
-                      get_attr {
-                        arg {
+                    lhs: {
+                      get_attr: {
+                        arg: {
                           name: "."
+                          source_context: {
+                            file: "tests/matching.sysl"
+                            start: {
+                              line: 7
+                              col: 17
+                            }
+                            end: {
+                              line: 7
+                              col: 18
+                            }
+                          }
                         }
                         attr: "abc"
                       }
+                      source_context: {
+                        file: "tests/matching.sysl"
+                        start: {
+                          line: 7
+                          col: 17
+                        }
+                        end: {
+                          line: 7
+                          col: 18
+                        }
+                      }
                     }
-                    rhs {
+                    rhs: {
                       name: "foo1"
+                      source_context: {
+                        file: "tests/matching.sysl"
+                        start: {
+                          line: 7
+                          col: 25
+                        }
+                        end: {
+                          line: 7
+                          col: 25
+                        }
+                      }
                     }
                     attr_name: "*"
+                  }
+                  type: {
+                    no_type: {}
+                  }
+                  source_context: {
+                    file: "tests/matching.sysl"
+                    start: {
+                      line: 7
+                      col: 6
+                    }
+                    end: {
+                      line: 7
+                      col: 25
+                    }
+                    text: "let out3 = .abc ~> foo1"
                   }
                 }
               }
             }
-            stmt {
-              let {
+            stmt: {
+              let: {
                 name: "out4"
-                expr {
-                  binexpr {
+                expr: {
+                  binexpr: {
                     op: TO_MATCHING
-                    lhs {
-                      get_attr {
-                        arg {
+                    lhs: {
+                      get_attr: {
+                        arg: {
                           name: "."
+                          source_context: {
+                            file: "tests/matching.sysl"
+                            start: {
+                              line: 8
+                              col: 17
+                            }
+                            end: {
+                              line: 8
+                              col: 18
+                            }
+                          }
                         }
                         attr: "abc"
                       }
+                      source_context: {
+                        file: "tests/matching.sysl"
+                        start: {
+                          line: 8
+                          col: 17
+                        }
+                        end: {
+                          line: 8
+                          col: 18
+                        }
+                      }
                     }
-                    rhs {
-                      get_attr {
-                        arg {
+                    rhs: {
+                      get_attr: {
+                        arg: {
                           name: "."
+                          source_context: {
+                            file: "tests/matching.sysl"
+                            start: {
+                              line: 8
+                              col: 25
+                            }
+                            end: {
+                              line: 8
+                              col: 26
+                            }
+                          }
                         }
                         attr: "def"
                       }
+                      source_context: {
+                        file: "tests/matching.sysl"
+                        start: {
+                          line: 8
+                          col: 25
+                        }
+                        end: {
+                          line: 8
+                          col: 26
+                        }
+                      }
                     }
                     attr_name: "*"
+                  }
+                  type: {
+                    no_type: {}
+                  }
+                  source_context: {
+                    file: "tests/matching.sysl"
+                    start: {
+                      line: 8
+                      col: 6
+                    }
+                    end: {
+                      line: 8
+                      col: 26
+                    }
+                    text: "let out4 = .abc ~> .def"
                   }
                 }
               }
             }
-            stmt {
-              let {
+            stmt: {
+              let: {
                 name: "out5"
-                expr {
-                  binexpr {
+                expr: {
+                  binexpr: {
                     op: TO_MATCHING
-                    lhs {
-                      get_attr {
-                        arg {
+                    lhs: {
+                      get_attr: {
+                        arg: {
                           name: "."
+                          source_context: {
+                            file: "tests/matching.sysl"
+                            start: {
+                              line: 9
+                              col: 17
+                            }
+                            end: {
+                              line: 9
+                              col: 18
+                            }
+                          }
                         }
                         attr: "abc"
                       }
+                      source_context: {
+                        file: "tests/matching.sysl"
+                        start: {
+                          line: 9
+                          col: 17
+                        }
+                        end: {
+                          line: 9
+                          col: 18
+                        }
+                      }
                     }
-                    rhs {
-                      get_attr {
-                        arg {
+                    rhs: {
+                      get_attr: {
+                        arg: {
                           name: "."
+                          source_context: {
+                            file: "tests/matching.sysl"
+                            start: {
+                              line: 9
+                              col: 25
+                            }
+                            end: {
+                              line: 9
+                              col: 35
+                            }
+                          }
                         }
                         attr: "abc"
                         setof: true
                       }
+                      source_context: {
+                        file: "tests/matching.sysl"
+                        start: {
+                          line: 9
+                          col: 25
+                        }
+                        end: {
+                          line: 9
+                          col: 35
+                        }
+                      }
                     }
                     attr_name: "*"
+                  }
+                  type: {
+                    no_type: {}
+                  }
+                  source_context: {
+                    file: "tests/matching.sysl"
+                    start: {
+                      line: 9
+                      col: 6
+                    }
+                    end: {
+                      line: 9
+                      col: 35
+                    }
+                    text: "let out5 = .abc ~> .table of abc"
                   }
                 }
               }
             }
-            stmt {
-              let {
+            stmt: {
+              let: {
                 name: "out6"
-                expr {
-                  binexpr {
+                expr: {
+                  binexpr: {
                     op: TO_MATCHING
-                    lhs {
-                      get_attr {
-                        arg {
+                    lhs: {
+                      get_attr: {
+                        arg: {
                           name: "."
+                          source_context: {
+                            file: "tests/matching.sysl"
+                            start: {
+                              line: 10
+                              col: 17
+                            }
+                            end: {
+                              line: 10
+                              col: 18
+                            }
+                          }
                         }
                         attr: "abc"
                       }
+                      source_context: {
+                        file: "tests/matching.sysl"
+                        start: {
+                          line: 10
+                          col: 17
+                        }
+                        end: {
+                          line: 10
+                          col: 18
+                        }
+                      }
                     }
-                    rhs {
-                      navigate {
-                        arg {
+                    rhs: {
+                      navigate: {
+                        arg: {
                           name: "."
+                          source_context: {
+                            file: "tests/matching.sysl"
+                            start: {
+                              line: 10
+                              col: 25
+                            }
+                            end: {
+                              line: 10
+                              col: 28
+                            }
+                          }
                         }
                         attr: "foo"
                       }
+                      source_context: {
+                        file: "tests/matching.sysl"
+                        start: {
+                          line: 10
+                          col: 25
+                        }
+                        end: {
+                          line: 10
+                          col: 28
+                        }
+                      }
                     }
                     attr_name: "*"
                   }
+                  type: {
+                    no_type: {}
+                  }
+                  source_context: {
+                    file: "tests/matching.sysl"
+                    start: {
+                      line: 10
+                      col: 6
+                    }
+                    end: {
+                      line: 10
+                      col: 28
+                    }
+                    text: "let out6 = .abc ~> -> foo"
+                  }
                 }
               }
             }
-            stmt {
-              let {
+            stmt: {
+              let: {
                 name: "out7"
-                expr {
-                  binexpr {
+                expr: {
+                  binexpr: {
                     op: TO_MATCHING
-                    lhs {
-                      get_attr {
-                        arg {
+                    lhs: {
+                      get_attr: {
+                        arg: {
                           name: "."
+                          source_context: {
+                            file: "tests/matching.sysl"
+                            start: {
+                              line: 11
+                              col: 17
+                            }
+                            end: {
+                              line: 11
+                              col: 18
+                            }
+                          }
                         }
                         attr: "abc"
                       }
+                      source_context: {
+                        file: "tests/matching.sysl"
+                        start: {
+                          line: 11
+                          col: 17
+                        }
+                        end: {
+                          line: 11
+                          col: 18
+                        }
+                      }
                     }
-                    rhs {
+                    rhs: {
                       name: "foo"
+                      source_context: {
+                        file: "tests/matching.sysl"
+                        start: {
+                          line: 11
+                          col: 30
+                        }
+                        end: {
+                          line: 11
+                          col: 30
+                        }
+                      }
                     }
                     attr_name: "abc"
+                  }
+                  type: {
+                    no_type: {}
+                  }
+                  source_context: {
+                    file: "tests/matching.sysl"
+                    start: {
+                      line: 11
+                      col: 6
+                    }
+                    end: {
+                      line: 11
+                      col: 30
+                    }
+                    text: "let out7 = .abc ~[abc]> foo"
                   }
                 }
               }
             }
-            stmt {
-              let {
+            stmt: {
+              let: {
                 name: "out7a"
-                expr {
-                  binexpr {
+                expr: {
+                  binexpr: {
                     op: TO_MATCHING
-                    lhs {
-                      get_attr {
-                        arg {
+                    lhs: {
+                      get_attr: {
+                        arg: {
                           name: "."
+                          source_context: {
+                            file: "tests/matching.sysl"
+                            start: {
+                              line: 12
+                              col: 18
+                            }
+                            end: {
+                              line: 12
+                              col: 19
+                            }
+                          }
                         }
                         attr: "abc"
                       }
+                      source_context: {
+                        file: "tests/matching.sysl"
+                        start: {
+                          line: 12
+                          col: 18
+                        }
+                        end: {
+                          line: 12
+                          col: 19
+                        }
+                      }
                     }
-                    rhs {
+                    rhs: {
                       name: "foo"
+                      source_context: {
+                        file: "tests/matching.sysl"
+                        start: {
+                          line: 12
+                          col: 35
+                        }
+                        end: {
+                          line: 12
+                          col: 35
+                        }
+                      }
                     }
                     attr_name: "abc"
                     attr_name: "def"
                   }
+                  type: {
+                    no_type: {}
+                  }
+                  source_context: {
+                    file: "tests/matching.sysl"
+                    start: {
+                      line: 12
+                      col: 6
+                    }
+                    end: {
+                      line: 12
+                      col: 35
+                    }
+                    text: "let out7a = .abc ~[abc,def]> foo"
+                  }
                 }
               }
             }
-            stmt {
-              let {
+            stmt: {
+              let: {
                 name: "out7b"
-                expr {
-                  binexpr {
+                expr: {
+                  binexpr: {
                     op: TO_NOT_MATCHING
-                    lhs {
-                      get_attr {
-                        arg {
+                    lhs: {
+                      get_attr: {
+                        arg: {
                           name: "."
+                          source_context: {
+                            file: "tests/matching.sysl"
+                            start: {
+                              line: 13
+                              col: 18
+                            }
+                            end: {
+                              line: 13
+                              col: 19
+                            }
+                          }
                         }
                         attr: "abc"
                       }
+                      source_context: {
+                        file: "tests/matching.sysl"
+                        start: {
+                          line: 13
+                          col: 18
+                        }
+                        end: {
+                          line: 13
+                          col: 19
+                        }
+                      }
                     }
-                    rhs {
+                    rhs: {
                       name: "foo"
+                      source_context: {
+                        file: "tests/matching.sysl"
+                        start: {
+                          line: 13
+                          col: 36
+                        }
+                        end: {
+                          line: 13
+                          col: 36
+                        }
+                      }
                     }
                     attr_name: "abc"
                     attr_name: "def"
                   }
+                  type: {
+                    no_type: {}
+                  }
+                  source_context: {
+                    file: "tests/matching.sysl"
+                    start: {
+                      line: 13
+                      col: 6
+                    }
+                    end: {
+                      line: 13
+                      col: 36
+                    }
+                    text: "let out7b = .abc !~[abc,def]> foo"
+                  }
                 }
               }
             }
-            stmt {
-              let {
+            stmt: {
+              let: {
                 name: "out8"
-                expr {
-                  get_attr {
-                    arg {
-                      binexpr {
+                expr: {
+                  get_attr: {
+                    arg: {
+                      binexpr: {
                         op: TO_NOT_MATCHING
-                        lhs {
-                          get_attr {
-                            arg {
+                        lhs: {
+                          get_attr: {
+                            arg: {
                               name: "."
+                              source_context: {
+                                file: "tests/matching.sysl"
+                                start: {
+                                  line: 14
+                                  col: 17
+                                }
+                                end: {
+                                  line: 14
+                                  col: 18
+                                }
+                              }
                             }
                             attr: "abc"
                           }
+                          source_context: {
+                            file: "tests/matching.sysl"
+                            start: {
+                              line: 14
+                              col: 17
+                            }
+                            end: {
+                              line: 14
+                              col: 18
+                            }
+                          }
                         }
-                        rhs {
+                        rhs: {
                           name: "foo"
+                          source_context: {
+                            file: "tests/matching.sysl"
+                            start: {
+                              line: 14
+                              col: 35
+                            }
+                            end: {
+                              line: 14
+                              col: 35
+                            }
+                          }
                         }
                         attr_name: "abc"
                         attr_name: "def"
                       }
+                      source_context: {
+                        file: "tests/matching.sysl"
+                        start: {
+                          line: 14
+                          col: 22
+                        }
+                        end: {
+                          line: 14
+                          col: 35
+                        }
+                      }
                     }
                     attr: "def"
+                  }
+                  source_context: {
+                    file: "tests/matching.sysl"
+                    start: {
+                      line: 14
+                      col: 6
+                    }
+                    end: {
+                      line: 14
+                      col: 39
+                    }
+                    text: "let out8 = .abc !~[abc,def]> foo.def"
                   }
                 }
               }
             }
-            stmt {
-              let {
+            stmt: {
+              let: {
                 name: "out8b"
-                expr {
-                  get_attr {
-                    arg {
-                      binexpr {
+                expr: {
+                  get_attr: {
+                    arg: {
+                      binexpr: {
                         op: TO_NOT_MATCHING
-                        lhs {
-                          get_attr {
-                            arg {
+                        lhs: {
+                          get_attr: {
+                            arg: {
                               name: "."
+                              source_context: {
+                                file: "tests/matching.sysl"
+                                start: {
+                                  line: 15
+                                  col: 18
+                                }
+                                end: {
+                                  line: 15
+                                  col: 19
+                                }
+                              }
                             }
                             attr: "abc"
                           }
+                          source_context: {
+                            file: "tests/matching.sysl"
+                            start: {
+                              line: 15
+                              col: 18
+                            }
+                            end: {
+                              line: 15
+                              col: 19
+                            }
+                          }
                         }
-                        rhs {
-                          get_attr {
-                            arg {
+                        rhs: {
+                          get_attr: {
+                            arg: {
                               name: "."
+                              source_context: {
+                                file: "tests/matching.sysl"
+                                start: {
+                                  line: 15
+                                  col: 36
+                                }
+                                end: {
+                                  line: 15
+                                  col: 37
+                                }
+                              }
                             }
                             attr: "foo"
                           }
+                          source_context: {
+                            file: "tests/matching.sysl"
+                            start: {
+                              line: 15
+                              col: 36
+                            }
+                            end: {
+                              line: 15
+                              col: 37
+                            }
+                          }
                         }
                         attr_name: "abc"
                         attr_name: "def"
                       }
+                      source_context: {
+                        file: "tests/matching.sysl"
+                        start: {
+                          line: 15
+                          col: 23
+                        }
+                        end: {
+                          line: 15
+                          col: 37
+                        }
+                      }
                     }
                     attr: "def"
+                  }
+                  source_context: {
+                    file: "tests/matching.sysl"
+                    start: {
+                      line: 15
+                      col: 6
+                    }
+                    end: {
+                      line: 15
+                      col: 41
+                    }
+                    text: "let out8b = .abc !~[abc,def]> .foo.def"
                   }
                 }
               }
             }
-            stmt {
-              let {
+            stmt: {
+              let: {
                 name: "out9"
-                expr {
-                  binexpr {
+                expr: {
+                  binexpr: {
                     op: WHERE
-                    lhs {
-                      get_attr {
-                        arg {
-                          binexpr {
+                    lhs: {
+                      get_attr: {
+                        arg: {
+                          binexpr: {
                             op: TO_NOT_MATCHING
-                            lhs {
-                              get_attr {
-                                arg {
+                            lhs: {
+                              get_attr: {
+                                arg: {
                                   name: "."
+                                  source_context: {
+                                    file: "tests/matching.sysl"
+                                    start: {
+                                      line: 16
+                                      col: 17
+                                    }
+                                    end: {
+                                      line: 16
+                                      col: 18
+                                    }
+                                  }
                                 }
                                 attr: "abc"
                               }
+                              source_context: {
+                                file: "tests/matching.sysl"
+                                start: {
+                                  line: 16
+                                  col: 17
+                                }
+                                end: {
+                                  line: 16
+                                  col: 18
+                                }
+                              }
                             }
-                            rhs {
-                              get_attr {
-                                arg {
+                            rhs: {
+                              get_attr: {
+                                arg: {
                                   name: "."
+                                  source_context: {
+                                    file: "tests/matching.sysl"
+                                    start: {
+                                      line: 16
+                                      col: 35
+                                    }
+                                    end: {
+                                      line: 16
+                                      col: 36
+                                    }
+                                  }
                                 }
                                 attr: "foo"
+                              }
+                              source_context: {
+                                file: "tests/matching.sysl"
+                                start: {
+                                  line: 16
+                                  col: 35
+                                }
+                                end: {
+                                  line: 16
+                                  col: 36
+                                }
                               }
                             }
                             attr_name: "abc"
                             attr_name: "def"
                           }
+                          source_context: {
+                            file: "tests/matching.sysl"
+                            start: {
+                              line: 16
+                              col: 22
+                            }
+                            end: {
+                              line: 16
+                              col: 36
+                            }
+                          }
                         }
                         attr: "def"
                       }
+                      source_context: {
+                        file: "tests/matching.sysl"
+                        start: {
+                          line: 16
+                          col: 39
+                        }
+                        end: {
+                          line: 16
+                          col: 40
+                        }
+                      }
                     }
-                    rhs {
-                      literal {
+                    rhs: {
+                      literal: {
                         b: true
                       }
-                      type {
+                      type: {
                         primitive: BOOL
+                      }
+                      source_context: {
+                        file: "tests/matching.sysl"
+                        start: {
+                          line: 16
+                          col: 50
+                        }
+                        end: {
+                          line: 16
+                          col: 50
+                        }
                       }
                     }
                     scopevar: "."
                   }
+                  type: {
+                    primitive: BOOL
+                  }
+                  source_context: {
+                    file: "tests/matching.sysl"
+                    start: {
+                      line: 16
+                      col: 6
+                    }
+                    end: {
+                      line: 16
+                      col: 54
+                    }
+                    text: "let out9 = .abc !~[abc,def]> .foo.def where(true)"
+                  }
                 }
               }
             }
-            stmt {
-              let {
+            stmt: {
+              let: {
                 name: "out9"
-                expr {
-                  unexpr {
+                expr: {
+                  unexpr: {
                     op: SINGLE
-                    arg {
-                      get_attr {
-                        arg {
-                          binexpr {
+                    arg: {
+                      get_attr: {
+                        arg: {
+                          binexpr: {
                             op: TO_NOT_MATCHING
-                            lhs {
-                              get_attr {
-                                arg {
+                            lhs: {
+                              get_attr: {
+                                arg: {
                                   name: "."
+                                  source_context: {
+                                    file: "tests/matching.sysl"
+                                    start: {
+                                      line: 17
+                                      col: 17
+                                    }
+                                    end: {
+                                      line: 17
+                                      col: 18
+                                    }
+                                  }
                                 }
                                 attr: "abc"
                               }
+                              source_context: {
+                                file: "tests/matching.sysl"
+                                start: {
+                                  line: 17
+                                  col: 17
+                                }
+                                end: {
+                                  line: 17
+                                  col: 18
+                                }
+                              }
                             }
-                            rhs {
-                              get_attr {
-                                arg {
+                            rhs: {
+                              get_attr: {
+                                arg: {
                                   name: "."
+                                  source_context: {
+                                    file: "tests/matching.sysl"
+                                    start: {
+                                      line: 17
+                                      col: 35
+                                    }
+                                    end: {
+                                      line: 17
+                                      col: 36
+                                    }
+                                  }
                                 }
                                 attr: "foo"
+                              }
+                              source_context: {
+                                file: "tests/matching.sysl"
+                                start: {
+                                  line: 17
+                                  col: 35
+                                }
+                                end: {
+                                  line: 17
+                                  col: 36
+                                }
                               }
                             }
                             attr_name: "abc"
                             attr_name: "def"
                           }
+                          source_context: {
+                            file: "tests/matching.sysl"
+                            start: {
+                              line: 17
+                              col: 22
+                            }
+                            end: {
+                              line: 17
+                              col: 36
+                            }
+                          }
                         }
                         attr: "def"
                       }
+                      source_context: {
+                        file: "tests/matching.sysl"
+                        start: {
+                          line: 17
+                          col: 39
+                        }
+                        end: {
+                          line: 17
+                          col: 40
+                        }
+                      }
                     }
+                  }
+                  source_context: {
+                    file: "tests/matching.sysl"
+                    start: {
+                      line: 17
+                      col: 6
+                    }
+                    end: {
+                      line: 17
+                      col: 44
+                    }
+                    text: "let out9 = .abc !~[abc,def]> .foo.def single"
                   }
                 }
               }
             }
-            stmt {
-              let {
+            stmt: {
+              let: {
                 name: "out9"
-                expr {
-                  unexpr {
+                expr: {
+                  unexpr: {
                     op: SINGLE_OR_NULL
-                    arg {
-                      get_attr {
-                        arg {
-                          binexpr {
+                    arg: {
+                      get_attr: {
+                        arg: {
+                          binexpr: {
                             op: TO_NOT_MATCHING
-                            lhs {
-                              get_attr {
-                                arg {
+                            lhs: {
+                              get_attr: {
+                                arg: {
                                   name: "."
+                                  source_context: {
+                                    file: "tests/matching.sysl"
+                                    start: {
+                                      line: 18
+                                      col: 17
+                                    }
+                                    end: {
+                                      line: 18
+                                      col: 18
+                                    }
+                                  }
                                 }
                                 attr: "abc"
                               }
+                              source_context: {
+                                file: "tests/matching.sysl"
+                                start: {
+                                  line: 18
+                                  col: 17
+                                }
+                                end: {
+                                  line: 18
+                                  col: 18
+                                }
+                              }
                             }
-                            rhs {
-                              get_attr {
-                                arg {
+                            rhs: {
+                              get_attr: {
+                                arg: {
                                   name: "."
+                                  source_context: {
+                                    file: "tests/matching.sysl"
+                                    start: {
+                                      line: 18
+                                      col: 35
+                                    }
+                                    end: {
+                                      line: 18
+                                      col: 36
+                                    }
+                                  }
                                 }
                                 attr: "foo"
+                              }
+                              source_context: {
+                                file: "tests/matching.sysl"
+                                start: {
+                                  line: 18
+                                  col: 35
+                                }
+                                end: {
+                                  line: 18
+                                  col: 36
+                                }
                               }
                             }
                             attr_name: "abc"
                             attr_name: "def"
                           }
+                          source_context: {
+                            file: "tests/matching.sysl"
+                            start: {
+                              line: 18
+                              col: 22
+                            }
+                            end: {
+                              line: 18
+                              col: 36
+                            }
+                          }
                         }
                         attr: "def"
                       }
+                      source_context: {
+                        file: "tests/matching.sysl"
+                        start: {
+                          line: 18
+                          col: 39
+                        }
+                        end: {
+                          line: 18
+                          col: 40
+                        }
+                      }
                     }
+                  }
+                  source_context: {
+                    file: "tests/matching.sysl"
+                    start: {
+                      line: 18
+                      col: 6
+                    }
+                    end: {
+                      line: 18
+                      col: 44
+                    }
+                    text: "let out9 = .abc !~[abc,def]> .foo.def singleOrNull"
                   }
                 }
               }
             }
-            stmt {
-              let {
+            stmt: {
+              let: {
                 name: "out10"
-                expr {
-                  ifelse {
-                    cond {
-                      call {
+                expr: {
+                  ifelse: {
+                    cond: {
+                      call: {
                         func: "bool"
-                        arg {
-                          binexpr {
+                        arg: {
+                          binexpr: {
                             op: EQ
-                            lhs {
+                            lhs: {
                               name: "a"
+                              source_context: {
+                                file: "tests/matching.sysl"
+                                start: {
+                                  line: 20
+                                  col: 8
+                                }
+                                end: {
+                                  line: 20
+                                  col: 8
+                                }
+                              }
                             }
-                            rhs {
-                              literal {
+                            rhs: {
+                              literal: {
                                 b: true
                               }
-                              type {
+                              type: {
                                 primitive: BOOL
                               }
+                              source_context: {
+                                file: "tests/matching.sysl"
+                                start: {
+                                  line: 20
+                                  col: 13
+                                }
+                                end: {
+                                  line: 20
+                                  col: 13
+                                }
+                              }
+                            }
+                          }
+                          source_context: {
+                            file: "tests/matching.sysl"
+                            start: {
+                              line: 20
+                              col: 8
+                            }
+                            end: {
+                              line: 20
+                              col: 13
                             }
                           }
                         }
                       }
-                    }
-                    if_true {
-                      binexpr {
-                        op: TO_MATCHING
-                        lhs {
-                          name: "."
+                      source_context: {
+                        file: "tests/matching.sysl"
+                        start: {
+                          line: 19
+                          col: 20
                         }
-                        rhs {
+                        end: {
+                          line: 21
+                          col: 6
+                        }
+                      }
+                    }
+                    if_true: {
+                      binexpr: {
+                        op: TO_MATCHING
+                        lhs: {
+                          name: "."
+                          source_context: {
+                            file: "tests/matching.sysl"
+                            start: {
+                              line: 20
+                              col: 21
+                            }
+                            end: {
+                              line: 20
+                              col: 26
+                            }
+                          }
+                        }
+                        rhs: {
                           name: "foo"
+                          source_context: {
+                            file: "tests/matching.sysl"
+                            start: {
+                              line: 20
+                              col: 26
+                            }
+                            end: {
+                              line: 20
+                              col: 26
+                            }
+                          }
                         }
                         attr_name: "*"
                       }
+                      type: {
+                        no_type: {}
+                      }
+                      source_context: {
+                        file: "tests/matching.sysl"
+                        start: {
+                          line: 20
+                          col: 23
+                        }
+                        end: {
+                          line: 20
+                          col: 26
+                        }
+                      }
                     }
+                  }
+                  type: {
+                    no_type: {}
+                  }
+                  source_context: {
+                    file: "tests/matching.sysl"
+                    start: {
+                      line: 19
+                      col: 6
+                    }
+                    end: {
+                      line: 21
+                      col: 6
+                    }
+                    text: "let out10 = if:\n        a == true => . ~> foo\n      let out11 = rankedSecurityDetailsSet ~[securityDetailsId]> (input.table of SecurityDetails)\n    )\n"
                   }
                 }
               }
             }
-            stmt {
-              let {
+            stmt: {
+              let: {
                 name: "out11"
-                expr {
-                  binexpr {
+                expr: {
+                  binexpr: {
                     op: TO_MATCHING
-                    lhs {
+                    lhs: {
                       name: "rankedSecurityDetailsSet"
+                      source_context: {
+                        file: "tests/matching.sysl"
+                        start: {
+                          line: 21
+                          col: 18
+                        }
+                        end: {
+                          line: 21
+                          col: 18
+                        }
+                      }
                     }
-                    rhs {
-                      get_attr {
-                        arg {
+                    rhs: {
+                      get_attr: {
+                        arg: {
                           name: "input"
+                          source_context: {
+                            file: "tests/matching.sysl"
+                            start: {
+                              line: 21
+                              col: 66
+                            }
+                            end: {
+                              line: 21
+                              col: 66
+                            }
+                          }
                         }
                         attr: "SecurityDetails"
                         setof: true
                       }
+                      source_context: {
+                        file: "tests/matching.sysl"
+                        start: {
+                          line: 21
+                          col: 71
+                        }
+                        end: {
+                          line: 21
+                          col: 81
+                        }
+                      }
                     }
                     attr_name: "securityDetailsId"
+                  }
+                  type: {
+                    no_type: {}
+                  }
+                  source_context: {
+                    file: "tests/matching.sysl"
+                    start: {
+                      line: 21
+                      col: 6
+                    }
+                    end: {
+                      line: 21
+                      col: 96
+                    }
+                    text: "let out11 = rankedSecurityDetailsSet ~[securityDetailsId]> (input.table of SecurityDetails)"
                   }
                 }
               }
             }
           }
+          source_context: {
+            file: "tests/matching.sysl"
+            start: {
+              line: 3
+              col: 4
+            }
+            end: {
+              line: 22
+              col: 5
+            }
+          }
         }
+        source_context: {
+          file: "tests/matching.sysl"
+          start: {
+            line: 2
+            col: 2
+          }
+          end: {
+            line: 23
+          }
+          text: "!view TestMatching(number <: int) -> int:"
+        }
+      }
+    }
+    source_context: {
+      file: "tests/matching.sysl"
+      start: {
+        line: 1
+        col: 1
+      }
+      end: {
+        line: 1
+        col: 47
       }
     }
   }

--- a/pkg/parse/tests/math.sysl.golden.textpb
+++ b/pkg/parse/tests/math.sysl.golden.textpb
@@ -1,30 +1,30 @@
-apps {
+apps: {
   key: "Calculator"
-  value {
-    name {
+  value: {
+    name: {
       part: "Calculator"
     }
-    attrs {
+    attrs: {
       key: "package"
-      value {
+      value: {
         s: "io.sysl.demo.petshop.views"
       }
     }
-    views {
+    views: {
       key: "NoArgTransform"
-      value {
-        param {
+      value: {
+        param: {
           name: "number1"
-          type {
+          type: {
             primitive: INT
           }
         }
-        param {
+        param: {
           name: "foo"
-          type {
-            type_ref {
-              ref {
-                appname {
+          type: {
+            type_ref: {
+              ref: {
+                appname: {
                   part: "Some"
                 }
                 path: "Type"
@@ -32,1002 +32,3229 @@ apps {
             }
           }
         }
-        ret_type {
-          type_ref {
-            ref {
-              appname {
+        ret_type: {
+          type_ref: {
+            ref: {
+              appname: {
                 part: "Model"
               }
               path: "Type"
             }
           }
         }
-        expr {
-          transform {
-            arg {
+        expr: {
+          transform: {
+            arg: {
               name: "."
+              source_context: {
+                file: "tests/math.sysl"
+                start: {
+                  line: 3
+                  col: 4
+                }
+                end: {
+                  line: 41
+                  col: 5
+                }
+              }
             }
             scopevar: "scopeVar"
-            stmt {
-              assign {
+            stmt: {
+              assign: {
                 name: "out"
-                expr {
-                  binexpr {
+                expr: {
+                  binexpr: {
                     op: SUB
-                    lhs {
-                      binexpr {
+                    lhs: {
+                      binexpr: {
                         op: ADD
-                        lhs {
+                        lhs: {
                           name: "number"
+                          source_context: {
+                            file: "tests/math.sysl"
+                            start: {
+                              line: 4
+                              col: 12
+                            }
+                            end: {
+                              line: 4
+                              col: 12
+                            }
+                          }
                         }
-                        rhs {
-                          literal {
+                        rhs: {
+                          literal: {
                             i: 1
                           }
+                          type: {
+                            primitive: INT
+                          }
+                          source_context: {
+                            file: "tests/math.sysl"
+                            start: {
+                              line: 4
+                              col: 21
+                            }
+                            end: {
+                              line: 4
+                              col: 21
+                            }
+                          }
+                        }
+                      }
+                      type: {
+                        primitive: INT
+                      }
+                      source_context: {
+                        file: "tests/math.sysl"
+                        start: {
+                          line: 4
+                          col: 19
+                        }
+                        end: {
+                          line: 4
+                          col: 21
                         }
                       }
                     }
-                    rhs {
+                    rhs: {
                       name: "scopeVar"
+                      source_context: {
+                        file: "tests/math.sysl"
+                        start: {
+                          line: 4
+                          col: 25
+                        }
+                        end: {
+                          line: 4
+                          col: 25
+                        }
+                      }
                     }
+                  }
+                  type: {
+                    no_type: {}
+                  }
+                  source_context: {
+                    file: "tests/math.sysl"
+                    start: {
+                      line: 4
+                      col: 6
+                    }
+                    end: {
+                      line: 4
+                      col: 25
+                    }
+                    text: "out = number + 1 - scopeVar"
                   }
                 }
               }
             }
-            stmt {
-              assign {
+            stmt: {
+              assign: {
                 name: "out"
-                expr {
-                  binexpr {
+                expr: {
+                  binexpr: {
                     op: POW
-                    lhs {
-                      literal {
+                    lhs: {
+                      literal: {
                         i: 2
                       }
+                      source_context: {
+                        file: "tests/math.sysl"
+                        start: {
+                          line: 5
+                          col: 12
+                        }
+                        end: {
+                          line: 5
+                          col: 12
+                        }
+                      }
                     }
-                    rhs {
-                      binexpr {
+                    rhs: {
+                      binexpr: {
                         op: POW
-                        lhs {
-                          literal {
+                        lhs: {
+                          literal: {
                             i: 3
                           }
+                          source_context: {
+                            file: "tests/math.sysl"
+                            start: {
+                              line: 5
+                              col: 17
+                            }
+                            end: {
+                              line: 5
+                              col: 17
+                            }
+                          }
                         }
-                        rhs {
-                          literal {
+                        rhs: {
+                          literal: {
                             i: 4
                           }
+                          source_context: {
+                            file: "tests/math.sysl"
+                            start: {
+                              line: 5
+                              col: 22
+                            }
+                            end: {
+                              line: 5
+                              col: 22
+                            }
+                          }
+                        }
+                      }
+                      source_context: {
+                        file: "tests/math.sysl"
+                        start: {
+                          line: 5
+                          col: 17
+                        }
+                        end: {
+                          line: 5
+                          col: 22
                         }
                       }
                     }
                   }
+                  source_context: {
+                    file: "tests/math.sysl"
+                    start: {
+                      line: 5
+                      col: 6
+                    }
+                    end: {
+                      line: 5
+                      col: 22
+                    }
+                    text: "out = 2 ** 3 ** 4"
+                  }
                 }
               }
             }
-            stmt {
-              assign {
+            stmt: {
+              assign: {
                 name: "out"
-                expr {
-                  binexpr {
+                expr: {
+                  binexpr: {
                     op: SUB
-                    lhs {
-                      binexpr {
+                    lhs: {
+                      binexpr: {
                         op: POW
-                        lhs {
-                          literal {
+                        lhs: {
+                          literal: {
                             i: 2
                           }
+                          source_context: {
+                            file: "tests/math.sysl"
+                            start: {
+                              line: 6
+                              col: 12
+                            }
+                            end: {
+                              line: 6
+                              col: 12
+                            }
+                          }
                         }
-                        rhs {
-                          binexpr {
+                        rhs: {
+                          binexpr: {
                             op: POW
-                            lhs {
-                              literal {
+                            lhs: {
+                              literal: {
                                 i: 3
                               }
+                              source_context: {
+                                file: "tests/math.sysl"
+                                start: {
+                                  line: 6
+                                  col: 17
+                                }
+                                end: {
+                                  line: 6
+                                  col: 17
+                                }
+                              }
                             }
-                            rhs {
-                              unexpr {
+                            rhs: {
+                              unexpr: {
                                 op: NEG
-                                arg {
-                                  literal {
+                                arg: {
+                                  literal: {
                                     i: 4
+                                  }
+                                  source_context: {
+                                    file: "tests/math.sysl"
+                                    start: {
+                                      line: 6
+                                      col: 23
+                                    }
+                                    end: {
+                                      line: 6
+                                      col: 23
+                                    }
                                   }
                                 }
                               }
-                            }
-                          }
-                        }
-                      }
-                    }
-                    rhs {
-                      literal {
-                        i: 10
-                      }
-                    }
-                  }
-                }
-              }
-            }
-            stmt {
-              assign {
-                name: "expr_not"
-                expr {
-                  unexpr {
-                    op: NOT
-                    arg {
-                      name: "foo"
-                    }
-                  }
-                }
-              }
-            }
-            stmt {
-              assign {
-                name: "expr_nota"
-                expr {
-                  unexpr {
-                    op: INV
-                    arg {
-                      name: "foo"
-                    }
-                  }
-                }
-              }
-            }
-            stmt {
-              assign {
-                name: "expr_notb"
-                expr {
-                  unexpr {
-                    op: NEG
-                    arg {
-                      name: "foo"
-                    }
-                  }
-                }
-              }
-            }
-            stmt {
-              assign {
-                name: "expr_notc"
-                expr {
-                  unexpr {
-                    op: POS
-                    arg {
-                      name: "foo"
-                    }
-                  }
-                }
-              }
-            }
-            stmt {
-              assign {
-                name: "expr_but_not"
-                expr {
-                  binexpr {
-                    op: BUTNOT
-                    lhs {
-                      binexpr {
-                        op: BUTNOT
-                        lhs {
-                          binexpr {
-                            op: OR
-                            lhs {
-                              name: "a"
-                            }
-                            rhs {
-                              name: "b"
-                            }
-                          }
-                        }
-                        rhs {
-                          binexpr {
-                            op: OR
-                            lhs {
-                              name: "c"
-                            }
-                            rhs {
-                              name: "d"
-                            }
-                          }
-                        }
-                      }
-                    }
-                    rhs {
-                      binexpr {
-                        op: OR
-                        lhs {
-                          name: "e"
-                        }
-                        rhs {
-                          name: "f"
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            }
-            stmt {
-              assign {
-                name: "expr_or"
-                expr {
-                  binexpr {
-                    op: OR
-                    lhs {
-                      binexpr {
-                        op: OR
-                        lhs {
-                          binexpr {
-                            op: OR
-                            lhs {
-                              name: "a"
-                            }
-                            rhs {
-                              binexpr {
-                                op: AND
-                                lhs {
-                                  name: "b"
+                              source_context: {
+                                file: "tests/math.sysl"
+                                start: {
+                                  line: 6
+                                  col: 22
                                 }
-                                rhs {
-                                  name: "c"
+                                end: {
+                                  line: 6
+                                  col: 23
                                 }
                               }
                             }
                           }
+                          source_context: {
+                            file: "tests/math.sysl"
+                            start: {
+                              line: 6
+                              col: 17
+                            }
+                            end: {
+                              line: 6
+                              col: 23
+                            }
+                          }
                         }
-                        rhs {
-                          binexpr {
+                      }
+                      source_context: {
+                        file: "tests/math.sysl"
+                        start: {
+                          line: 6
+                          col: 12
+                        }
+                        end: {
+                          line: 6
+                          col: 23
+                        }
+                      }
+                    }
+                    rhs: {
+                      literal: {
+                        i: 10
+                      }
+                      source_context: {
+                        file: "tests/math.sysl"
+                        start: {
+                          line: 6
+                          col: 27
+                        }
+                        end: {
+                          line: 6
+                          col: 27
+                        }
+                      }
+                    }
+                  }
+                  source_context: {
+                    file: "tests/math.sysl"
+                    start: {
+                      line: 6
+                      col: 6
+                    }
+                    end: {
+                      line: 6
+                      col: 27
+                    }
+                    text: "out = 2 ** 3 ** -4 - 10"
+                  }
+                }
+              }
+            }
+            stmt: {
+              assign: {
+                name: "expr_not"
+                expr: {
+                  unexpr: {
+                    op: NOT
+                    arg: {
+                      name: "foo"
+                      source_context: {
+                        file: "tests/math.sysl"
+                        start: {
+                          line: 7
+                          col: 18
+                        }
+                        end: {
+                          line: 7
+                          col: 18
+                        }
+                      }
+                    }
+                  }
+                  type: {
+                    primitive: BOOL
+                  }
+                  source_context: {
+                    file: "tests/math.sysl"
+                    start: {
+                      line: 7
+                      col: 6
+                    }
+                    end: {
+                      line: 7
+                      col: 18
+                    }
+                    text: "expr_not = !foo"
+                  }
+                }
+              }
+            }
+            stmt: {
+              assign: {
+                name: "expr_nota"
+                expr: {
+                  unexpr: {
+                    op: INV
+                    arg: {
+                      name: "foo"
+                      source_context: {
+                        file: "tests/math.sysl"
+                        start: {
+                          line: 8
+                          col: 19
+                        }
+                        end: {
+                          line: 8
+                          col: 19
+                        }
+                      }
+                    }
+                  }
+                  type: {
+                    primitive: BOOL
+                  }
+                  source_context: {
+                    file: "tests/math.sysl"
+                    start: {
+                      line: 8
+                      col: 6
+                    }
+                    end: {
+                      line: 8
+                      col: 19
+                    }
+                    text: "expr_nota = ~foo"
+                  }
+                }
+              }
+            }
+            stmt: {
+              assign: {
+                name: "expr_notb"
+                expr: {
+                  unexpr: {
+                    op: NEG
+                    arg: {
+                      name: "foo"
+                      source_context: {
+                        file: "tests/math.sysl"
+                        start: {
+                          line: 9
+                          col: 19
+                        }
+                        end: {
+                          line: 9
+                          col: 19
+                        }
+                      }
+                    }
+                  }
+                  type: {
+                    primitive: INT
+                  }
+                  source_context: {
+                    file: "tests/math.sysl"
+                    start: {
+                      line: 9
+                      col: 6
+                    }
+                    end: {
+                      line: 9
+                      col: 19
+                    }
+                    text: "expr_notb = -foo"
+                  }
+                }
+              }
+            }
+            stmt: {
+              assign: {
+                name: "expr_notc"
+                expr: {
+                  unexpr: {
+                    op: POS
+                    arg: {
+                      name: "foo"
+                      source_context: {
+                        file: "tests/math.sysl"
+                        start: {
+                          line: 10
+                          col: 19
+                        }
+                        end: {
+                          line: 10
+                          col: 19
+                        }
+                      }
+                    }
+                  }
+                  type: {
+                    primitive: INT
+                  }
+                  source_context: {
+                    file: "tests/math.sysl"
+                    start: {
+                      line: 10
+                      col: 6
+                    }
+                    end: {
+                      line: 10
+                      col: 19
+                    }
+                    text: "expr_notc = +foo"
+                  }
+                }
+              }
+            }
+            stmt: {
+              assign: {
+                name: "expr_but_not"
+                expr: {
+                  binexpr: {
+                    op: BUTNOT
+                    lhs: {
+                      binexpr: {
+                        op: BUTNOT
+                        lhs: {
+                          binexpr: {
+                            op: OR
+                            lhs: {
+                              name: "a"
+                              source_context: {
+                                file: "tests/math.sysl"
+                                start: {
+                                  line: 11
+                                  col: 21
+                                }
+                                end: {
+                                  line: 11
+                                  col: 21
+                                }
+                              }
+                            }
+                            rhs: {
+                              name: "b"
+                              source_context: {
+                                file: "tests/math.sysl"
+                                start: {
+                                  line: 11
+                                  col: 26
+                                }
+                                end: {
+                                  line: 11
+                                  col: 26
+                                }
+                              }
+                            }
+                          }
+                          type: {
+                            no_type: {}
+                          }
+                          source_context: {
+                            file: "tests/math.sysl"
+                            start: {
+                              line: 11
+                              col: 21
+                            }
+                            end: {
+                              line: 11
+                              col: 26
+                            }
+                          }
+                        }
+                        rhs: {
+                          binexpr: {
+                            op: OR
+                            lhs: {
+                              name: "c"
+                              source_context: {
+                                file: "tests/math.sysl"
+                                start: {
+                                  line: 11
+                                  col: 36
+                                }
+                                end: {
+                                  line: 11
+                                  col: 36
+                                }
+                              }
+                            }
+                            rhs: {
+                              name: "d"
+                              source_context: {
+                                file: "tests/math.sysl"
+                                start: {
+                                  line: 11
+                                  col: 41
+                                }
+                                end: {
+                                  line: 11
+                                  col: 41
+                                }
+                              }
+                            }
+                          }
+                          type: {
+                            no_type: {}
+                          }
+                          source_context: {
+                            file: "tests/math.sysl"
+                            start: {
+                              line: 11
+                              col: 36
+                            }
+                            end: {
+                              line: 11
+                              col: 41
+                            }
+                          }
+                        }
+                      }
+                      type: {
+                        no_type: {}
+                      }
+                      source_context: {
+                        file: "tests/math.sysl"
+                        start: {
+                          line: 11
+                          col: 21
+                        }
+                        end: {
+                          line: 11
+                          col: 56
+                        }
+                      }
+                    }
+                    rhs: {
+                      binexpr: {
+                        op: OR
+                        lhs: {
+                          name: "e"
+                          source_context: {
+                            file: "tests/math.sysl"
+                            start: {
+                              line: 11
+                              col: 51
+                            }
+                            end: {
+                              line: 11
+                              col: 51
+                            }
+                          }
+                        }
+                        rhs: {
+                          name: "f"
+                          source_context: {
+                            file: "tests/math.sysl"
+                            start: {
+                              line: 11
+                              col: 56
+                            }
+                            end: {
+                              line: 11
+                              col: 56
+                            }
+                          }
+                        }
+                      }
+                      type: {
+                        no_type: {}
+                      }
+                      source_context: {
+                        file: "tests/math.sysl"
+                        start: {
+                          line: 11
+                          col: 51
+                        }
+                        end: {
+                          line: 11
+                          col: 56
+                        }
+                      }
+                    }
+                  }
+                  type: {
+                    no_type: {}
+                  }
+                  source_context: {
+                    file: "tests/math.sysl"
+                    start: {
+                      line: 11
+                      col: 6
+                    }
+                    end: {
+                      line: 11
+                      col: 56
+                    }
+                    text: "expr_but_not = a || b but not c || d but not e || f"
+                  }
+                }
+              }
+            }
+            stmt: {
+              assign: {
+                name: "expr_or"
+                expr: {
+                  binexpr: {
+                    op: OR
+                    lhs: {
+                      binexpr: {
+                        op: OR
+                        lhs: {
+                          binexpr: {
+                            op: OR
+                            lhs: {
+                              name: "a"
+                              source_context: {
+                                file: "tests/math.sysl"
+                                start: {
+                                  line: 12
+                                  col: 16
+                                }
+                                end: {
+                                  line: 12
+                                  col: 16
+                                }
+                              }
+                            }
+                            rhs: {
+                              binexpr: {
+                                op: AND
+                                lhs: {
+                                  name: "b"
+                                  source_context: {
+                                    file: "tests/math.sysl"
+                                    start: {
+                                      line: 12
+                                      col: 21
+                                    }
+                                    end: {
+                                      line: 12
+                                      col: 21
+                                    }
+                                  }
+                                }
+                                rhs: {
+                                  name: "c"
+                                  source_context: {
+                                    file: "tests/math.sysl"
+                                    start: {
+                                      line: 12
+                                      col: 26
+                                    }
+                                    end: {
+                                      line: 12
+                                      col: 26
+                                    }
+                                  }
+                                }
+                              }
+                              type: {
+                                no_type: {}
+                              }
+                              source_context: {
+                                file: "tests/math.sysl"
+                                start: {
+                                  line: 12
+                                  col: 21
+                                }
+                                end: {
+                                  line: 12
+                                  col: 26
+                                }
+                              }
+                            }
+                          }
+                          type: {
+                            no_type: {}
+                          }
+                          source_context: {
+                            file: "tests/math.sysl"
+                            start: {
+                              line: 12
+                              col: 16
+                            }
+                            end: {
+                              line: 12
+                              col: 41
+                            }
+                          }
+                        }
+                        rhs: {
+                          binexpr: {
                             op: AND
-                            lhs {
+                            lhs: {
                               name: "d"
+                              source_context: {
+                                file: "tests/math.sysl"
+                                start: {
+                                  line: 12
+                                  col: 31
+                                }
+                                end: {
+                                  line: 12
+                                  col: 31
+                                }
+                              }
                             }
-                            rhs {
+                            rhs: {
                               name: "e"
+                              source_context: {
+                                file: "tests/math.sysl"
+                                start: {
+                                  line: 12
+                                  col: 36
+                                }
+                                end: {
+                                  line: 12
+                                  col: 36
+                                }
+                              }
+                            }
+                          }
+                          type: {
+                            no_type: {}
+                          }
+                          source_context: {
+                            file: "tests/math.sysl"
+                            start: {
+                              line: 12
+                              col: 31
+                            }
+                            end: {
+                              line: 12
+                              col: 36
                             }
                           }
                         }
                       }
+                      type: {
+                        no_type: {}
+                      }
+                      source_context: {
+                        file: "tests/math.sysl"
+                        start: {
+                          line: 12
+                          col: 16
+                        }
+                        end: {
+                          line: 12
+                          col: 41
+                        }
+                      }
                     }
-                    rhs {
+                    rhs: {
                       name: "f"
+                      source_context: {
+                        file: "tests/math.sysl"
+                        start: {
+                          line: 12
+                          col: 41
+                        }
+                        end: {
+                          line: 12
+                          col: 41
+                        }
+                      }
                     }
+                  }
+                  type: {
+                    no_type: {}
+                  }
+                  source_context: {
+                    file: "tests/math.sysl"
+                    start: {
+                      line: 12
+                      col: 6
+                    }
+                    end: {
+                      line: 12
+                      col: 41
+                    }
+                    text: "expr_or = a || b && c || d && e || f"
                   }
                 }
               }
             }
-            stmt {
-              assign {
+            stmt: {
+              assign: {
                 name: "expr_and"
-                expr {
-                  binexpr {
+                expr: {
+                  binexpr: {
                     op: AND
-                    lhs {
-                      binexpr {
+                    lhs: {
+                      binexpr: {
                         op: AND
-                        lhs {
-                          binexpr {
+                        lhs: {
+                          binexpr: {
                             op: BITXOR
-                            lhs {
+                            lhs: {
                               name: "a"
+                              source_context: {
+                                file: "tests/math.sysl"
+                                start: {
+                                  line: 13
+                                  col: 17
+                                }
+                                end: {
+                                  line: 13
+                                  col: 17
+                                }
+                              }
                             }
-                            rhs {
+                            rhs: {
                               name: "b"
+                              source_context: {
+                                file: "tests/math.sysl"
+                                start: {
+                                  line: 13
+                                  col: 21
+                                }
+                                end: {
+                                  line: 13
+                                  col: 21
+                                }
+                              }
+                            }
+                          }
+                          type: {
+                            no_type: {}
+                          }
+                          source_context: {
+                            file: "tests/math.sysl"
+                            start: {
+                              line: 13
+                              col: 17
+                            }
+                            end: {
+                              line: 13
+                              col: 21
                             }
                           }
                         }
-                        rhs {
-                          binexpr {
+                        rhs: {
+                          binexpr: {
                             op: BITXOR
-                            lhs {
+                            lhs: {
                               name: "c"
+                              source_context: {
+                                file: "tests/math.sysl"
+                                start: {
+                                  line: 13
+                                  col: 26
+                                }
+                                end: {
+                                  line: 13
+                                  col: 26
+                                }
+                              }
                             }
-                            rhs {
+                            rhs: {
                               name: "d"
+                              source_context: {
+                                file: "tests/math.sysl"
+                                start: {
+                                  line: 13
+                                  col: 30
+                                }
+                                end: {
+                                  line: 13
+                                  col: 30
+                                }
+                              }
+                            }
+                          }
+                          type: {
+                            no_type: {}
+                          }
+                          source_context: {
+                            file: "tests/math.sysl"
+                            start: {
+                              line: 13
+                              col: 26
+                            }
+                            end: {
+                              line: 13
+                              col: 30
                             }
                           }
                         }
                       }
-                    }
-                    rhs {
-                      binexpr {
-                        op: BITXOR
-                        lhs {
-                          name: "e"
+                      type: {
+                        no_type: {}
+                      }
+                      source_context: {
+                        file: "tests/math.sysl"
+                        start: {
+                          line: 13
+                          col: 17
                         }
-                        rhs {
+                        end: {
+                          line: 13
+                          col: 39
+                        }
+                      }
+                    }
+                    rhs: {
+                      binexpr: {
+                        op: BITXOR
+                        lhs: {
+                          name: "e"
+                          source_context: {
+                            file: "tests/math.sysl"
+                            start: {
+                              line: 13
+                              col: 35
+                            }
+                            end: {
+                              line: 13
+                              col: 35
+                            }
+                          }
+                        }
+                        rhs: {
                           name: "f"
+                          source_context: {
+                            file: "tests/math.sysl"
+                            start: {
+                              line: 13
+                              col: 39
+                            }
+                            end: {
+                              line: 13
+                              col: 39
+                            }
+                          }
+                        }
+                      }
+                      type: {
+                        no_type: {}
+                      }
+                      source_context: {
+                        file: "tests/math.sysl"
+                        start: {
+                          line: 13
+                          col: 35
+                        }
+                        end: {
+                          line: 13
+                          col: 39
                         }
                       }
                     }
                   }
+                  type: {
+                    no_type: {}
+                  }
+                  source_context: {
+                    file: "tests/math.sysl"
+                    start: {
+                      line: 13
+                      col: 6
+                    }
+                    end: {
+                      line: 13
+                      col: 39
+                    }
+                    text: "expr_and = a ^ b && c ^ d && e ^ f"
+                  }
                 }
               }
             }
-            stmt {
-              assign {
+            stmt: {
+              assign: {
                 name: "expr_bitor"
-                expr {
-                  binexpr {
+                expr: {
+                  binexpr: {
                     op: BITOR
-                    lhs {
-                      binexpr {
+                    lhs: {
+                      binexpr: {
                         op: BITOR
-                        lhs {
-                          binexpr {
+                        lhs: {
+                          binexpr: {
                             op: BITXOR
-                            lhs {
+                            lhs: {
                               name: "a"
+                              source_context: {
+                                file: "tests/math.sysl"
+                                start: {
+                                  line: 14
+                                  col: 19
+                                }
+                                end: {
+                                  line: 14
+                                  col: 19
+                                }
+                              }
                             }
-                            rhs {
+                            rhs: {
                               name: "b"
+                              source_context: {
+                                file: "tests/math.sysl"
+                                start: {
+                                  line: 14
+                                  col: 23
+                                }
+                                end: {
+                                  line: 14
+                                  col: 23
+                                }
+                              }
+                            }
+                          }
+                          type: {
+                            no_type: {}
+                          }
+                          source_context: {
+                            file: "tests/math.sysl"
+                            start: {
+                              line: 14
+                              col: 19
+                            }
+                            end: {
+                              line: 14
+                              col: 23
                             }
                           }
                         }
-                        rhs {
-                          binexpr {
+                        rhs: {
+                          binexpr: {
                             op: BITXOR
-                            lhs {
+                            lhs: {
                               name: "c"
+                              source_context: {
+                                file: "tests/math.sysl"
+                                start: {
+                                  line: 14
+                                  col: 28
+                                }
+                                end: {
+                                  line: 14
+                                  col: 28
+                                }
+                              }
                             }
-                            rhs {
+                            rhs: {
                               name: "d"
+                              source_context: {
+                                file: "tests/math.sysl"
+                                start: {
+                                  line: 14
+                                  col: 32
+                                }
+                                end: {
+                                  line: 14
+                                  col: 32
+                                }
+                              }
+                            }
+                          }
+                          type: {
+                            no_type: {}
+                          }
+                          source_context: {
+                            file: "tests/math.sysl"
+                            start: {
+                              line: 14
+                              col: 28
+                            }
+                            end: {
+                              line: 14
+                              col: 32
                             }
                           }
                         }
                       }
-                    }
-                    rhs {
-                      binexpr {
-                        op: BITXOR
-                        lhs {
-                          name: "e"
+                      type: {
+                        no_type: {}
+                      }
+                      source_context: {
+                        file: "tests/math.sysl"
+                        start: {
+                          line: 14
+                          col: 19
                         }
-                        rhs {
+                        end: {
+                          line: 14
+                          col: 41
+                        }
+                      }
+                    }
+                    rhs: {
+                      binexpr: {
+                        op: BITXOR
+                        lhs: {
+                          name: "e"
+                          source_context: {
+                            file: "tests/math.sysl"
+                            start: {
+                              line: 14
+                              col: 37
+                            }
+                            end: {
+                              line: 14
+                              col: 37
+                            }
+                          }
+                        }
+                        rhs: {
                           name: "f"
+                          source_context: {
+                            file: "tests/math.sysl"
+                            start: {
+                              line: 14
+                              col: 41
+                            }
+                            end: {
+                              line: 14
+                              col: 41
+                            }
+                          }
+                        }
+                      }
+                      type: {
+                        no_type: {}
+                      }
+                      source_context: {
+                        file: "tests/math.sysl"
+                        start: {
+                          line: 14
+                          col: 37
+                        }
+                        end: {
+                          line: 14
+                          col: 41
                         }
                       }
                     }
                   }
+                  type: {
+                    no_type: {}
+                  }
+                  source_context: {
+                    file: "tests/math.sysl"
+                    start: {
+                      line: 14
+                      col: 6
+                    }
+                    end: {
+                      line: 14
+                      col: 41
+                    }
+                    text: "expr_bitor = a ^ b or c ^ d or e ^ f"
+                  }
                 }
               }
             }
-            stmt {
-              assign {
+            stmt: {
+              assign: {
                 name: "expr_bitor"
-                expr {
-                  binexpr {
+                expr: {
+                  binexpr: {
                     op: BITOR
-                    lhs {
-                      binexpr {
+                    lhs: {
+                      binexpr: {
                         op: BITOR
-                        lhs {
-                          binexpr {
+                        lhs: {
+                          binexpr: {
                             op: BITXOR
-                            lhs {
+                            lhs: {
                               name: "a"
+                              source_context: {
+                                file: "tests/math.sysl"
+                                start: {
+                                  line: 15
+                                  col: 19
+                                }
+                                end: {
+                                  line: 15
+                                  col: 19
+                                }
+                              }
                             }
-                            rhs {
+                            rhs: {
                               name: "b"
+                              source_context: {
+                                file: "tests/math.sysl"
+                                start: {
+                                  line: 15
+                                  col: 23
+                                }
+                                end: {
+                                  line: 15
+                                  col: 23
+                                }
+                              }
+                            }
+                          }
+                          source_context: {
+                            file: "tests/math.sysl"
+                            start: {
+                              line: 15
+                              col: 19
+                            }
+                            end: {
+                              line: 15
+                              col: 23
                             }
                           }
                         }
-                        rhs {
-                          binexpr {
+                        rhs: {
+                          binexpr: {
                             op: BITXOR
-                            lhs {
+                            lhs: {
                               name: "c"
+                              source_context: {
+                                file: "tests/math.sysl"
+                                start: {
+                                  line: 15
+                                  col: 27
+                                }
+                                end: {
+                                  line: 15
+                                  col: 27
+                                }
+                              }
                             }
-                            rhs {
+                            rhs: {
                               name: "d"
+                              source_context: {
+                                file: "tests/math.sysl"
+                                start: {
+                                  line: 15
+                                  col: 31
+                                }
+                                end: {
+                                  line: 15
+                                  col: 31
+                                }
+                              }
+                            }
+                          }
+                          source_context: {
+                            file: "tests/math.sysl"
+                            start: {
+                              line: 15
+                              col: 27
+                            }
+                            end: {
+                              line: 15
+                              col: 31
                             }
                           }
                         }
                       }
-                    }
-                    rhs {
-                      binexpr {
-                        op: BITXOR
-                        lhs {
-                          name: "e"
+                      source_context: {
+                        file: "tests/math.sysl"
+                        start: {
+                          line: 15
+                          col: 19
                         }
-                        rhs {
+                        end: {
+                          line: 15
+                          col: 39
+                        }
+                      }
+                    }
+                    rhs: {
+                      binexpr: {
+                        op: BITXOR
+                        lhs: {
+                          name: "e"
+                          source_context: {
+                            file: "tests/math.sysl"
+                            start: {
+                              line: 15
+                              col: 35
+                            }
+                            end: {
+                              line: 15
+                              col: 35
+                            }
+                          }
+                        }
+                        rhs: {
                           name: "f"
+                          source_context: {
+                            file: "tests/math.sysl"
+                            start: {
+                              line: 15
+                              col: 39
+                            }
+                            end: {
+                              line: 15
+                              col: 39
+                            }
+                          }
+                        }
+                      }
+                      source_context: {
+                        file: "tests/math.sysl"
+                        start: {
+                          line: 15
+                          col: 35
+                        }
+                        end: {
+                          line: 15
+                          col: 39
                         }
                       }
                     }
                   }
+                  source_context: {
+                    file: "tests/math.sysl"
+                    start: {
+                      line: 15
+                      col: 6
+                    }
+                    end: {
+                      line: 15
+                      col: 39
+                    }
+                    text: "expr_bitor = a ^ b | c ^ d | e ^ f"
+                  }
                 }
               }
             }
-            stmt {
-              assign {
+            stmt: {
+              assign: {
                 name: "expr_bit_xor"
-                expr {
-                  binexpr {
+                expr: {
+                  binexpr: {
                     op: BITXOR
-                    lhs {
-                      binexpr {
+                    lhs: {
+                      binexpr: {
                         op: BITXOR
-                        lhs {
-                          binexpr {
+                        lhs: {
+                          binexpr: {
                             op: BITAND
-                            lhs {
+                            lhs: {
                               name: "a"
+                              source_context: {
+                                file: "tests/math.sysl"
+                                start: {
+                                  line: 16
+                                  col: 21
+                                }
+                                end: {
+                                  line: 16
+                                  col: 21
+                                }
+                              }
                             }
-                            rhs {
+                            rhs: {
                               name: "b"
+                              source_context: {
+                                file: "tests/math.sysl"
+                                start: {
+                                  line: 16
+                                  col: 25
+                                }
+                                end: {
+                                  line: 16
+                                  col: 25
+                                }
+                              }
+                            }
+                          }
+                          type: {
+                            no_type: {}
+                          }
+                          source_context: {
+                            file: "tests/math.sysl"
+                            start: {
+                              line: 16
+                              col: 21
+                            }
+                            end: {
+                              line: 16
+                              col: 25
                             }
                           }
                         }
-                        rhs {
-                          binexpr {
+                        rhs: {
+                          binexpr: {
                             op: BITAND
-                            lhs {
+                            lhs: {
                               name: "c"
+                              source_context: {
+                                file: "tests/math.sysl"
+                                start: {
+                                  line: 16
+                                  col: 29
+                                }
+                                end: {
+                                  line: 16
+                                  col: 29
+                                }
+                              }
                             }
-                            rhs {
+                            rhs: {
                               name: "d"
+                              source_context: {
+                                file: "tests/math.sysl"
+                                start: {
+                                  line: 16
+                                  col: 33
+                                }
+                                end: {
+                                  line: 16
+                                  col: 33
+                                }
+                              }
+                            }
+                          }
+                          type: {
+                            no_type: {}
+                          }
+                          source_context: {
+                            file: "tests/math.sysl"
+                            start: {
+                              line: 16
+                              col: 29
+                            }
+                            end: {
+                              line: 16
+                              col: 33
                             }
                           }
                         }
                       }
+                      type: {
+                        no_type: {}
+                      }
+                      source_context: {
+                        file: "tests/math.sysl"
+                        start: {
+                          line: 16
+                          col: 21
+                        }
+                        end: {
+                          line: 16
+                          col: 41
+                        }
+                      }
                     }
-                    rhs {
-                      binexpr {
+                    rhs: {
+                      binexpr: {
                         op: BITAND
-                        lhs {
+                        lhs: {
                           name: "e"
+                          source_context: {
+                            file: "tests/math.sysl"
+                            start: {
+                              line: 16
+                              col: 37
+                            }
+                            end: {
+                              line: 16
+                              col: 37
+                            }
+                          }
                         }
-                        rhs {
+                        rhs: {
                           name: "f"
+                          source_context: {
+                            file: "tests/math.sysl"
+                            start: {
+                              line: 16
+                              col: 41
+                            }
+                            end: {
+                              line: 16
+                              col: 41
+                            }
+                          }
+                        }
+                      }
+                      type: {
+                        no_type: {}
+                      }
+                      source_context: {
+                        file: "tests/math.sysl"
+                        start: {
+                          line: 16
+                          col: 37
+                        }
+                        end: {
+                          line: 16
+                          col: 41
                         }
                       }
                     }
                   }
+                  type: {
+                    no_type: {}
+                  }
+                  source_context: {
+                    file: "tests/math.sysl"
+                    start: {
+                      line: 16
+                      col: 6
+                    }
+                    end: {
+                      line: 16
+                      col: 41
+                    }
+                    text: "expr_bit_xor = a & b ^ c & d ^ e & f"
+                  }
                 }
               }
             }
-            stmt {
-              assign {
+            stmt: {
+              assign: {
                 name: "expr_rel"
-                expr {
-                  binexpr {
+                expr: {
+                  binexpr: {
                     op: LE
-                    lhs {
-                      binexpr {
+                    lhs: {
+                      binexpr: {
                         op: ADD
-                        lhs {
+                        lhs: {
                           name: "a"
+                          source_context: {
+                            file: "tests/math.sysl"
+                            start: {
+                              line: 17
+                              col: 17
+                            }
+                            end: {
+                              line: 17
+                              col: 17
+                            }
+                          }
                         }
-                        rhs {
+                        rhs: {
                           name: "b"
+                          source_context: {
+                            file: "tests/math.sysl"
+                            start: {
+                              line: 17
+                              col: 21
+                            }
+                            end: {
+                              line: 17
+                              col: 21
+                            }
+                          }
+                        }
+                      }
+                      type: {
+                        no_type: {}
+                      }
+                      source_context: {
+                        file: "tests/math.sysl"
+                        start: {
+                          line: 17
+                          col: 19
+                        }
+                        end: {
+                          line: 17
+                          col: 21
                         }
                       }
                     }
-                    rhs {
-                      binexpr {
+                    rhs: {
+                      binexpr: {
                         op: SUB
-                        lhs {
+                        lhs: {
                           name: "c"
+                          source_context: {
+                            file: "tests/math.sysl"
+                            start: {
+                              line: 17
+                              col: 26
+                            }
+                            end: {
+                              line: 17
+                              col: 26
+                            }
+                          }
                         }
-                        rhs {
+                        rhs: {
                           name: "d"
+                          source_context: {
+                            file: "tests/math.sysl"
+                            start: {
+                              line: 17
+                              col: 30
+                            }
+                            end: {
+                              line: 17
+                              col: 30
+                            }
+                          }
+                        }
+                      }
+                      type: {
+                        no_type: {}
+                      }
+                      source_context: {
+                        file: "tests/math.sysl"
+                        start: {
+                          line: 17
+                          col: 28
+                        }
+                        end: {
+                          line: 17
+                          col: 30
                         }
                       }
                     }
                   }
+                  type: {
+                    no_type: {}
+                  }
+                  source_context: {
+                    file: "tests/math.sysl"
+                    start: {
+                      line: 17
+                      col: 6
+                    }
+                    end: {
+                      line: 17
+                      col: 30
+                    }
+                    text: "expr_rel = a + b <= c - d"
+                  }
                 }
               }
             }
-            stmt {
-              assign {
+            stmt: {
+              assign: {
                 name: "expr_rel"
-                expr {
-                  binexpr {
+                expr: {
+                  binexpr: {
                     op: GE
-                    lhs {
-                      binexpr {
+                    lhs: {
+                      binexpr: {
                         op: MUL
-                        lhs {
+                        lhs: {
                           name: "a"
+                          source_context: {
+                            file: "tests/math.sysl"
+                            start: {
+                              line: 18
+                              col: 17
+                            }
+                            end: {
+                              line: 18
+                              col: 17
+                            }
+                          }
                         }
-                        rhs {
+                        rhs: {
                           name: "b"
+                          source_context: {
+                            file: "tests/math.sysl"
+                            start: {
+                              line: 18
+                              col: 21
+                            }
+                            end: {
+                              line: 18
+                              col: 21
+                            }
+                          }
+                        }
+                      }
+                      source_context: {
+                        file: "tests/math.sysl"
+                        start: {
+                          line: 18
+                          col: 19
+                        }
+                        end: {
+                          line: 18
+                          col: 21
                         }
                       }
                     }
-                    rhs {
-                      binexpr {
+                    rhs: {
+                      binexpr: {
                         op: DIV
-                        lhs {
+                        lhs: {
                           name: "c"
+                          source_context: {
+                            file: "tests/math.sysl"
+                            start: {
+                              line: 18
+                              col: 26
+                            }
+                            end: {
+                              line: 18
+                              col: 26
+                            }
+                          }
                         }
-                        rhs {
+                        rhs: {
                           name: "d"
+                          source_context: {
+                            file: "tests/math.sysl"
+                            start: {
+                              line: 18
+                              col: 30
+                            }
+                            end: {
+                              line: 18
+                              col: 30
+                            }
+                          }
+                        }
+                      }
+                      source_context: {
+                        file: "tests/math.sysl"
+                        start: {
+                          line: 18
+                          col: 28
+                        }
+                        end: {
+                          line: 18
+                          col: 30
                         }
                       }
                     }
                   }
+                  source_context: {
+                    file: "tests/math.sysl"
+                    start: {
+                      line: 18
+                      col: 6
+                    }
+                    end: {
+                      line: 18
+                      col: 30
+                    }
+                    text: "expr_rel = a * b >= c / d"
+                  }
                 }
               }
             }
-            stmt {
-              assign {
+            stmt: {
+              assign: {
                 name: "expr_rel"
-                expr {
-                  binexpr {
+                expr: {
+                  binexpr: {
                     op: GT
-                    lhs {
-                      binexpr {
+                    lhs: {
+                      binexpr: {
                         op: POW
-                        lhs {
+                        lhs: {
                           name: "a"
+                          source_context: {
+                            file: "tests/math.sysl"
+                            start: {
+                              line: 19
+                              col: 17
+                            }
+                            end: {
+                              line: 19
+                              col: 17
+                            }
+                          }
                         }
-                        rhs {
+                        rhs: {
                           name: "b"
+                          source_context: {
+                            file: "tests/math.sysl"
+                            start: {
+                              line: 19
+                              col: 22
+                            }
+                            end: {
+                              line: 19
+                              col: 22
+                            }
+                          }
+                        }
+                      }
+                      source_context: {
+                        file: "tests/math.sysl"
+                        start: {
+                          line: 19
+                          col: 17
+                        }
+                        end: {
+                          line: 19
+                          col: 22
                         }
                       }
                     }
-                    rhs {
-                      binexpr {
+                    rhs: {
+                      binexpr: {
                         op: POW
-                        lhs {
+                        lhs: {
                           name: "c"
+                          source_context: {
+                            file: "tests/math.sysl"
+                            start: {
+                              line: 19
+                              col: 26
+                            }
+                            end: {
+                              line: 19
+                              col: 26
+                            }
+                          }
                         }
-                        rhs {
+                        rhs: {
                           name: "d"
+                          source_context: {
+                            file: "tests/math.sysl"
+                            start: {
+                              line: 19
+                              col: 31
+                            }
+                            end: {
+                              line: 19
+                              col: 31
+                            }
+                          }
+                        }
+                      }
+                      source_context: {
+                        file: "tests/math.sysl"
+                        start: {
+                          line: 19
+                          col: 26
+                        }
+                        end: {
+                          line: 19
+                          col: 31
                         }
                       }
                     }
                   }
+                  source_context: {
+                    file: "tests/math.sysl"
+                    start: {
+                      line: 19
+                      col: 6
+                    }
+                    end: {
+                      line: 19
+                      col: 31
+                    }
+                    text: "expr_rel = a ** b > c ** d"
+                  }
                 }
               }
             }
-            stmt {
-              assign {
+            stmt: {
+              assign: {
                 name: "expr_rel"
-                expr {
-                  binexpr {
+                expr: {
+                  binexpr: {
                     op: LT
-                    lhs {
-                      binexpr {
+                    lhs: {
+                      binexpr: {
                         op: POW
-                        lhs {
+                        lhs: {
                           name: "a"
+                          source_context: {
+                            file: "tests/math.sysl"
+                            start: {
+                              line: 20
+                              col: 17
+                            }
+                            end: {
+                              line: 20
+                              col: 17
+                            }
+                          }
                         }
-                        rhs {
+                        rhs: {
                           name: "b"
+                          source_context: {
+                            file: "tests/math.sysl"
+                            start: {
+                              line: 20
+                              col: 22
+                            }
+                            end: {
+                              line: 20
+                              col: 22
+                            }
+                          }
+                        }
+                      }
+                      source_context: {
+                        file: "tests/math.sysl"
+                        start: {
+                          line: 20
+                          col: 17
+                        }
+                        end: {
+                          line: 20
+                          col: 22
                         }
                       }
                     }
-                    rhs {
-                      binexpr {
+                    rhs: {
+                      binexpr: {
                         op: POW
-                        lhs {
+                        lhs: {
                           name: "c"
+                          source_context: {
+                            file: "tests/math.sysl"
+                            start: {
+                              line: 20
+                              col: 26
+                            }
+                            end: {
+                              line: 20
+                              col: 26
+                            }
+                          }
                         }
-                        rhs {
+                        rhs: {
                           name: "d"
+                          source_context: {
+                            file: "tests/math.sysl"
+                            start: {
+                              line: 20
+                              col: 31
+                            }
+                            end: {
+                              line: 20
+                              col: 31
+                            }
+                          }
+                        }
+                      }
+                      source_context: {
+                        file: "tests/math.sysl"
+                        start: {
+                          line: 20
+                          col: 26
+                        }
+                        end: {
+                          line: 20
+                          col: 31
                         }
                       }
                     }
                   }
+                  source_context: {
+                    file: "tests/math.sysl"
+                    start: {
+                      line: 20
+                      col: 6
+                    }
+                    end: {
+                      line: 20
+                      col: 31
+                    }
+                    text: "expr_rel = a ** b < c ** d"
+                  }
                 }
               }
             }
-            stmt {
-              assign {
+            stmt: {
+              assign: {
                 name: "expr_rel"
-                expr {
-                  binexpr {
+                expr: {
+                  binexpr: {
                     op: NE
-                    lhs {
-                      binexpr {
+                    lhs: {
+                      binexpr: {
                         op: ADD
-                        lhs {
+                        lhs: {
                           name: "a"
+                          source_context: {
+                            file: "tests/math.sysl"
+                            start: {
+                              line: 21
+                              col: 17
+                            }
+                            end: {
+                              line: 21
+                              col: 17
+                            }
+                          }
                         }
-                        rhs {
+                        rhs: {
                           name: "b"
+                          source_context: {
+                            file: "tests/math.sysl"
+                            start: {
+                              line: 21
+                              col: 21
+                            }
+                            end: {
+                              line: 21
+                              col: 21
+                            }
+                          }
+                        }
+                      }
+                      source_context: {
+                        file: "tests/math.sysl"
+                        start: {
+                          line: 21
+                          col: 19
+                        }
+                        end: {
+                          line: 21
+                          col: 21
                         }
                       }
                     }
-                    rhs {
-                      binexpr {
+                    rhs: {
+                      binexpr: {
                         op: ADD
-                        lhs {
+                        lhs: {
                           name: "c"
+                          source_context: {
+                            file: "tests/math.sysl"
+                            start: {
+                              line: 21
+                              col: 26
+                            }
+                            end: {
+                              line: 21
+                              col: 26
+                            }
+                          }
                         }
-                        rhs {
+                        rhs: {
                           name: "d"
+                          source_context: {
+                            file: "tests/math.sysl"
+                            start: {
+                              line: 21
+                              col: 30
+                            }
+                            end: {
+                              line: 21
+                              col: 30
+                            }
+                          }
+                        }
+                      }
+                      source_context: {
+                        file: "tests/math.sysl"
+                        start: {
+                          line: 21
+                          col: 28
+                        }
+                        end: {
+                          line: 21
+                          col: 30
                         }
                       }
                     }
                   }
+                  source_context: {
+                    file: "tests/math.sysl"
+                    start: {
+                      line: 21
+                      col: 6
+                    }
+                    end: {
+                      line: 21
+                      col: 30
+                    }
+                    text: "expr_rel = a + b != c + d"
+                  }
                 }
               }
             }
-            stmt {
-              assign {
+            stmt: {
+              assign: {
                 name: "expr_rel"
-                expr {
-                  binexpr {
+                expr: {
+                  binexpr: {
                     op: EQ
-                    lhs {
-                      binexpr {
+                    lhs: {
+                      binexpr: {
                         op: ADD
-                        lhs {
+                        lhs: {
                           name: "a"
+                          source_context: {
+                            file: "tests/math.sysl"
+                            start: {
+                              line: 22
+                              col: 17
+                            }
+                            end: {
+                              line: 22
+                              col: 17
+                            }
+                          }
                         }
-                        rhs {
+                        rhs: {
                           name: "b"
+                          source_context: {
+                            file: "tests/math.sysl"
+                            start: {
+                              line: 22
+                              col: 21
+                            }
+                            end: {
+                              line: 22
+                              col: 21
+                            }
+                          }
+                        }
+                      }
+                      source_context: {
+                        file: "tests/math.sysl"
+                        start: {
+                          line: 22
+                          col: 19
+                        }
+                        end: {
+                          line: 22
+                          col: 21
                         }
                       }
                     }
-                    rhs {
-                      binexpr {
+                    rhs: {
+                      binexpr: {
                         op: ADD
-                        lhs {
+                        lhs: {
                           name: "c"
+                          source_context: {
+                            file: "tests/math.sysl"
+                            start: {
+                              line: 22
+                              col: 26
+                            }
+                            end: {
+                              line: 22
+                              col: 26
+                            }
+                          }
                         }
-                        rhs {
+                        rhs: {
                           name: "d"
+                          source_context: {
+                            file: "tests/math.sysl"
+                            start: {
+                              line: 22
+                              col: 30
+                            }
+                            end: {
+                              line: 22
+                              col: 30
+                            }
+                          }
+                        }
+                      }
+                      source_context: {
+                        file: "tests/math.sysl"
+                        start: {
+                          line: 22
+                          col: 28
+                        }
+                        end: {
+                          line: 22
+                          col: 30
                         }
                       }
                     }
                   }
-                }
-              }
-            }
-            stmt {
-              assign {
-                name: "expr_rel"
-                expr {
-                  binexpr {
-                    op: IN
-                    lhs {
-                      name: "a"
+                  source_context: {
+                    file: "tests/math.sysl"
+                    start: {
+                      line: 22
+                      col: 6
                     }
-                    rhs {
-                      name: "d"
+                    end: {
+                      line: 22
+                      col: 30
                     }
+                    text: "expr_rel = a + b == c + d"
                   }
                 }
               }
             }
-            stmt {
-              assign {
+            stmt: {
+              assign: {
                 name: "expr_rel"
-                expr {
-                  binexpr {
+                expr: {
+                  binexpr: {
+                    op: IN
+                    lhs: {
+                      name: "a"
+                      source_context: {
+                        file: "tests/math.sysl"
+                        start: {
+                          line: 23
+                          col: 17
+                        }
+                        end: {
+                          line: 23
+                          col: 17
+                        }
+                      }
+                    }
+                    rhs: {
+                      name: "d"
+                      source_context: {
+                        file: "tests/math.sysl"
+                        start: {
+                          line: 23
+                          col: 22
+                        }
+                        end: {
+                          line: 23
+                          col: 22
+                        }
+                      }
+                    }
+                  }
+                  source_context: {
+                    file: "tests/math.sysl"
+                    start: {
+                      line: 23
+                      col: 6
+                    }
+                    end: {
+                      line: 23
+                      col: 22
+                    }
+                    text: "expr_rel = a in d"
+                  }
+                }
+              }
+            }
+            stmt: {
+              assign: {
+                name: "expr_rel"
+                expr: {
+                  binexpr: {
                     op: NOT_IN
-                    lhs {
+                    lhs: {
                       name: "a"
+                      source_context: {
+                        file: "tests/math.sysl"
+                        start: {
+                          line: 24
+                          col: 17
+                        }
+                        end: {
+                          line: 24
+                          col: 17
+                        }
+                      }
                     }
-                    rhs {
+                    rhs: {
                       name: "d"
+                      source_context: {
+                        file: "tests/math.sysl"
+                        start: {
+                          line: 24
+                          col: 23
+                        }
+                        end: {
+                          line: 24
+                          col: 23
+                        }
+                      }
                     }
+                  }
+                  source_context: {
+                    file: "tests/math.sysl"
+                    start: {
+                      line: 24
+                      col: 6
+                    }
+                    end: {
+                      line: 24
+                      col: 23
+                    }
+                    text: "expr_rel = a !in d"
                   }
                 }
               }
             }
-            stmt {
-              assign {
+            stmt: {
+              assign: {
                 name: "expr_rel"
-                expr {
-                  binexpr {
+                expr: {
+                  binexpr: {
                     op: NOT_CONTAINS
-                    lhs {
+                    lhs: {
                       name: "a"
+                      source_context: {
+                        file: "tests/math.sysl"
+                        start: {
+                          line: 25
+                          col: 17
+                        }
+                        end: {
+                          line: 25
+                          col: 17
+                        }
+                      }
                     }
-                    rhs {
+                    rhs: {
                       name: "d"
+                      source_context: {
+                        file: "tests/math.sysl"
+                        start: {
+                          line: 25
+                          col: 29
+                        }
+                        end: {
+                          line: 25
+                          col: 29
+                        }
+                      }
                     }
+                  }
+                  source_context: {
+                    file: "tests/math.sysl"
+                    start: {
+                      line: 25
+                      col: 6
+                    }
+                    end: {
+                      line: 25
+                      col: 29
+                    }
+                    text: "expr_rel = a !contains d"
                   }
                 }
               }
             }
-            stmt {
-              assign {
+            stmt: {
+              assign: {
                 name: "expr_rel"
-                expr {
-                  binexpr {
+                expr: {
+                  binexpr: {
                     op: CONTAINS
-                    lhs {
+                    lhs: {
                       name: "a"
+                      source_context: {
+                        file: "tests/math.sysl"
+                        start: {
+                          line: 26
+                          col: 17
+                        }
+                        end: {
+                          line: 26
+                          col: 17
+                        }
+                      }
                     }
-                    rhs {
+                    rhs: {
                       name: "d"
+                      source_context: {
+                        file: "tests/math.sysl"
+                        start: {
+                          line: 26
+                          col: 28
+                        }
+                        end: {
+                          line: 26
+                          col: 28
+                        }
+                      }
                     }
+                  }
+                  source_context: {
+                    file: "tests/math.sysl"
+                    start: {
+                      line: 26
+                      col: 6
+                    }
+                    end: {
+                      line: 26
+                      col: 28
+                    }
+                    text: "expr_rel = a contains d"
                   }
                 }
               }
             }
-            stmt {
-              assign {
+            stmt: {
+              assign: {
                 name: "expr_set1"
-                expr {
-                  binexpr {
+                expr: {
+                  binexpr: {
                     op: IN
-                    lhs {
+                    lhs: {
                       name: "a"
+                      source_context: {
+                        file: "tests/math.sysl"
+                        start: {
+                          line: 27
+                          col: 18
+                        }
+                        end: {
+                          line: 27
+                          col: 18
+                        }
+                      }
                     }
-                    rhs {
-                      set {
-                        expr {
-                          literal {
+                    rhs: {
+                      set: {
+                        expr: {
+                          literal: {
                             s: "abc"
                           }
+                          source_context: {
+                            file: "tests/math.sysl"
+                            start: {
+                              line: 27
+                              col: 24
+                            }
+                            end: {
+                              line: 27
+                              col: 24
+                            }
+                          }
                         }
-                        expr {
-                          literal {
+                        expr: {
+                          literal: {
                             s: "def"
                           }
+                          source_context: {
+                            file: "tests/math.sysl"
+                            start: {
+                              line: 27
+                              col: 31
+                            }
+                            end: {
+                              line: 27
+                              col: 31
+                            }
+                          }
                         }
                       }
-                      type {
-                        set {
+                      type: {
+                        set: {}
+                      }
+                      source_context: {
+                        file: "tests/math.sysl"
+                        start: {
+                          line: 27
+                          col: 23
+                        }
+                        end: {
+                          line: 27
+                          col: 36
                         }
                       }
                     }
                   }
+                  type: {
+                    no_type: {}
+                  }
+                  source_context: {
+                    file: "tests/math.sysl"
+                    start: {
+                      line: 27
+                      col: 6
+                    }
+                    end: {
+                      line: 27
+                      col: 36
+                    }
+                    text: "expr_set1 = a in {\"abc\", \"def\"}"
+                  }
                 }
               }
             }
-            stmt {
-              assign {
+            stmt: {
+              assign: {
                 name: "expr_set2"
-                expr {
-                  set {
-                    expr {
-                      literal {
+                expr: {
+                  set: {
+                    expr: {
+                      literal: {
                         s: "abc"
                       }
+                      source_context: {
+                        file: "tests/math.sysl"
+                        start: {
+                          line: 28
+                          col: 19
+                        }
+                        end: {
+                          line: 28
+                          col: 19
+                        }
+                      }
                     }
-                    expr {
-                      literal {
+                    expr: {
+                      literal: {
                         s: "def"
                       }
-                    }
-                  }
-                  type {
-                    set {
-                    }
-                  }
-                }
-              }
-            }
-            stmt {
-              assign {
-                name: "expr_set3"
-                expr {
-                  set {
-                    expr {
-                      type {
-                        tuple {
+                      source_context: {
+                        file: "tests/math.sysl"
+                        start: {
+                          line: 28
+                          col: 26
+                        }
+                        end: {
+                          line: 28
+                          col: 26
                         }
                       }
-                      tuple {
-                      }
                     }
                   }
-                  type {
-                    set {
-                      tuple {
-                      }
+                  type: {
+                    set: {}
+                  }
+                  source_context: {
+                    file: "tests/math.sysl"
+                    start: {
+                      line: 28
+                      col: 6
                     }
+                    end: {
+                      line: 28
+                      col: 31
+                    }
+                    text: "expr_set2 = {\"abc\", \"def\"}"
                   }
                 }
               }
             }
-            stmt {
-              assign {
+            stmt: {
+              assign: {
+                name: "expr_set3"
+                expr: {
+                  set: {
+                    expr: {
+                      tuple: {}
+                      type: {
+                        tuple: {}
+                      }
+                      source_context: {
+                        file: "tests/math.sysl"
+                        start: {
+                          line: 29
+                          col: 19
+                        }
+                        end: {
+                          line: 29
+                          col: 19
+                        }
+                      }
+                    }
+                  }
+                  type: {
+                    set: {
+                      tuple: {}
+                    }
+                  }
+                  source_context: {
+                    file: "tests/math.sysl"
+                    start: {
+                      line: 29
+                      col: 6
+                    }
+                    end: {
+                      line: 29
+                      col: 22
+                    }
+                    text: "expr_set3 = {{:}}"
+                  }
+                }
+              }
+            }
+            stmt: {
+              assign: {
                 name: "expr_set4"
-                expr {
-                  call {
+                expr: {
+                  call: {
                     func: "someFunc"
-                    arg {
-                      list {
-                        expr {
-                          literal {
+                    arg: {
+                      list: {
+                        expr: {
+                          literal: {
                             s: "1"
                           }
+                          source_context: {
+                            file: "tests/math.sysl"
+                            start: {
+                              line: 30
+                              col: 28
+                            }
+                            end: {
+                              line: 30
+                              col: 28
+                            }
+                          }
                         }
-                        expr {
-                          literal {
+                        expr: {
+                          literal: {
                             s: "2"
                           }
+                          source_context: {
+                            file: "tests/math.sysl"
+                            start: {
+                              line: 30
+                              col: 32
+                            }
+                            end: {
+                              line: 30
+                              col: 32
+                            }
+                          }
                         }
-                        expr {
-                          literal {
+                        expr: {
+                          literal: {
                             s: "abc"
+                          }
+                          source_context: {
+                            file: "tests/math.sysl"
+                            start: {
+                              line: 30
+                              col: 36
+                            }
+                            end: {
+                              line: 30
+                              col: 36
+                            }
                           }
                         }
                       }
+                      source_context: {
+                        file: "tests/math.sysl"
+                        start: {
+                          line: 30
+                          col: 27
+                        }
+                        end: {
+                          line: 30
+                          col: 41
+                        }
+                      }
                     }
+                  }
+                  source_context: {
+                    file: "tests/math.sysl"
+                    start: {
+                      line: 30
+                      col: 6
+                    }
+                    end: {
+                      line: 30
+                      col: 42
+                    }
+                    text: "expr_set4 = someFunc([\"1\",\"2\",\"abc\"])"
                   }
                 }
               }
             }
-            stmt {
-              assign {
+            stmt: {
+              assign: {
                 name: "expr_set4"
-                expr {
-                  set {
-                    expr {
-                      literal {
+                expr: {
+                  set: {
+                    expr: {
+                      literal: {
                         i: 1
                       }
-                    }
-                    expr {
-                      literal {
-                        i: 2
+                      source_context: {
+                        file: "tests/math.sysl"
+                        start: {
+                          line: 31
+                          col: 19
+                        }
+                        end: {
+                          line: 31
+                          col: 19
+                        }
                       }
                     }
-                    expr {
-                      literal {
+                    expr: {
+                      literal: {
+                        i: 2
+                      }
+                      source_context: {
+                        file: "tests/math.sysl"
+                        start: {
+                          line: 31
+                          col: 21
+                        }
+                        end: {
+                          line: 31
+                          col: 21
+                        }
+                      }
+                    }
+                    expr: {
+                      literal: {
                         s: "abc"
+                      }
+                      source_context: {
+                        file: "tests/math.sysl"
+                        start: {
+                          line: 31
+                          col: 23
+                        }
+                        end: {
+                          line: 31
+                          col: 23
+                        }
                       }
                     }
                   }
-                  type {
-                    set {
+                  type: {
+                    set: {}
+                  }
+                  source_context: {
+                    file: "tests/math.sysl"
+                    start: {
+                      line: 31
+                      col: 6
                     }
+                    end: {
+                      line: 31
+                      col: 28
+                    }
+                    text: "expr_set4 = {1,2,\"abc\"}"
                   }
                 }
               }
             }
-            stmt {
-              assign {
+            stmt: {
+              assign: {
                 name: "expr_list1"
-                expr {
-                  list {
-                    expr {
-                      literal {
+                expr: {
+                  list: {
+                    expr: {
+                      literal: {
                         i: 1
                       }
+                      type: {
+                        primitive: INT
+                      }
+                      source_context: {
+                        file: "tests/math.sysl"
+                        start: {
+                          line: 32
+                          col: 20
+                        }
+                        end: {
+                          line: 32
+                          col: 20
+                        }
+                      }
                     }
-                    expr {
-                      literal {
+                    expr: {
+                      literal: {
                         i: 2
                       }
-                    }
-                    expr {
-                      literal {
-                        s: "abc"
+                      source_context: {
+                        file: "tests/math.sysl"
+                        start: {
+                          line: 32
+                          col: 22
+                        }
+                        end: {
+                          line: 32
+                          col: 22
+                        }
                       }
                     }
+                    expr: {
+                      literal: {
+                        s: "abc"
+                      }
+                      source_context: {
+                        file: "tests/math.sysl"
+                        start: {
+                          line: 32
+                          col: 24
+                        }
+                        end: {
+                          line: 32
+                          col: 24
+                        }
+                      }
+                    }
+                  }
+                  type: {
+                    primitive: INT
+                  }
+                  source_context: {
+                    file: "tests/math.sysl"
+                    start: {
+                      line: 32
+                      col: 6
+                    }
+                    end: {
+                      line: 32
+                      col: 29
+                    }
+                    text: "expr_list1 = [1,2,\"abc\"]"
                   }
                 }
               }
             }
-            stmt {
-              assign {
+            stmt: {
+              assign: {
                 name: "expr_list2"
-                expr {
-                  list {
-                    expr {
-                      literal {
+                expr: {
+                  list: {
+                    expr: {
+                      literal: {
                         s: "1"
                       }
+                      type: {
+                        primitive: STRING
+                      }
+                      source_context: {
+                        file: "tests/math.sysl"
+                        start: {
+                          line: 33
+                          col: 20
+                        }
+                        end: {
+                          line: 33
+                          col: 20
+                        }
+                      }
                     }
-                    expr {
-                      literal {
+                    expr: {
+                      literal: {
                         s: "2"
                       }
+                      source_context: {
+                        file: "tests/math.sysl"
+                        start: {
+                          line: 33
+                          col: 24
+                        }
+                        end: {
+                          line: 33
+                          col: 24
+                        }
+                      }
                     }
-                    expr {
-                      literal {
+                    expr: {
+                      literal: {
                         s: "abc"
                       }
-                    }
-                  }
-                }
-              }
-            }
-            stmt {
-              assign {
-                name: "expr_list3"
-                expr {
-                  call {
-                    func: "someFunc"
-                    arg {
-                      list {
-                        expr {
-                          literal {
-                            s: "1"
-                          }
+                      source_context: {
+                        file: "tests/math.sysl"
+                        start: {
+                          line: 33
+                          col: 28
                         }
-                        expr {
-                          literal {
-                            s: "2"
-                          }
-                        }
-                        expr {
-                          literal {
-                            s: "abc"
-                          }
+                        end: {
+                          line: 33
+                          col: 28
                         }
                       }
                     }
                   }
-                }
-              }
-            }
-            stmt {
-              assign {
-                name: "literal1"
-                expr {
-                  literal {
-                    b: false
+                  type: {
+                    primitive: STRING
                   }
-                  type {
-                    primitive: BOOL
-                  }
-                }
-              }
-            }
-            stmt {
-              assign {
-                name: "literal2"
-                expr {
-                  literal {
-                    b: true
-                  }
-                  type {
-                    primitive: BOOL
+                  source_context: {
+                    file: "tests/math.sysl"
+                    start: {
+                      line: 33
+                      col: 6
+                    }
+                    end: {
+                      line: 33
+                      col: 33
+                    }
+                    text: "expr_list2 = [\"1\",\"2\",\"abc\"]"
                   }
                 }
               }
             }
-            stmt {
-              assign {
-                name: "literal3"
-                expr {
-                  literal {
-                    null {
+            stmt: {
+              assign: {
+                name: "expr_list3"
+                expr: {
+                  call: {
+                    func: "someFunc"
+                    arg: {
+                      list: {
+                        expr: {
+                          literal: {
+                            s: "1"
+                          }
+                          source_context: {
+                            file: "tests/math.sysl"
+                            start: {
+                              line: 34
+                              col: 29
+                            }
+                            end: {
+                              line: 34
+                              col: 29
+                            }
+                          }
+                        }
+                        expr: {
+                          literal: {
+                            s: "2"
+                          }
+                          source_context: {
+                            file: "tests/math.sysl"
+                            start: {
+                              line: 34
+                              col: 33
+                            }
+                            end: {
+                              line: 34
+                              col: 33
+                            }
+                          }
+                        }
+                        expr: {
+                          literal: {
+                            s: "abc"
+                          }
+                          source_context: {
+                            file: "tests/math.sysl"
+                            start: {
+                              line: 34
+                              col: 37
+                            }
+                            end: {
+                              line: 34
+                              col: 37
+                            }
+                          }
+                        }
+                      }
+                      source_context: {
+                        file: "tests/math.sysl"
+                        start: {
+                          line: 34
+                          col: 28
+                        }
+                        end: {
+                          line: 34
+                          col: 42
+                        }
+                      }
                     }
                   }
-                  type {
+                  source_context: {
+                    file: "tests/math.sysl"
+                    start: {
+                      line: 34
+                      col: 6
+                    }
+                    end: {
+                      line: 34
+                      col: 43
+                    }
+                    text: "expr_list3 = someFunc([\"1\",\"2\",\"abc\"])"
+                  }
+                }
+              }
+            }
+            stmt: {
+              assign: {
+                name: "literal1"
+                expr: {
+                  literal: {
+                    b: false
+                  }
+                  type: {
+                    primitive: BOOL
+                  }
+                  source_context: {
+                    file: "tests/math.sysl"
+                    start: {
+                      line: 35
+                      col: 6
+                    }
+                    end: {
+                      line: 35
+                      col: 17
+                    }
+                    text: "literal1 = false"
+                  }
+                }
+              }
+            }
+            stmt: {
+              assign: {
+                name: "literal2"
+                expr: {
+                  literal: {
+                    b: true
+                  }
+                  type: {
+                    primitive: BOOL
+                  }
+                  source_context: {
+                    file: "tests/math.sysl"
+                    start: {
+                      line: 36
+                      col: 6
+                    }
+                    end: {
+                      line: 36
+                      col: 17
+                    }
+                    text: "literal2 = true"
+                  }
+                }
+              }
+            }
+            stmt: {
+              assign: {
+                name: "literal3"
+                expr: {
+                  literal: {
+                    null: {}
+                  }
+                  type: {
                     primitive: EMPTY
                   }
+                  source_context: {
+                    file: "tests/math.sysl"
+                    start: {
+                      line: 37
+                      col: 6
+                    }
+                    end: {
+                      line: 37
+                      col: 17
+                    }
+                    text: "literal3 = null"
+                  }
                 }
               }
             }
-            stmt {
-              assign {
+            stmt: {
+              assign: {
                 name: "literal4"
-                expr {
-                  literal {
+                expr: {
+                  literal: {
                     s: "abc"
                   }
-                }
-              }
-            }
-            stmt {
-              assign {
-                name: "literal5"
-                expr {
-                  literal {
-                    i: 123
+                  type: {
+                    primitive: STRING
+                  }
+                  source_context: {
+                    file: "tests/math.sysl"
+                    start: {
+                      line: 38
+                      col: 6
+                    }
+                    end: {
+                      line: 38
+                      col: 17
+                    }
+                    text: "literal4 = \"abc\""
                   }
                 }
               }
             }
-            stmt {
-              assign {
+            stmt: {
+              assign: {
+                name: "literal5"
+                expr: {
+                  literal: {
+                    i: 123
+                  }
+                  type: {
+                    primitive: INT
+                  }
+                  source_context: {
+                    file: "tests/math.sysl"
+                    start: {
+                      line: 39
+                      col: 6
+                    }
+                    end: {
+                      line: 39
+                      col: 17
+                    }
+                    text: "literal5 = 123"
+                  }
+                }
+              }
+            }
+            stmt: {
+              assign: {
                 name: "literal6"
-                expr {
-                  literal {
+                expr: {
+                  literal: {
                     decimal: "123.45"
+                  }
+                  type: {
+                    primitive: DECIMAL
+                  }
+                  source_context: {
+                    file: "tests/math.sysl"
+                    start: {
+                      line: 40
+                      col: 6
+                    }
+                    end: {
+                      line: 40
+                      col: 17
+                    }
+                    text: "literal6 = 123.45"
                   }
                 }
               }
             }
           }
+          source_context: {
+            file: "tests/math.sysl"
+            start: {
+              line: 3
+              col: 4
+            }
+            end: {
+              line: 41
+              col: 5
+            }
+          }
         }
+        source_context: {
+          file: "tests/math.sysl"
+          start: {
+            line: 2
+            col: 2
+          }
+          end: {
+            line: 43
+          }
+          text: "!view NoArgTransform(number1 <: int, foo <: Some.Type ) -> Model.Type:"
+        }
+      }
+    }
+    source_context: {
+      file: "tests/math.sysl"
+      start: {
+        line: 1
+        col: 1
+      }
+      end: {
+        line: 1
+        col: 47
       }
     }
   }

--- a/pkg/parse/tests/merge_attrs.sysl.golden.textpb
+++ b/pkg/parse/tests/merge_attrs.sysl.golden.textpb
@@ -1,79 +1,79 @@
-apps:  {
-  key:  "Test"
-  value:  {
-    name:  {
-      part:  "Test"
+apps: {
+  key: "Test"
+  value: {
+    name: {
+      part: "Test"
     }
-    types:  {
-      key:  "Foo"
-      value:  {
-        tuple:  {
-          attr_defs:  {
-            key:  "x"
-            value:  {
-              primitive:  STRING
-              attrs:  {
-                key:  "anothertag"
-                value:  {
-                  s:  "bar"
+    types: {
+      key: "Foo"
+      value: {
+        tuple: {
+          attr_defs: {
+            key: "x"
+            value: {
+              primitive: STRING
+              attrs: {
+                key: "anothertag"
+                value: {
+                  s: "bar"
                 }
               }
-              attrs:  {
-                key:  "json_tag"
-                value:  {
-                  s:  "hello"
+              attrs: {
+                key: "json_tag"
+                value: {
+                  s: "hello"
                 }
               }
-              source_context:  {
-                file:  "tests/merge_attrs.sysl"
-                start:  {
-                  line:  11
-                  col:  13
+              source_context: {
+                file: "tests/merge_attrs.sysl"
+                start: {
+                  line: 11
+                  col: 13
                 }
-                end:  {
-                  line:  12
+                end: {
+                  line: 12
                 }
               }
             }
           }
-          attr_defs:  {
-            key:  "y"
-            value:  {
-              primitive:  INT
-              source_context:  {
-                file:  "tests/merge_attrs.sysl"
-                start:  {
-                  line:  6
-                  col:  13
+          attr_defs: {
+            key: "y"
+            value: {
+              primitive: INT
+              source_context: {
+                file: "tests/merge_attrs.sysl"
+                start: {
+                  line: 6
+                  col: 13
                 }
-                end:  {
-                  line:  6
-                  col:  13
+                end: {
+                  line: 6
+                  col: 13
                 }
               }
             }
           }
         }
-        source_context:  {
-          file:  "tests/merge_attrs.sysl"
-          start:  {
-            line:  9
-            col:  4
+        source_context: {
+          file: "tests/merge_attrs.sysl"
+          start: {
+            line: 9
+            col: 4
           }
-          end:  {
-            line:  12
+          end: {
+            line: 12
           }
         }
       }
     }
-    source_context:  {
-      file:  "tests/merge_attrs.sysl"
-      start:  {
-        line:  1
-        col:  1
+    source_context: {
+      file: "tests/merge_attrs.sysl"
+      start: {
+        line: 1
+        col: 1
       }
-      end:  {
-        line:  1
+      end: {
+        line: 1
       }
     }
   }

--- a/pkg/parse/tests/mixin.sysl.golden.textpb
+++ b/pkg/parse/tests/mixin.sysl.golden.textpb
@@ -1,272 +1,495 @@
-apps: <
+apps: {
   key: "API"
-  value: <
-    name: <
+  value: {
+    name: {
       part: "API"
-    >
-    endpoints: <
+    }
+    endpoints: {
       key: "Service Call"
-      value: <
+      value: {
         name: "Service Call"
-      >
-    >
-    types: <
+        source_context: {
+          file: "tests/mixin.sysl"
+          start: {
+            line: 16
+            col: 4
+          }
+          end: {
+            line: 16
+            col: 18
+          }
+        }
+      }
+    }
+    types: {
       key: "UberUser"
-      value: <
-        tuple: <
-          attr_defs: <
+      value: {
+        tuple: {
+          attr_defs: {
             key: "user"
-            value: <
-              type_ref: <
-                context: <
-                  appname: <
+            value: {
+              type_ref: {
+                context: {
+                  appname: {
                     part: "API"
-                  >
+                  }
                   path: "UberUser"
-                >
-                ref: <
+                }
+                ref: {
                   path: "User"
-                >
-              >
-              source_context: <
+                }
+              }
+              source_context: {
                 file: "tests/mixin.sysl"
-                start: <
+                start: {
                   line: 19
                   col: 16
-                >
-                end: <
+                }
+                end: {
                   line: 19
                   col: 16
-                >
-              >
-            >
-          >
-        >
-      >
-    >
-    types: <
+                }
+              }
+            }
+          }
+        }
+        source_context: {
+          file: "tests/mixin.sysl"
+          start: {
+            line: 18
+            col: 4
+          }
+          end: {
+            line: 20
+          }
+        }
+      }
+    }
+    types: {
       key: "User"
-      value: <
-        relation: <
-          attr_defs: <
+      value: {
+        relation: {
+          attr_defs: {
             key: "id"
-            value: <
+            value: {
               primitive: INT
-              attrs: <
+              attrs: {
                 key: "description"
-                value: <
+                value: {
                   s: "some description"
-                >
-              >
-              source_context: <
+                }
+              }
+              source_context: {
                 file: "tests/mixin.sysl"
-                start: <
+                start: {
                   line: 4
                   col: 14
-                >
-                end: <
+                }
+                end: {
                   line: 4
                   col: 14
-                >
-              >
-            >
-          >
-        >
-        attrs: <
+                }
+              }
+            }
+          }
+        }
+        attrs: {
           key: "description"
-          value: <
+          value: {
             s: "some description"
-          >
-        >
-        attrs: <
+          }
+        }
+        attrs: {
           key: "patterns"
-          value: <
-            a: <
-              elt: <
+          value: {
+            a: {
+              elt: {
                 s: "foo"
-              >
-            >
-          >
-        >
-      >
-    >
-    views: <
+              }
+            }
+          }
+        }
+        source_context: {
+          file: "tests/mixin.sysl"
+          start: {
+            line: 3
+            col: 4
+          }
+          end: {
+            line: 6
+            col: 12
+          }
+        }
+      }
+    }
+    views: {
       key: "FooTransform"
-      value: <
-        param: <
+      value: {
+        param: {
           name: "number"
-          type: <
+          type: {
             primitive: INT
-          >
-        >
-        ret_type: <
+          }
+        }
+        ret_type: {
           primitive: INT
-        >
-        expr: <
-          transform: <
-            arg: <
+        }
+        expr: {
+          transform: {
+            arg: {
               name: "number"
-            >
+              source_context: {
+                file: "tests/mixin.sysl"
+                start: {
+                  line: 8
+                  col: 4
+                }
+                end: {
+                  line: 8
+                  col: 4
+                }
+              }
+            }
             scopevar: "."
-            stmt: <
-              assign: <
+            stmt: {
+              assign: {
                 name: "out"
-                expr: <
-                  binexpr: <
+                expr: {
+                  binexpr: {
                     op: ADD
-                    lhs: <
+                    lhs: {
                       name: "number"
-                    >
-                    rhs: <
-                      literal: <
+                      source_context: {
+                        file: "tests/mixin.sysl"
+                        start: {
+                          line: 9
+                          col: 12
+                        }
+                        end: {
+                          line: 9
+                          col: 12
+                        }
+                      }
+                    }
+                    rhs: {
+                      literal: {
                         i: 1
-                      >
-                    >
-                  >
-                >
-              >
-            >
-          >
-        >
-      >
-    >
-    mixin2: <
-      name: <
+                      }
+                      type: {
+                        primitive: INT
+                      }
+                      source_context: {
+                        file: "tests/mixin.sysl"
+                        start: {
+                          line: 9
+                          col: 21
+                        }
+                        end: {
+                          line: 9
+                          col: 21
+                        }
+                      }
+                    }
+                  }
+                  type: {
+                    primitive: INT
+                  }
+                  source_context: {
+                    file: "tests/mixin.sysl"
+                    start: {
+                      line: 9
+                      col: 6
+                    }
+                    end: {
+                      line: 9
+                      col: 21
+                    }
+                    text: "out = number + 1"
+                  }
+                }
+              }
+            }
+          }
+          source_context: {
+            file: "tests/mixin.sysl"
+            start: {
+              line: 8
+              col: 4
+            }
+            end: {
+              line: 10
+              col: 5
+            }
+          }
+        }
+        source_context: {
+          file: "tests/mixin.sysl"
+          start: {
+            line: 7
+            col: 2
+          }
+          end: {
+            line: 12
+            col: 3
+          }
+          text: "!view FooTransform(number <: int) -> int:"
+        }
+      }
+    }
+    mixin2: {
+      name: {
         part: "Relational Model"
-      >
-    >
-    mixin2: <
-      name: <
+      }
+    }
+    mixin2: {
+      name: {
         part: "TransformApp"
-      >
-    >
-  >
->
-apps: <
+      }
+    }
+    source_context: {
+      file: "tests/mixin.sysl"
+      start: {
+        line: 12
+        col: 1
+      }
+      end: {
+        line: 12
+      }
+    }
+  }
+}
+apps: {
   key: "Relational Model"
-  value: <
-    name: <
+  value: {
+    name: {
       part: "Relational Model"
-    >
-    attrs: <
+    }
+    attrs: {
       key: "patterns"
-      value: <
-        a: <
-          elt: <
+      value: {
+        a: {
+          elt: {
             s: "abstract"
-          >
-        >
-      >
-    >
-    types: <
+          }
+        }
+      }
+    }
+    types: {
       key: "User"
-      value: <
-        relation: <
-          attr_defs: <
+      value: {
+        relation: {
+          attr_defs: {
             key: "id"
-            value: <
+            value: {
               primitive: INT
-              attrs: <
+              attrs: {
                 key: "description"
-                value: <
+                value: {
                   s: "some description"
-                >
-              >
-              source_context: <
+                }
+              }
+              source_context: {
                 file: "tests/mixin.sysl"
-                start: <
+                start: {
                   line: 4
                   col: 14
-                >
-                end: <
+                }
+                end: {
                   line: 4
                   col: 14
-                >
-              >
-            >
-          >
-        >
-        attrs: <
+                }
+              }
+            }
+          }
+        }
+        attrs: {
           key: "description"
-          value: <
+          value: {
             s: "some description"
-          >
-        >
-        attrs: <
+          }
+        }
+        attrs: {
           key: "patterns"
-          value: <
-            a: <
-              elt: <
+          value: {
+            a: {
+              elt: {
                 s: "foo"
-              >
-            >
-          >
-        >
-      >
-    >
-  >
->
-apps: <
+              }
+            }
+          }
+        }
+        source_context: {
+          file: "tests/mixin.sysl"
+          start: {
+            line: 3
+            col: 4
+          }
+          end: {
+            line: 6
+            col: 12
+          }
+        }
+      }
+    }
+    source_context: {
+      file: "tests/mixin.sysl"
+      start: {
+        line: 1
+        col: 1
+      }
+      end: {
+        line: 1
+        col: 27
+      }
+    }
+  }
+}
+apps: {
   key: "TransformApp"
-  value: <
-    name: <
+  value: {
+    name: {
       part: "TransformApp"
-    >
-    attrs: <
+    }
+    attrs: {
       key: "package"
-      value: <
+      value: {
         s: "com.foo.example"
-      >
-    >
-    attrs: <
+      }
+    }
+    attrs: {
       key: "patterns"
-      value: <
-        a: <
-          elt: <
+      value: {
+        a: {
+          elt: {
             s: "abstract"
-          >
-        >
-      >
-    >
-    views: <
+          }
+        }
+      }
+    }
+    views: {
       key: "FooTransform"
-      value: <
-        param: <
+      value: {
+        param: {
           name: "number"
-          type: <
+          type: {
             primitive: INT
-          >
-        >
-        ret_type: <
+          }
+        }
+        ret_type: {
           primitive: INT
-        >
-        expr: <
-          transform: <
-            arg: <
+        }
+        expr: {
+          transform: {
+            arg: {
               name: "number"
-            >
+              source_context: {
+                file: "tests/mixin.sysl"
+                start: {
+                  line: 8
+                  col: 4
+                }
+                end: {
+                  line: 8
+                  col: 4
+                }
+              }
+            }
             scopevar: "."
-            stmt: <
-              assign: <
+            stmt: {
+              assign: {
                 name: "out"
-                expr: <
-                  binexpr: <
+                expr: {
+                  binexpr: {
                     op: ADD
-                    lhs: <
+                    lhs: {
                       name: "number"
-                    >
-                    rhs: <
-                      literal: <
+                      source_context: {
+                        file: "tests/mixin.sysl"
+                        start: {
+                          line: 9
+                          col: 12
+                        }
+                        end: {
+                          line: 9
+                          col: 12
+                        }
+                      }
+                    }
+                    rhs: {
+                      literal: {
                         i: 1
-                      >
-                    >
-                  >
-                >
-              >
-            >
-          >
-        >
-      >
-    >
-  >
->
+                      }
+                      type: {
+                        primitive: INT
+                      }
+                      source_context: {
+                        file: "tests/mixin.sysl"
+                        start: {
+                          line: 9
+                          col: 21
+                        }
+                        end: {
+                          line: 9
+                          col: 21
+                        }
+                      }
+                    }
+                  }
+                  type: {
+                    primitive: INT
+                  }
+                  source_context: {
+                    file: "tests/mixin.sysl"
+                    start: {
+                      line: 9
+                      col: 6
+                    }
+                    end: {
+                      line: 9
+                      col: 21
+                    }
+                    text: "out = number + 1"
+                  }
+                }
+              }
+            }
+          }
+          source_context: {
+            file: "tests/mixin.sysl"
+            start: {
+              line: 8
+              col: 4
+            }
+            end: {
+              line: 10
+              col: 5
+            }
+          }
+        }
+        source_context: {
+          file: "tests/mixin.sysl"
+          start: {
+            line: 7
+            col: 2
+          }
+          end: {
+            line: 12
+            col: 3
+          }
+          text: "!view FooTransform(number <: int) -> int:"
+        }
+      }
+    }
+    source_context: {
+      file: "tests/mixin.sysl"
+      start: {
+        line: 6
+        col: 1
+      }
+      end: {
+        line: 6
+        col: 49
+      }
+    }
+  }
+}

--- a/pkg/parse/tests/navigate.sysl.golden.textpb
+++ b/pkg/parse/tests/navigate.sysl.golden.textpb
@@ -1,239 +1,656 @@
-apps {
+apps: {
   key: "TransformationTest"
-  value {
-    name {
+  value: {
+    name: {
       part: "TransformationTest"
     }
-    attrs {
+    attrs: {
       key: "package"
-      value {
+      value: {
         s: "io.sysl.test.views"
       }
     }
-    views {
+    views: {
       key: "TestNavigate"
-      value {
-        param {
+      value: {
+        param: {
           name: "number"
-          type {
+          type: {
             primitive: INT
           }
         }
-        ret_type {
+        ret_type: {
           primitive: INT
         }
-        expr {
-          transform {
-            arg {
+        expr: {
+          transform: {
+            arg: {
               name: "number"
+              source_context: {
+                file: "tests/navigate.sysl"
+                start: {
+                  line: 3
+                  col: 4
+                }
+                end: {
+                  line: 3
+                  col: 4
+                }
+              }
             }
             scopevar: "."
-            stmt {
-              let {
+            stmt: {
+              let: {
                 name: "out1"
-                expr {
-                  navigate {
-                    arg {
+                expr: {
+                  navigate: {
+                    arg: {
                       name: "."
+                      source_context: {
+                        file: "tests/navigate.sysl"
+                        start: {
+                          line: 4
+                          col: 17
+                        }
+                        end: {
+                          line: 4
+                          col: 20
+                        }
+                      }
                     }
                     attr: "foo"
+                  }
+                  source_context: {
+                    file: "tests/navigate.sysl"
+                    start: {
+                      line: 4
+                      col: 6
+                    }
+                    end: {
+                      line: 4
+                      col: 20
+                    }
+                    text: "let out1 = -> foo"
                   }
                 }
               }
             }
-            stmt {
-              let {
+            stmt: {
+              let: {
                 name: "out2"
-                expr {
-                  navigate {
-                    arg {
+                expr: {
+                  navigate: {
+                    arg: {
                       name: "abc"
+                      source_context: {
+                        file: "tests/navigate.sysl"
+                        start: {
+                          line: 5
+                          col: 17
+                        }
+                        end: {
+                          line: 5
+                          col: 17
+                        }
+                      }
                     }
                     attr: "foo"
+                  }
+                  source_context: {
+                    file: "tests/navigate.sysl"
+                    start: {
+                      line: 5
+                      col: 6
+                    }
+                    end: {
+                      line: 5
+                      col: 24
+                    }
+                    text: "let out2 = abc -> foo"
                   }
                 }
               }
             }
-            stmt {
-              let {
+            stmt: {
+              let: {
                 name: "out2a"
-                expr {
-                  navigate {
-                    arg {
+                expr: {
+                  navigate: {
+                    arg: {
                       name: "abc"
+                      source_context: {
+                        file: "tests/navigate.sysl"
+                        start: {
+                          line: 6
+                          col: 18
+                        }
+                        end: {
+                          line: 6
+                          col: 18
+                        }
+                      }
                     }
                     attr: "foo"
                     nullsafe: true
                   }
+                  source_context: {
+                    file: "tests/navigate.sysl"
+                    start: {
+                      line: 6
+                      col: 6
+                    }
+                    end: {
+                      line: 6
+                      col: 26
+                    }
+                    text: "let out2a = abc ?-> foo"
+                  }
                 }
               }
             }
-            stmt {
-              let {
+            stmt: {
+              let: {
                 name: "out2b"
-                expr {
-                  get_attr {
-                    arg {
-                      navigate {
-                        arg {
+                expr: {
+                  get_attr: {
+                    arg: {
+                      navigate: {
+                        arg: {
                           name: "abc"
+                          source_context: {
+                            file: "tests/navigate.sysl"
+                            start: {
+                              line: 7
+                              col: 18
+                            }
+                            end: {
+                              line: 7
+                              col: 18
+                            }
+                          }
                         }
                         attr: "foo"
+                      }
+                      source_context: {
+                        file: "tests/navigate.sysl"
+                        start: {
+                          line: 7
+                          col: 22
+                        }
+                        end: {
+                          line: 7
+                          col: 25
+                        }
                       }
                     }
                     attr: "bar"
                   }
+                  source_context: {
+                    file: "tests/navigate.sysl"
+                    start: {
+                      line: 7
+                      col: 6
+                    }
+                    end: {
+                      line: 7
+                      col: 29
+                    }
+                    text: "let out2b = abc -> foo.bar"
+                  }
                 }
               }
             }
-            stmt {
-              let {
+            stmt: {
+              let: {
                 name: "out3"
-                expr {
-                  navigate {
-                    arg {
-                      get_attr {
-                        arg {
+                expr: {
+                  navigate: {
+                    arg: {
+                      get_attr: {
+                        arg: {
                           name: "."
+                          source_context: {
+                            file: "tests/navigate.sysl"
+                            start: {
+                              line: 8
+                              col: 17
+                            }
+                            end: {
+                              line: 8
+                              col: 18
+                            }
+                          }
                         }
                         attr: "abc"
+                      }
+                      source_context: {
+                        file: "tests/navigate.sysl"
+                        start: {
+                          line: 8
+                          col: 17
+                        }
+                        end: {
+                          line: 8
+                          col: 18
+                        }
                       }
                     }
                     attr: "foo"
                   }
+                  source_context: {
+                    file: "tests/navigate.sysl"
+                    start: {
+                      line: 8
+                      col: 6
+                    }
+                    end: {
+                      line: 8
+                      col: 25
+                    }
+                    text: "let out3 = .abc -> foo"
+                  }
                 }
               }
             }
-            stmt {
-              let {
+            stmt: {
+              let: {
                 name: "out4"
-                expr {
-                  navigate {
-                    arg {
-                      get_attr {
-                        arg {
+                expr: {
+                  navigate: {
+                    arg: {
+                      get_attr: {
+                        arg: {
                           name: "."
+                          source_context: {
+                            file: "tests/navigate.sysl"
+                            start: {
+                              line: 9
+                              col: 17
+                            }
+                            end: {
+                              line: 9
+                              col: 18
+                            }
+                          }
                         }
                         attr: "abc"
+                      }
+                      source_context: {
+                        file: "tests/navigate.sysl"
+                        start: {
+                          line: 9
+                          col: 17
+                        }
+                        end: {
+                          line: 9
+                          col: 18
+                        }
                       }
                     }
                     attr: ".foo"
                   }
+                  source_context: {
+                    file: "tests/navigate.sysl"
+                    start: {
+                      line: 9
+                      col: 6
+                    }
+                    end: {
+                      line: 9
+                      col: 26
+                    }
+                    text: "let out4 = .abc -> .foo"
+                  }
                 }
               }
             }
-            stmt {
-              let {
+            stmt: {
+              let: {
                 name: "out5"
-                expr {
-                  navigate {
-                    arg {
-                      get_attr {
-                        arg {
+                expr: {
+                  navigate: {
+                    arg: {
+                      get_attr: {
+                        arg: {
                           name: "."
+                          source_context: {
+                            file: "tests/navigate.sysl"
+                            start: {
+                              line: 10
+                              col: 17
+                            }
+                            end: {
+                              line: 10
+                              col: 18
+                            }
+                          }
                         }
                         attr: "abc"
+                      }
+                      source_context: {
+                        file: "tests/navigate.sysl"
+                        start: {
+                          line: 10
+                          col: 17
+                        }
+                        end: {
+                          line: 10
+                          col: 18
+                        }
                       }
                     }
                     attr: ".foo"
                     setof: true
                   }
+                  source_context: {
+                    file: "tests/navigate.sysl"
+                    start: {
+                      line: 10
+                      col: 6
+                    }
+                    end: {
+                      line: 10
+                      col: 33
+                    }
+                    text: "let out5 = .abc -> set of .foo"
+                  }
                 }
               }
             }
-            stmt {
-              let {
+            stmt: {
+              let: {
                 name: "out6"
-                expr {
-                  navigate {
-                    arg {
-                      get_attr {
-                        arg {
+                expr: {
+                  navigate: {
+                    arg: {
+                      get_attr: {
+                        arg: {
                           name: "."
+                          source_context: {
+                            file: "tests/navigate.sysl"
+                            start: {
+                              line: 11
+                              col: 17
+                            }
+                            end: {
+                              line: 11
+                              col: 18
+                            }
+                          }
                         }
                         attr: "abc"
+                      }
+                      source_context: {
+                        file: "tests/navigate.sysl"
+                        start: {
+                          line: 11
+                          col: 17
+                        }
+                        end: {
+                          line: 11
+                          col: 18
+                        }
                       }
                     }
                     attr: "foo"
                     setof: true
                   }
+                  source_context: {
+                    file: "tests/navigate.sysl"
+                    start: {
+                      line: 11
+                      col: 6
+                    }
+                    end: {
+                      line: 11
+                      col: 32
+                    }
+                    text: "let out6 = .abc -> set of foo"
+                  }
                 }
               }
             }
-            stmt {
-              let {
+            stmt: {
+              let: {
                 name: "out7"
-                expr {
-                  navigate {
-                    arg {
-                      get_attr {
-                        arg {
+                expr: {
+                  navigate: {
+                    arg: {
+                      get_attr: {
+                        arg: {
                           name: "."
+                          source_context: {
+                            file: "tests/navigate.sysl"
+                            start: {
+                              line: 12
+                              col: 17
+                            }
+                            end: {
+                              line: 12
+                              col: 18
+                            }
+                          }
                         }
                         attr: "abc"
+                      }
+                      source_context: {
+                        file: "tests/navigate.sysl"
+                        start: {
+                          line: 12
+                          col: 17
+                        }
+                        end: {
+                          line: 12
+                          col: 18
+                        }
                       }
                     }
                     attr: "foo"
                     setof: true
                     via: "bar"
                   }
+                  source_context: {
+                    file: "tests/navigate.sysl"
+                    start: {
+                      line: 12
+                      col: 6
+                    }
+                    end: {
+                      line: 12
+                      col: 40
+                    }
+                    text: "let out7 = .abc -> set of foo via bar"
+                  }
                 }
               }
             }
-            stmt {
-              let {
+            stmt: {
+              let: {
                 name: "out8"
-                expr {
-                  relexpr {
+                expr: {
+                  relexpr: {
                     op: SNAPSHOT
-                    target {
-                      binexpr {
+                    target: {
+                      binexpr: {
                         op: WHERE
-                        lhs {
-                          navigate {
-                            arg {
-                              get_attr {
-                                arg {
+                        lhs: {
+                          navigate: {
+                            arg: {
+                              get_attr: {
+                                arg: {
                                   name: "."
+                                  source_context: {
+                                    file: "tests/navigate.sysl"
+                                    start: {
+                                      line: 13
+                                      col: 17
+                                    }
+                                    end: {
+                                      line: 13
+                                      col: 18
+                                    }
+                                  }
                                 }
                                 attr: "abc"
+                              }
+                              source_context: {
+                                file: "tests/navigate.sysl"
+                                start: {
+                                  line: 13
+                                  col: 17
+                                }
+                                end: {
+                                  line: 13
+                                  col: 18
+                                }
                               }
                             }
                             attr: "foo"
                             setof: true
                             via: "bar"
                           }
+                          source_context: {
+                            file: "tests/navigate.sysl"
+                            start: {
+                              line: 13
+                              col: 22
+                            }
+                            end: {
+                              line: 13
+                              col: 40
+                            }
+                          }
                         }
-                        rhs {
-                          binexpr {
+                        rhs: {
+                          binexpr: {
                             op: EQ
-                            lhs {
-                              get_attr {
-                                arg {
+                            lhs: {
+                              get_attr: {
+                                arg: {
                                   name: "."
+                                  source_context: {
+                                    file: "tests/navigate.sysl"
+                                    start: {
+                                      line: 13
+                                      col: 50
+                                    }
+                                    end: {
+                                      line: 13
+                                      col: 51
+                                    }
+                                  }
                                 }
                                 attr: "a"
                               }
+                              source_context: {
+                                file: "tests/navigate.sysl"
+                                start: {
+                                  line: 13
+                                  col: 50
+                                }
+                                end: {
+                                  line: 13
+                                  col: 51
+                                }
+                              }
                             }
-                            rhs {
-                              literal {
+                            rhs: {
+                              literal: {
                                 b: true
                               }
-                              type {
+                              type: {
                                 primitive: BOOL
                               }
+                              source_context: {
+                                file: "tests/navigate.sysl"
+                                start: {
+                                  line: 13
+                                  col: 56
+                                }
+                                end: {
+                                  line: 13
+                                  col: 56
+                                }
+                              }
+                            }
+                          }
+                          source_context: {
+                            file: "tests/navigate.sysl"
+                            start: {
+                              line: 13
+                              col: 50
+                            }
+                            end: {
+                              line: 13
+                              col: 56
                             }
                           }
                         }
                         scopevar: "."
                       }
+                      source_context: {
+                        file: "tests/navigate.sysl"
+                        start: {
+                          line: 13
+                          col: 44
+                        }
+                        end: {
+                          line: 13
+                          col: 44
+                        }
+                      }
                     }
+                  }
+                  source_context: {
+                    file: "tests/navigate.sysl"
+                    start: {
+                      line: 13
+                      col: 6
+                    }
+                    end: {
+                      line: 13
+                      col: 62
+                    }
+                    text: "let out8 = .abc -> set of foo via bar where(.a == true) snapshot"
                   }
                 }
               }
             }
           }
+          source_context: {
+            file: "tests/navigate.sysl"
+            start: {
+              line: 3
+              col: 4
+            }
+            end: {
+              line: 14
+              col: 5
+            }
+          }
         }
+        source_context: {
+          file: "tests/navigate.sysl"
+          start: {
+            line: 2
+            col: 2
+          }
+          end: {
+            line: 15
+          }
+          text: "!view TestNavigate(number <: int) -> int:"
+        }
+      }
+    }
+    source_context: {
+      file: "tests/navigate.sysl"
+      start: {
+        line: 1
+        col: 1
+      }
+      end: {
+        line: 1
+        col: 47
       }
     }
   }

--- a/pkg/parse/tests/oneof.sysl.golden.textpb
+++ b/pkg/parse/tests/oneof.sysl.golden.textpb
@@ -1,46 +1,46 @@
-apps {
+apps: {
   key: "OtherApp"
-  value {
-    name {
+  value: {
+    name: {
       part: "OtherApp"
     }
-    endpoints {
+    endpoints: {
       key: "Endpoint"
-      value {
+      value: {
         name: "Endpoint"
-        stmt {
-          alt {
-            choice {
+        stmt: {
+          alt: {
+            choice: {
               cond: "requested_state = submitted"
-              stmt {
-                call {
-                  target {
+              stmt: {
+                call: {
+                  target: {
                     part: "SomeApp"
                   }
                   endpoint: "EP1"
                 }
               }
             }
-            choice {
+            choice: {
               cond: "requested_state = unsubmitted"
-              stmt {
-                call {
-                  target {
+              stmt: {
+                call: {
+                  target: {
                     part: "SomeApp"
                   }
                   endpoint: "EP2"
                 }
               }
             }
-            choice {
+            choice: {
               cond: "requested_state = referred"
-              stmt {
-                call {
-                  target {
+              stmt: {
+                call: {
+                  target: {
                     part: "SomeApp"
                   }
                   endpoint: "EP3"
-                  arg {
+                  arg: {
                     name: "\"referred\""
                   }
                 }
@@ -48,62 +48,136 @@ apps {
             }
           }
         }
+        source_context: {
+          file: "tests/oneof.sysl"
+          start: {
+            line: 7
+            col: 4
+          }
+          end: {
+            line: 16
+            col: 4
+          }
+        }
       }
     }
-    endpoints {
+    endpoints: {
       key: "Endpoint with no label"
-      value {
+      value: {
         name: "Endpoint with no label"
-        stmt {
-          alt {
-            choice {
-              stmt {
-                action {
+        stmt: {
+          alt: {
+            choice: {
+              stmt: {
+                action: {
                   action: "statement 1"
                 }
               }
             }
-            choice {
-              stmt {
-                action {
+            choice: {
+              stmt: {
+                action: {
                   action: "statement 2"
                 }
               }
             }
           }
         }
+        source_context: {
+          file: "tests/oneof.sysl"
+          start: {
+            line: 16
+            col: 4
+          }
+          end: {
+            line: 22
+          }
+        }
+      }
+    }
+    source_context: {
+      file: "tests/oneof.sysl"
+      start: {
+        line: 6
+        col: 1
+      }
+      end: {
+        line: 6
       }
     }
   }
 }
-apps {
+apps: {
   key: "SomeApp"
-  value {
-    name {
+  value: {
+    name: {
       part: "SomeApp"
     }
-    endpoints {
+    endpoints: {
       key: "EP1"
-      value {
+      value: {
         name: "EP1"
+        source_context: {
+          file: "tests/oneof.sysl"
+          start: {
+            line: 2
+            col: 4
+          }
+          end: {
+            line: 2
+            col: 9
+          }
+        }
       }
     }
-    endpoints {
+    endpoints: {
       key: "EP2"
-      value {
+      value: {
         name: "EP2"
+        source_context: {
+          file: "tests/oneof.sysl"
+          start: {
+            line: 3
+            col: 4
+          }
+          end: {
+            line: 3
+            col: 9
+          }
+        }
       }
     }
-    endpoints {
+    endpoints: {
       key: "EP3"
-      value {
+      value: {
         name: "EP3"
-        param {
+        param: {
           name: "status"
-          type {
+          type: {
             primitive: STRING
           }
         }
+        source_context: {
+          file: "tests/oneof.sysl"
+          start: {
+            line: 4
+            col: 4
+          }
+          end: {
+            line: 4
+            col: 28
+          }
+        }
+      }
+    }
+    source_context: {
+      file: "tests/oneof.sysl"
+      start: {
+        line: 1
+        col: 1
+      }
+      end: {
+        line: 1
       }
     }
   }

--- a/pkg/parse/tests/openapi3.sysl.golden.textpb
+++ b/pkg/parse/tests/openapi3.sysl.golden.textpb
@@ -1,352 +1,352 @@
-apps: <
+apps: {
   key: "Simple"
-  value: <
-    name: <
+  value: {
+    name: {
       part: "Simple"
-    >
+    }
     long_name: "Simple Server"
-    attrs: <
+    attrs: {
       key: "basePath"
-      value: <
+      value: {
         s: "simple"
-      >
-    >
-    attrs: <
+      }
+    }
+    attrs: {
       key: "package"
-      value: <
+      value: {
         s: "simple"
-      >
-    >
-    endpoints: <
+      }
+    }
+    endpoints: {
       key: "GET /stuff"
-      value: <
+      value: {
         name: "GET /stuff"
-        attrs: <
+        attrs: {
           key: "patterns"
-          value: <
-            a: <
-              elt: <
+          value: {
+            a: {
+              elt: {
                 s: "rest"
-              >
-            >
-          >
-        >
-        stmt: <
-          ret: <
+              }
+            }
+          }
+        }
+        stmt: {
+          ret: {
             payload: "ok <: Stuff"
-          >
-        >
-        rest_params: <
+          }
+        }
+        rest_params: {
           method: GET
           path: "/stuff"
-        >
-        source_context: <
+        }
+        source_context: {
           file: "tests/openapi3.sysl"
-          start: <
+          start: {
             line: 7
             col: 8
-          >
-          end: <
+          }
+          end: {
             line: 10
             col: 4
-          >
-        >
-      >
-    >
-    types: <
+          }
+        }
+      }
+    }
+    types: {
       key: "Stuff"
-      value: <
-        tuple: <
-          attr_defs: <
+      value: {
+        tuple: {
+          attr_defs: {
             key: "innerStuff"
-            value: <
+            value: {
               primitive: STRING
-              attrs: <
+              attrs: {
                 key: "json_tag"
-                value: <
+                value: {
                   s: "innerStuff"
-                >
-              >
-              source_context: <
+                }
+              }
+              source_context: {
                 file: "tests/openapi3.sysl"
-                start: <
+                start: {
                   line: 12
                   col: 22
-                >
-                end: <
+                }
+                end: {
                   line: 13
-                >
-              >
-            >
-          >
-        >
-        source_context: <
+                }
+              }
+            }
+          }
+        }
+        source_context: {
           file: "tests/openapi3.sysl"
-          start: <
+          start: {
             line: 10
             col: 4
-          >
-          end: <
+          }
+          end: {
             line: 13
-          >
-        >
-      >
-    >
-    source_context: <
+          }
+        }
+      }
+    }
+    source_context: {
       file: "tests/openapi3.sysl"
-      start: <
+      start: {
         line: 3
         col: 1
-      >
-      end: <
+      }
+      end: {
         line: 3
         col: 40
-      >
-    >
-  >
->
-apps: <
+      }
+    }
+  }
+}
+apps: {
   key: "preference"
-  value: <
-    name: <
+  value: {
+    name: {
       part: "preference"
-    >
+    }
     long_name: "User Preference"
-    attrs: <
+    attrs: {
       key: "description"
-      value: <
-        s: "No description."
-      >
-    >
-    attrs: <
+      value: {
+        s: "No description.\n"
+      }
+    }
+    attrs: {
       key: "version"
-      value: <
+      value: {
         s: "1.0.0"
-      >
-    >
-    endpoints: <
+      }
+    }
+    endpoints: {
       key: "GET /preference"
-      value: <
+      value: {
         name: "GET /preference"
         docstring: "No description."
-        attrs: <
+        attrs: {
           key: "patterns"
-          value: <
-            a: <
-              elt: <
+          value: {
+            a: {
+              elt: {
                 s: "rest"
-              >
-            >
-          >
-        >
-        stmt: <
-          ret: <
+              }
+            }
+          }
+        }
+        stmt: {
+          ret: {
             payload: "ok <: sequence of Preferences_obj"
-          >
-        >
-        rest_params: <
+          }
+        }
+        rest_params: {
           method: GET
           path: "/preference"
-        >
-        source_context: <
+        }
+        source_context: {
           file: "tests/preference.yaml"
-          start: <
+          start: {
             line: 13
             col: 8
-          >
-          end: <
+          }
+          end: {
             line: 20
             col: 4
-          >
-        >
-      >
-    >
-    types: <
+          }
+        }
+      }
+    }
+    types: {
       key: "Preferences"
-      value: <
-        sequence: <
-          type_ref: <
-            context: <
-              appname: <
+      value: {
+        sequence: {
+          type_ref: {
+            context: {
+              appname: {
                 part: "preference"
-              >
+              }
               path: "Preferences"
-            >
-            ref: <
+            }
+            ref: {
               path: "Preferences_obj"
-            >
-          >
-          source_context: <
+            }
+          }
+          source_context: {
             file: "tests/preference.yaml"
-            start: <
+            start: {
               line: 33
               col: 4
-            >
-            end: <
+            }
+            end: {
               line: 35
-            >
-          >
-        >
-        source_context: <
+            }
+          }
+        }
+        source_context: {
           file: "tests/preference.yaml"
-          start: <
+          start: {
             line: 33
             col: 4
-          >
-          end: <
+          }
+          end: {
             line: 35
-          >
-        >
-      >
-    >
-    types: <
+          }
+        }
+      }
+    }
+    types: {
       key: "Preferences_obj"
-      value: <
-        tuple: <
-          attr_defs: <
+      value: {
+        tuple: {
+          attr_defs: {
             key: "preferenceName"
-            value: <
+            value: {
               primitive: STRING
-              attrs: <
+              attrs: {
                 key: "json_tag"
-                value: <
+                value: {
                   s: "preferenceName"
-                >
-              >
-              source_context: <
+                }
+              }
+              source_context: {
                 file: "tests/preference.yaml"
-                start: <
+                start: {
                   line: 22
                   col: 26
-                >
-                end: <
+                }
+                end: {
                   line: 23
                   col: 8
-                >
-              >
-            >
-          >
-          attr_defs: <
+                }
+              }
+            }
+          }
+          attr_defs: {
             key: "preferenceValue"
-            value: <
+            value: {
               primitive: STRING
-              attrs: <
+              attrs: {
                 key: "json_tag"
-                value: <
+                value: {
                   s: "preferenceValue"
-                >
-              >
+                }
+              }
               opt: true
-              source_context: <
+              source_context: {
                 file: "tests/preference.yaml"
-                start: <
+                start: {
                   line: 24
                   col: 27
-                >
-                end: <
+                }
+                end: {
                   line: 25
                   col: 8
-                >
-              >
-            >
-          >
-          attr_defs: <
+                }
+              }
+            }
+          }
+          attr_defs: {
             key: "status"
-            value: <
-              type_ref: <
-                context: <
-                  appname: <
+            value: {
+              type_ref: {
+                context: {
+                  appname: {
                     part: "preference"
-                  >
+                  }
                   path: "Preferences_obj"
-                >
-                ref: <
+                }
+                ref: {
                   path: "Preferences_obj_status"
-                >
-              >
-              attrs: <
+                }
+              }
+              attrs: {
                 key: "json_tag"
-                value: <
+                value: {
                   s: "status"
-                >
-              >
-              source_context: <
+                }
+              }
+              source_context: {
                 file: "tests/preference.yaml"
-                start: <
+                start: {
                   line: 26
                   col: 18
-                >
-                end: <
+                }
+                end: {
                   line: 27
                   col: 8
-                >
-              >
-            >
-          >
-          attr_defs: <
+                }
+              }
+            }
+          }
+          attr_defs: {
             key: "userId"
-            value: <
+            value: {
               primitive: STRING
-              attrs: <
+              attrs: {
                 key: "json_tag"
-                value: <
+                value: {
                   s: "userId"
-                >
-              >
-              source_context: <
+                }
+              }
+              source_context: {
                 file: "tests/preference.yaml"
-                start: <
+                start: {
                   line: 28
                   col: 18
-                >
-                end: <
+                }
+                end: {
                   line: 30
                   col: 4
-                >
-              >
-            >
-          >
-        >
-        source_context: <
+                }
+              }
+            }
+          }
+        }
+        source_context: {
           file: "tests/preference.yaml"
-          start: <
+          start: {
             line: 20
             col: 4
-          >
-          end: <
+          }
+          end: {
             line: 30
             col: 4
-          >
-        >
-      >
-    >
-    types: <
+          }
+        }
+      }
+    }
+    types: {
       key: "Preferences_obj_status"
-      value: <
+      value: {
         primitive: STRING
-        source_context: <
+        source_context: {
           file: "tests/preference.yaml"
-          start: <
+          start: {
             line: 30
             col: 4
-          >
-          end: <
+          }
+          end: {
             line: 33
             col: 4
-          >
-        >
-      >
-    >
-    source_context: <
+          }
+        }
+      }
+    }
+    source_context: {
       file: "tests/preference.yaml"
-      start: <
+      start: {
         line: 7
         col: 1
-      >
-      end: <
+      }
+      end: {
         line: 7
         col: 11
-      >
-    >
-  >
->
+      }
+    }
+  }
+}

--- a/pkg/parse/tests/petshop.sysl.golden.textpb
+++ b/pkg/parse/tests/petshop.sysl.golden.textpb
@@ -1,2525 +1,4679 @@
-apps: <
+apps: {
   key: "PetShopApi"
-  value: <
-    name: <
+  value: {
+    name: {
       part: "PetShopApi"
-    >
-    attrs: <
+    }
+    attrs: {
       key: "package"
-      value: <
+      value: {
         s: "io.sysl.demo.petshop.api"
-      >
-    >
-    endpoints: <
+      }
+    }
+    endpoints: {
       key: "GET /petshop"
-      value: <
+      value: {
         name: "GET /petshop"
-        attrs: <
+        attrs: {
           key: "patterns"
-          value: <
-            a: <
-              elt: <
+          value: {
+            a: {
+              elt: {
                 s: "rest"
-              >
-            >
-          >
-        >
-        stmt: <
-          ret: <
+              }
+            }
+          }
+        }
+        stmt: {
+          ret: {
             payload: "PetShop"
-          >
-        >
-        rest_params: <
+          }
+        }
+        rest_params: {
           method: GET
           path: "/petshop"
-        >
-      >
-    >
-    types: <
+        }
+        source_context: {
+          file: "tests/petshop.sysl"
+          start: {
+            line: 39
+            col: 8
+          }
+          end: {
+            line: 42
+            col: 4
+          }
+        }
+      }
+    }
+    types: {
       key: "Breed"
-      value: <
-        tuple: <
-          attr_defs: <
+      value: {
+        tuple: {
+          attr_defs: {
             key: "avgLifespan"
-            value: <
+            value: {
               primitive: DECIMAL
               opt: true
-              source_context: <
+              source_context: {
                 file: "tests/petshop.sysl"
-                start: <
+                start: {
                   line: 56
                   col: 23
-                >
-                end: <
+                }
+                end: {
                   line: 56
                   col: 30
-                >
-              >
-            >
-          >
-          attr_defs: <
+                }
+              }
+            }
+          }
+          attr_defs: {
             key: "index"
-            value: <
+            value: {
               primitive: INT
-              attrs: <
+              attrs: {
                 key: "patterns"
-                value: <
-                  a: <
-                    elt: <
+                value: {
+                  a: {
+                    elt: {
                       s: "xml_attribute"
-                    >
-                  >
-                >
-              >
-              source_context: <
+                    }
+                  }
+                }
+              }
+              source_context: {
                 file: "tests/petshop.sysl"
-                start: <
+                start: {
                   line: 57
                   col: 17
-                >
-                end: <
+                }
+                end: {
                   line: 57
                   col: 36
-                >
-              >
-            >
-          >
-          attr_defs: <
+                }
+              }
+            }
+          }
+          attr_defs: {
             key: "name"
-            value: <
+            value: {
               primitive: STRING
               opt: true
-              source_context: <
+              source_context: {
                 file: "tests/petshop.sysl"
-                start: <
+                start: {
                   line: 53
                   col: 16
-                >
-                end: <
+                }
+                end: {
                   line: 53
                   col: 22
-                >
-              >
-            >
-          >
-          attr_defs: <
+                }
+              }
+            }
+          }
+          attr_defs: {
             key: "pets"
-            value: <
-              set: <
-                type_ref: <
-                  context: <
-                    appname: <
+            value: {
+              set: {
+                type_ref: {
+                  context: {
+                    appname: {
                       part: "PetShopApi"
-                    >
+                    }
                     path: "Breed"
-                  >
-                  ref: <
+                  }
+                  ref: {
                     path: "Pet"
-                  >
-                >
-                source_context: <
+                  }
+                }
+                source_context: {
                   file: "tests/petshop.sysl"
-                  start: <
+                  start: {
                     line: 55
                     col: 16
-                  >
-                  end: <
+                  }
+                  end: {
                     line: 55
                     col: 23
-                  >
-                >
-              >
-              source_context: <
+                  }
+                }
+              }
+              source_context: {
                 file: "tests/petshop.sysl"
-                start: <
+                start: {
                   line: 55
                   col: 16
-                >
-                end: <
+                }
+                end: {
                   line: 55
                   col: 23
-                >
-              >
-            >
-          >
-          attr_defs: <
+                }
+              }
+            }
+          }
+          attr_defs: {
             key: "species"
-            value: <
+            value: {
               primitive: STRING
               opt: true
-              source_context: <
+              source_context: {
                 file: "tests/petshop.sysl"
-                start: <
+                start: {
                   line: 54
                   col: 19
-                >
-                end: <
+                }
+                end: {
                   line: 54
                   col: 25
-                >
-              >
-            >
-          >
-        >
-      >
-    >
-    types: <
+                }
+              }
+            }
+          }
+        }
+        source_context: {
+          file: "tests/petshop.sysl"
+          start: {
+            line: 52
+            col: 4
+          }
+          end: {
+            line: 59
+            col: 4
+          }
+        }
+      }
+    }
+    types: {
       key: "Employee"
-      value: <
-        tuple: <
-          attr_defs: <
+      value: {
+        tuple: {
+          attr_defs: {
             key: "dob"
-            value: <
+            value: {
               primitive: DATE
               opt: true
-              source_context: <
+              source_context: {
                 file: "tests/petshop.sysl"
-                start: <
+                start: {
                   line: 49
                   col: 15
-                >
-                end: <
+                }
+                end: {
                   line: 49
                   col: 19
-                >
-              >
-            >
-          >
-          attr_defs: <
+                }
+              }
+            }
+          }
+          attr_defs: {
             key: "index"
-            value: <
+            value: {
               primitive: INT
-              attrs: <
+              attrs: {
                 key: "patterns"
-                value: <
-                  a: <
-                    elt: <
+                value: {
+                  a: {
+                    elt: {
                       s: "xml_attribute"
-                    >
-                  >
-                >
-              >
-              source_context: <
+                    }
+                  }
+                }
+              }
+              source_context: {
                 file: "tests/petshop.sysl"
-                start: <
+                start: {
                   line: 50
                   col: 17
-                >
-                end: <
+                }
+                end: {
                   line: 50
                   col: 36
-                >
-              >
-            >
-          >
-          attr_defs: <
+                }
+              }
+            }
+          }
+          attr_defs: {
             key: "name"
-            value: <
+            value: {
               primitive: STRING
               opt: true
-              source_context: <
+              source_context: {
                 file: "tests/petshop.sysl"
-                start: <
+                start: {
                   line: 48
                   col: 16
-                >
-                end: <
+                }
+                end: {
                   line: 48
                   col: 22
-                >
-              >
-            >
-          >
-        >
-      >
-    >
-    types: <
+                }
+              }
+            }
+          }
+        }
+        source_context: {
+          file: "tests/petshop.sysl"
+          start: {
+            line: 47
+            col: 4
+          }
+          end: {
+            line: 52
+            col: 4
+          }
+        }
+      }
+    }
+    types: {
       key: "Pet"
-      value: <
-        tuple: <
-          attr_defs: <
+      value: {
+        tuple: {
+          attr_defs: {
             key: "dob"
-            value: <
+            value: {
               primitive: DATE
               opt: true
-              source_context: <
+              source_context: {
                 file: "tests/petshop.sysl"
-                start: <
+                start: {
                   line: 61
                   col: 15
-                >
-                end: <
+                }
+                end: {
                   line: 61
                   col: 19
-                >
-              >
-            >
-          >
-          attr_defs: <
+                }
+              }
+            }
+          }
+          attr_defs: {
             key: "legRank"
-            value: <
+            value: {
               primitive: INT
-              source_context: <
+              source_context: {
                 file: "tests/petshop.sysl"
-                start: <
+                start: {
                   line: 63
                   col: 19
-                >
-                end: <
+                }
+                end: {
                   line: 63
                   col: 19
-                >
-              >
-            >
-          >
-          attr_defs: <
+                }
+              }
+            }
+          }
+          attr_defs: {
             key: "name"
-            value: <
+            value: {
               primitive: STRING
               opt: true
-              source_context: <
+              source_context: {
                 file: "tests/petshop.sysl"
-                start: <
+                start: {
                   line: 60
                   col: 16
-                >
-                end: <
+                }
+                end: {
                   line: 60
                   col: 22
-                >
-              >
-            >
-          >
-          attr_defs: <
+                }
+              }
+            }
+          }
+          attr_defs: {
             key: "numLegs"
-            value: <
+            value: {
               primitive: INT
               opt: true
-              source_context: <
+              source_context: {
                 file: "tests/petshop.sysl"
-                start: <
+                start: {
                   line: 62
                   col: 19
-                >
-                end: <
+                }
+                end: {
                   line: 62
                   col: 22
-                >
-              >
-            >
-          >
-        >
-      >
-    >
-    types: <
+                }
+              }
+            }
+          }
+        }
+        source_context: {
+          file: "tests/petshop.sysl"
+          start: {
+            line: 59
+            col: 4
+          }
+          end: {
+            line: 66
+            col: 17
+          }
+        }
+      }
+    }
+    types: {
       key: "PetShop"
-      value: <
-        tuple: <
-          attr_defs: <
+      value: {
+        tuple: {
+          attr_defs: {
             key: "breeds"
-            value: <
-              set: <
-                type_ref: <
-                  context: <
-                    appname: <
+            value: {
+              set: {
+                type_ref: {
+                  context: {
+                    appname: {
                       part: "PetShopApi"
-                    >
+                    }
                     path: "PetShop"
-                  >
-                  ref: <
+                  }
+                  ref: {
                     path: "Breed"
-                  >
-                >
-                source_context: <
+                  }
+                }
+                source_context: {
                   file: "tests/petshop.sysl"
-                  start: <
+                  start: {
                     line: 44
                     col: 18
-                  >
-                  end: <
+                  }
+                  end: {
                     line: 44
                     col: 25
-                  >
-                >
-              >
-              source_context: <
+                  }
+                }
+              }
+              source_context: {
                 file: "tests/petshop.sysl"
-                start: <
+                start: {
                   line: 44
                   col: 18
-                >
-                end: <
+                }
+                end: {
                   line: 44
                   col: 25
-                >
-              >
-            >
-          >
-          attr_defs: <
+                }
+              }
+            }
+          }
+          attr_defs: {
             key: "employees"
-            value: <
-              set: <
-                type_ref: <
-                  context: <
-                    appname: <
+            value: {
+              set: {
+                type_ref: {
+                  context: {
+                    appname: {
                       part: "PetShopApi"
-                    >
+                    }
                     path: "PetShop"
-                  >
-                  ref: <
+                  }
+                  ref: {
                     path: "Employee"
-                  >
-                >
-                source_context: <
+                  }
+                }
+                source_context: {
                   file: "tests/petshop.sysl"
-                  start: <
+                  start: {
                     line: 43
                     col: 21
-                  >
-                  end: <
+                  }
+                  end: {
                     line: 43
                     col: 28
-                  >
-                >
-              >
-              source_context: <
+                  }
+                }
+              }
+              source_context: {
                 file: "tests/petshop.sysl"
-                start: <
+                start: {
                   line: 43
                   col: 21
-                >
-                end: <
+                }
+                end: {
                   line: 43
                   col: 28
-                >
-              >
-            >
-          >
-          attr_defs: <
+                }
+              }
+            }
+          }
+          attr_defs: {
             key: "numLegs"
-            value: <
+            value: {
               primitive: INT
               opt: true
-              source_context: <
+              source_context: {
                 file: "tests/petshop.sysl"
-                start: <
+                start: {
                   line: 45
                   col: 19
-                >
-                end: <
+                }
+                end: {
                   line: 45
                   col: 22
-                >
-              >
-            >
-          >
-        >
-      >
-    >
-  >
->
-apps: <
+                }
+              }
+            }
+          }
+        }
+        source_context: {
+          file: "tests/petshop.sysl"
+          start: {
+            line: 42
+            col: 4
+          }
+          end: {
+            line: 47
+            col: 4
+          }
+        }
+      }
+    }
+    source_context: {
+      file: "tests/petshop.sysl"
+      start: {
+        line: 37
+        col: 1
+      }
+      end: {
+        line: 37
+        col: 46
+      }
+    }
+  }
+}
+apps: {
   key: "PetShopApiToModel"
-  value: <
-    name: <
+  value: {
+    name: {
       part: "PetShopApiToModel"
-    >
-    attrs: <
+    }
+    attrs: {
       key: "package"
-      value: <
+      value: {
         s: "io.sysl.demo.petshop.views"
-      >
-    >
-    types: <
+      }
+    }
+    types: {
       key: "AnonType_0__"
-      value: <
-        tuple: <
-          attr_defs: <
+      value: {
+        tuple: {
+          attr_defs: {
             key: "breed"
-            value: <
-              type_ref: <
-                context: <
-                  appname: <
+            value: {
+              type_ref: {
+                context: {
+                  appname: {
                     part: "PetShopApiToModel"
-                  >
+                  }
                   path: "AnonType_0__"
-                >
-                ref: <
-                  appname: <
+                }
+                ref: {
+                  appname: {
                     part: "PetShopModel"
-                  >
+                  }
                   path: "Breed"
-                >
-              >
-            >
-          >
-          attr_defs: <
+                }
+              }
+            }
+          }
+          attr_defs: {
             key: "pets"
-            value: <
-              set: <
-                type_ref: <
-                  context: <
-                    appname: <
+            value: {
+              set: {
+                type_ref: {
+                  context: {
+                    appname: {
                       part: "PetShopApiToModel"
-                    >
+                    }
                     path: "AnonType_0__"
-                  >
-                  ref: <
-                    appname: <
+                  }
+                  ref: {
+                    appname: {
                       part: "PetShopModel"
-                    >
+                    }
                     path: "Pet"
-                  >
-                >
-              >
-            >
-          >
-        >
-      >
-    >
-    views: <
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+    views: {
       key: "apiToModel"
-      value: <
-        param: <
+      value: {
+        param: {
           name: "petshop"
-          type: <
-            type_ref: <
-              ref: <
-                appname: <
+          type: {
+            type_ref: {
+              ref: {
+                appname: {
                   part: "PetShopApi"
-                >
+                }
                 path: "PetShop"
-              >
-            >
-          >
-        >
-        ret_type: <
-          type_ref: <
-            context: <
-              appname: <
+              }
+            }
+          }
+        }
+        ret_type: {
+          type_ref: {
+            context: {
+              appname: {
                 part: "PetShopApiToModel"
-              >
-            >
-            ref: <
-              appname: <
+              }
+            }
+            ref: {
+              appname: {
                 part: "PetShopModel"
-              >
-            >
-          >
-        >
-        expr: <
-          transform: <
-            arg: <
+              }
+            }
+          }
+        }
+        expr: {
+          transform: {
+            arg: {
               name: "petshop"
-            >
+              source_context: {
+                file: "tests/petshop.sysl"
+                start: {
+                  line: 126
+                  col: 8
+                }
+                end: {
+                  line: 126
+                  col: 8
+                }
+              }
+            }
             scopevar: "."
-            stmt: <
-              let: <
+            stmt: {
+              let: {
                 name: "_breedsAndPets"
-                expr: <
-                  transform: <
-                    arg: <
-                      get_attr: <
-                        arg: <
+                expr: {
+                  transform: {
+                    arg: {
+                      get_attr: {
+                        arg: {
                           name: "."
-                        >
+                          source_context: {
+                            file: "tests/petshop.sysl"
+                            start: {
+                              line: 127
+                              col: 33
+                            }
+                            end: {
+                              line: 127
+                              col: 34
+                            }
+                          }
+                        }
                         attr: "breeds"
-                      >
-                    >
+                      }
+                      source_context: {
+                        file: "tests/petshop.sysl"
+                        start: {
+                          line: 127
+                          col: 33
+                        }
+                        end: {
+                          line: 127
+                          col: 34
+                        }
+                      }
+                    }
                     scopevar: "."
-                    stmt: <
-                      let: <
+                    stmt: {
+                      let: {
                         name: "breedId"
-                        expr: <
-                          call: <
+                        expr: {
+                          call: {
                             func: "autoinc"
-                          >
-                        >
-                      >
-                    >
-                    stmt: <
-                      assign: <
+                          }
+                          source_context: {
+                            file: "tests/petshop.sysl"
+                            start: {
+                              line: 128
+                              col: 16
+                            }
+                            end: {
+                              line: 128
+                              col: 38
+                            }
+                            text: "let breedId = autoinc()"
+                          }
+                        }
+                      }
+                    }
+                    stmt: {
+                      assign: {
                         name: "breed"
-                        expr: <
-                          transform: <
-                            arg: <
+                        expr: {
+                          transform: {
+                            arg: {
                               name: "."
-                            >
+                              source_context: {
+                                file: "tests/petshop.sysl"
+                                start: {
+                                  line: 130
+                                  col: 24
+                                }
+                                end: {
+                                  line: 134
+                                  col: 17
+                                }
+                              }
+                            }
                             scopevar: "."
-                            stmt: <
-                              assign: <
+                            stmt: {
+                              assign: {
                                 name: "breedId"
-                                expr: <
+                                expr: {
                                   name: "breedId"
-                                >
-                              >
-                            >
-                            stmt: <
-                              assign: <
+                                  source_context: {
+                                    file: "tests/petshop.sysl"
+                                    start: {
+                                      line: 131
+                                      col: 20
+                                    }
+                                    end: {
+                                      line: 131
+                                      col: 30
+                                    }
+                                    text: "breedId = breedId"
+                                  }
+                                }
+                              }
+                            }
+                            stmt: {
+                              assign: {
                                 name: "species"
-                                expr: <
-                                  get_attr: <
-                                    arg: <
+                                expr: {
+                                  get_attr: {
+                                    arg: {
                                       name: "."
-                                    >
+                                      source_context: {
+                                        file: "tests/petshop.sysl"
+                                        start: {
+                                          line: 132
+                                          col: 30
+                                        }
+                                        end: {
+                                          line: 132
+                                          col: 31
+                                        }
+                                      }
+                                    }
                                     attr: "species"
-                                  >
-                                >
-                              >
-                            >
-                            stmt: <
-                              assign: <
+                                  }
+                                  source_context: {
+                                    file: "tests/petshop.sysl"
+                                    start: {
+                                      line: 132
+                                      col: 20
+                                    }
+                                    end: {
+                                      line: 132
+                                      col: 31
+                                    }
+                                    text: "species = .species"
+                                  }
+                                }
+                              }
+                            }
+                            stmt: {
+                              assign: {
                                 name: "breedName"
-                                expr: <
-                                  get_attr: <
-                                    arg: <
+                                expr: {
+                                  get_attr: {
+                                    arg: {
                                       name: "."
-                                    >
+                                      source_context: {
+                                        file: "tests/petshop.sysl"
+                                        start: {
+                                          line: 133
+                                          col: 32
+                                        }
+                                        end: {
+                                          line: 133
+                                          col: 33
+                                        }
+                                      }
+                                    }
                                     attr: "name"
-                                  >
-                                >
-                              >
-                            >
-                          >
-                          type: <
-                            type_ref: <
-                              context: <
-                                appname: <
+                                  }
+                                  source_context: {
+                                    file: "tests/petshop.sysl"
+                                    start: {
+                                      line: 133
+                                      col: 20
+                                    }
+                                    end: {
+                                      line: 133
+                                      col: 33
+                                    }
+                                    text: "breedName = .name"
+                                  }
+                                }
+                              }
+                            }
+                          }
+                          type: {
+                            type_ref: {
+                              context: {
+                                appname: {
                                   part: "PetShopApiToModel"
-                                >
-                              >
-                              ref: <
-                                appname: <
+                                }
+                              }
+                              ref: {
+                                appname: {
                                   part: "PetShopModel"
-                                >
+                                }
                                 path: "Breed"
-                              >
-                            >
-                          >
-                        >
-                      >
-                    >
-                    stmt: <
-                      assign: <
+                              }
+                            }
+                          }
+                          source_context: {
+                            file: "tests/petshop.sysl"
+                            start: {
+                              line: 130
+                              col: 16
+                            }
+                            end: {
+                              line: 134
+                              col: 17
+                            }
+                            text: "breed = -> <PetShopModel.Breed>(:\n                    breedId = breedId\n                    species = .species\n                    breedName = .name\n                )\n"
+                          }
+                        }
+                      }
+                    }
+                    stmt: {
+                      assign: {
                         name: "pets"
-                        expr: <
-                          transform: <
-                            arg: <
-                              get_attr: <
-                                arg: <
+                        expr: {
+                          transform: {
+                            arg: {
+                              get_attr: {
+                                arg: {
                                   name: "."
-                                >
+                                  source_context: {
+                                    file: "tests/petshop.sysl"
+                                    start: {
+                                      line: 136
+                                      col: 23
+                                    }
+                                    end: {
+                                      line: 136
+                                      col: 24
+                                    }
+                                  }
+                                }
                                 attr: "pets"
-                              >
-                            >
+                              }
+                              source_context: {
+                                file: "tests/petshop.sysl"
+                                start: {
+                                  line: 136
+                                  col: 23
+                                }
+                                end: {
+                                  line: 136
+                                  col: 24
+                                }
+                              }
+                            }
                             scopevar: "."
-                            stmt: <
-                              assign: <
+                            stmt: {
+                              assign: {
                                 name: "petId"
-                                expr: <
-                                  call: <
+                                expr: {
+                                  call: {
                                     func: "autoinc"
-                                  >
-                                >
-                              >
-                            >
-                            stmt: <
-                              assign: <
+                                  }
+                                  source_context: {
+                                    file: "tests/petshop.sysl"
+                                    start: {
+                                      line: 137
+                                      col: 20
+                                    }
+                                    end: {
+                                      line: 137
+                                      col: 36
+                                    }
+                                    text: "petId = autoinc()"
+                                  }
+                                }
+                              }
+                            }
+                            stmt: {
+                              assign: {
                                 name: "breedId"
-                                expr: <
+                                expr: {
                                   name: "breedId"
-                                >
-                              >
-                            >
-                            stmt: <
-                              assign: <
+                                  source_context: {
+                                    file: "tests/petshop.sysl"
+                                    start: {
+                                      line: 138
+                                      col: 20
+                                    }
+                                    end: {
+                                      line: 138
+                                      col: 30
+                                    }
+                                    text: "breedId = breedId"
+                                  }
+                                }
+                              }
+                            }
+                            stmt: {
+                              assign: {
                                 name: "name"
-                                expr: <
-                                  get_attr: <
-                                    arg: <
+                                expr: {
+                                  get_attr: {
+                                    arg: {
                                       name: "."
-                                    >
+                                      source_context: {
+                                        file: "tests/petshop.sysl"
+                                        start: {
+                                          line: 139
+                                          col: 20
+                                        }
+                                        end: {
+                                          line: 139
+                                          col: 20
+                                        }
+                                      }
+                                    }
                                     attr: "name"
-                                  >
-                                >
-                              >
-                            >
-                            stmt: <
-                              assign: <
+                                  }
+                                  source_context: {
+                                    file: "tests/petshop.sysl"
+                                    start: {
+                                      line: 139
+                                      col: 20
+                                    }
+                                    end: {
+                                      line: 139
+                                      col: 20
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                            stmt: {
+                              assign: {
                                 name: "dob"
-                                expr: <
-                                  get_attr: <
-                                    arg: <
+                                expr: {
+                                  get_attr: {
+                                    arg: {
                                       name: "."
-                                    >
+                                      source_context: {
+                                        file: "tests/petshop.sysl"
+                                        start: {
+                                          line: 140
+                                          col: 20
+                                        }
+                                        end: {
+                                          line: 140
+                                          col: 20
+                                        }
+                                      }
+                                    }
                                     attr: "dob"
-                                  >
-                                >
-                              >
-                            >
-                          >
-                          type: <
-                            set: <
-                              type_ref: <
-                                context: <
-                                  appname: <
+                                  }
+                                  source_context: {
+                                    file: "tests/petshop.sysl"
+                                    start: {
+                                      line: 140
+                                      col: 20
+                                    }
+                                    end: {
+                                      line: 140
+                                      col: 20
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          }
+                          type: {
+                            set: {
+                              type_ref: {
+                                context: {
+                                  appname: {
                                     part: "PetShopApiToModel"
-                                  >
-                                >
-                                ref: <
-                                  appname: <
+                                  }
+                                }
+                                ref: {
+                                  appname: {
                                     part: "PetShopModel"
-                                  >
+                                  }
                                   path: "Pet"
-                                >
-                              >
-                            >
-                          >
-                        >
-                      >
-                    >
-                  >
-                  type: <
-                    set: <
-                      type_ref: <
-                        context: <
-                          appname: <
+                                }
+                              }
+                            }
+                          }
+                          source_context: {
+                            file: "tests/petshop.sysl"
+                            start: {
+                              line: 136
+                              col: 16
+                            }
+                            end: {
+                              line: 141
+                              col: 17
+                            }
+                            text: "pets = .pets -> <set of PetShopModel.Pet>(:\n                    petId = autoinc()\n                    breedId = breedId\n                    .name\n                    .dob\n                )\n"
+                          }
+                        }
+                      }
+                    }
+                  }
+                  type: {
+                    set: {
+                      type_ref: {
+                        context: {
+                          appname: {
                             part: "PetShopApiToModel"
-                          >
-                        >
-                        ref: <
-                          appname: <
+                          }
+                        }
+                        ref: {
+                          appname: {
                             part: "PetShopApiToModel"
-                          >
+                          }
                           path: "AnonType_0__"
-                        >
-                      >
-                    >
-                  >
-                >
-              >
-            >
-            stmt: <
-              let: <
+                        }
+                      }
+                    }
+                  }
+                  source_context: {
+                    file: "tests/petshop.sysl"
+                    start: {
+                      line: 127
+                      col: 12
+                    }
+                    end: {
+                      line: 142
+                      col: 13
+                    }
+                    text: "let _breedsAndPets = .breeds -> <set of>(:\n                let breedId = autoinc()\n\n                breed = -> <PetShopModel.Breed>(:\n                    breedId = breedId\n                    species = .species\n                    breedName = .name\n                )\n\n                pets = .pets -> <set of PetShopModel.Pet>(:\n                    petId = autoinc()\n                    breedId = breedId\n                    .name\n                    .dob\n                )\n            )\n"
+                  }
+                }
+              }
+            }
+            stmt: {
+              let: {
                 name: "breedsAndPets"
-                expr: <
-                  relexpr: <
+                expr: {
+                  relexpr: {
                     op: SNAPSHOT
-                    target: <
+                    target: {
                       name: "_breedsAndPets"
-                    >
-                  >
-                >
-              >
-            >
-            stmt: <
-              let: <
+                      source_context: {
+                        file: "tests/petshop.sysl"
+                        start: {
+                          line: 144
+                          col: 32
+                        }
+                        end: {
+                          line: 144
+                          col: 32
+                        }
+                      }
+                    }
+                  }
+                  source_context: {
+                    file: "tests/petshop.sysl"
+                    start: {
+                      line: 144
+                      col: 12
+                    }
+                    end: {
+                      line: 144
+                      col: 47
+                    }
+                    text: "let breedsAndPets = _breedsAndPets snapshot"
+                  }
+                }
+              }
+            }
+            stmt: {
+              let: {
                 name: "minId1"
-                expr: <
-                  relexpr: <
+                expr: {
+                  relexpr: {
                     op: MAX
-                    target: <
+                    target: {
                       name: "breedsAndPets"
-                    >
-                    arg: <
-                      get_attr: <
-                        arg: <
-                          get_attr: <
-                            arg: <
+                      source_context: {
+                        file: "tests/petshop.sysl"
+                        start: {
+                          line: 146
+                          col: 25
+                        }
+                        end: {
+                          line: 146
+                          col: 25
+                        }
+                      }
+                    }
+                    arg: {
+                      get_attr: {
+                        arg: {
+                          get_attr: {
+                            arg: {
                               name: "."
-                            >
+                              source_context: {
+                                file: "tests/petshop.sysl"
+                                start: {
+                                  line: 146
+                                  col: 43
+                                }
+                                end: {
+                                  line: 146
+                                  col: 44
+                                }
+                              }
+                            }
                             attr: "breed"
-                          >
-                        >
+                          }
+                          source_context: {
+                            file: "tests/petshop.sysl"
+                            start: {
+                              line: 146
+                              col: 43
+                            }
+                            end: {
+                              line: 146
+                              col: 44
+                            }
+                          }
+                        }
                         attr: "breedId"
-                      >
-                    >
+                      }
+                      source_context: {
+                        file: "tests/petshop.sysl"
+                        start: {
+                          line: 146
+                          col: 49
+                        }
+                        end: {
+                          line: 146
+                          col: 50
+                        }
+                      }
+                    }
                     scopevar: "."
-                  >
-                >
-              >
-            >
-            stmt: <
-              let: <
+                  }
+                  source_context: {
+                    file: "tests/petshop.sysl"
+                    start: {
+                      line: 146
+                      col: 12
+                    }
+                    end: {
+                      line: 146
+                      col: 57
+                    }
+                    text: "let minId1 = breedsAndPets max(.breed.breedId)"
+                  }
+                }
+              }
+            }
+            stmt: {
+              let: {
                 name: "minId2"
-                expr: <
-                  relexpr: <
+                expr: {
+                  relexpr: {
                     op: MAX
-                    target: <
+                    target: {
                       name: "breedsAndPets"
-                    >
-                    arg: <
-                      get_attr: <
-                        arg: <
-                          get_attr: <
-                            arg: <
+                      source_context: {
+                        file: "tests/petshop.sysl"
+                        start: {
+                          line: 147
+                          col: 25
+                        }
+                        end: {
+                          line: 147
+                          col: 25
+                        }
+                      }
+                    }
+                    arg: {
+                      get_attr: {
+                        arg: {
+                          get_attr: {
+                            arg: {
                               name: "."
-                            >
+                              source_context: {
+                                file: "tests/petshop.sysl"
+                                start: {
+                                  line: 147
+                                  col: 43
+                                }
+                                end: {
+                                  line: 147
+                                  col: 44
+                                }
+                              }
+                            }
                             attr: "breed"
-                          >
-                        >
+                          }
+                          source_context: {
+                            file: "tests/petshop.sysl"
+                            start: {
+                              line: 147
+                              col: 43
+                            }
+                            end: {
+                              line: 147
+                              col: 44
+                            }
+                          }
+                        }
                         attr: "breedId"
-                      >
-                    >
+                      }
+                      source_context: {
+                        file: "tests/petshop.sysl"
+                        start: {
+                          line: 147
+                          col: 49
+                        }
+                        end: {
+                          line: 147
+                          col: 50
+                        }
+                      }
+                    }
                     scopevar: "."
-                  >
-                >
-              >
-            >
-            stmt: <
-              let: <
+                  }
+                  source_context: {
+                    file: "tests/petshop.sysl"
+                    start: {
+                      line: 147
+                      col: 12
+                    }
+                    end: {
+                      line: 147
+                      col: 57
+                    }
+                    text: "let minId2 = breedsAndPets max(.breed.breedId)"
+                  }
+                }
+              }
+            }
+            stmt: {
+              let: {
                 name: "lee"
-                expr: <
-                  transform: <
-                    arg: <
-                      set: <
-                        expr: <
-                          tuple: <
-                          >
-                          type: <
-                            tuple: <
-                            >
-                          >
-                        >
-                      >
-                      type: <
-                        set: <
-                          tuple: <
-                          >
-                        >
-                      >
-                    >
+                expr: {
+                  transform: {
+                    arg: {
+                      set: {
+                        expr: {
+                          tuple: {}
+                          type: {
+                            tuple: {}
+                          }
+                          source_context: {
+                            file: "tests/petshop.sysl"
+                            start: {
+                              line: 149
+                              col: 23
+                            }
+                            end: {
+                              line: 149
+                              col: 23
+                            }
+                          }
+                        }
+                      }
+                      type: {
+                        set: {
+                          tuple: {}
+                        }
+                      }
+                      source_context: {
+                        file: "tests/petshop.sysl"
+                        start: {
+                          line: 149
+                          col: 22
+                        }
+                        end: {
+                          line: 149
+                          col: 26
+                        }
+                      }
+                    }
                     scopevar: "."
-                    stmt: <
-                      assign: <
+                    stmt: {
+                      assign: {
                         name: "name"
-                        expr: <
-                          literal: <
+                        expr: {
+                          literal: {
                             s: "Bruce"
-                          >
-                        >
-                      >
-                    >
-                  >
-                  type: <
-                    set: <
-                      type_ref: <
-                        context: <
-                          appname: <
+                          }
+                          type: {
+                            primitive: STRING
+                          }
+                          source_context: {
+                            file: "tests/petshop.sysl"
+                            start: {
+                              line: 150
+                              col: 16
+                            }
+                            end: {
+                              line: 150
+                              col: 23
+                            }
+                            text: "name = \"Bruce\""
+                          }
+                        }
+                      }
+                    }
+                  }
+                  type: {
+                    set: {
+                      type_ref: {
+                        context: {
+                          appname: {
                             part: "PetShopApiToModel"
-                          >
-                        >
-                        ref: <
-                          appname: <
+                          }
+                        }
+                        ref: {
+                          appname: {
                             part: "PetShopModel"
-                          >
+                          }
                           path: "Employee"
-                        >
-                      >
-                    >
-                  >
-                >
-              >
-            >
-            stmt: <
-              let: <
+                        }
+                      }
+                    }
+                  }
+                  source_context: {
+                    file: "tests/petshop.sysl"
+                    start: {
+                      line: 149
+                      col: 12
+                    }
+                    end: {
+                      line: 151
+                      col: 13
+                    }
+                    text: "let lee = {{:}} -> <set of PetShopModel.Employee>(:\n                name = \"Bruce\"\n            )\n"
+                  }
+                }
+              }
+            }
+            stmt: {
+              let: {
                 name: "leeless"
-                expr: <
-                  unexpr: <
+                expr: {
+                  unexpr: {
                     op: NOT
-                    arg: <
+                    arg: {
                       name: "lee"
-                    >
-                  >
-                >
-              >
-            >
-            stmt: <
-              let: <
+                      source_context: {
+                        file: "tests/petshop.sysl"
+                        start: {
+                          line: 153
+                          col: 27
+                        }
+                        end: {
+                          line: 153
+                          col: 27
+                        }
+                      }
+                    }
+                  }
+                  type: {
+                    primitive: BOOL
+                  }
+                  source_context: {
+                    file: "tests/petshop.sysl"
+                    start: {
+                      line: 153
+                      col: 12
+                    }
+                    end: {
+                      line: 153
+                      col: 27
+                    }
+                    text: "let leeless = !lee"
+                  }
+                }
+              }
+            }
+            stmt: {
+              let: {
                 name: "decimal1"
-                expr: <
-                  literal: <
+                expr: {
+                  literal: {
                     decimal: "1.2"
-                  >
-                >
-              >
-            >
-            stmt: <
-              let: <
+                  }
+                  type: {
+                    primitive: DECIMAL
+                  }
+                  source_context: {
+                    file: "tests/petshop.sysl"
+                    start: {
+                      line: 155
+                      col: 12
+                    }
+                    end: {
+                      line: 155
+                      col: 27
+                    }
+                    text: "let decimal1 = 1.2"
+                  }
+                }
+              }
+            }
+            stmt: {
+              let: {
                 name: "decimal2"
-                expr: <
-                  literal: <
+                expr: {
+                  literal: {
                     decimal: "2.3"
-                  >
-                >
-              >
-            >
-            stmt: <
-              let: <
+                  }
+                  type: {
+                    primitive: DECIMAL
+                  }
+                  source_context: {
+                    file: "tests/petshop.sysl"
+                    start: {
+                      line: 156
+                      col: 12
+                    }
+                    end: {
+                      line: 156
+                      col: 27
+                    }
+                    text: "let decimal2 = 2.3"
+                  }
+                }
+              }
+            }
+            stmt: {
+              let: {
                 name: "decimal3"
-                expr: <
-                  binexpr: <
+                expr: {
+                  binexpr: {
                     op: ADD
-                    lhs: <
-                      unexpr: <
+                    lhs: {
+                      unexpr: {
                         op: POS
-                        arg: <
+                        arg: {
                           name: "decimal1"
-                        >
-                      >
-                    >
-                    rhs: <
+                          source_context: {
+                            file: "tests/petshop.sysl"
+                            start: {
+                              line: 157
+                              col: 28
+                            }
+                            end: {
+                              line: 157
+                              col: 28
+                            }
+                          }
+                        }
+                      }
+                      type: {
+                        primitive: INT
+                      }
+                      source_context: {
+                        file: "tests/petshop.sysl"
+                        start: {
+                          line: 157
+                          col: 27
+                        }
+                        end: {
+                          line: 157
+                          col: 28
+                        }
+                      }
+                    }
+                    rhs: {
                       name: "decimal2"
-                    >
-                  >
-                >
-              >
-            >
-            stmt: <
-              let: <
+                      source_context: {
+                        file: "tests/petshop.sysl"
+                        start: {
+                          line: 157
+                          col: 39
+                        }
+                        end: {
+                          line: 157
+                          col: 39
+                        }
+                      }
+                    }
+                  }
+                  type: {
+                    no_type: {}
+                  }
+                  source_context: {
+                    file: "tests/petshop.sysl"
+                    start: {
+                      line: 157
+                      col: 12
+                    }
+                    end: {
+                      line: 157
+                      col: 39
+                    }
+                    text: "let decimal3 = +decimal1 + decimal2"
+                  }
+                }
+              }
+            }
+            stmt: {
+              let: {
                 name: "one_third"
-                expr: <
-                  binexpr: <
+                expr: {
+                  binexpr: {
                     op: DIV
-                    lhs: <
-                      literal: <
+                    lhs: {
+                      literal: {
                         decimal: "1.0"
-                      >
-                    >
-                    rhs: <
-                      literal: <
+                      }
+                      type: {
+                        primitive: DECIMAL
+                      }
+                      source_context: {
+                        file: "tests/petshop.sysl"
+                        start: {
+                          line: 159
+                          col: 28
+                        }
+                        end: {
+                          line: 159
+                          col: 28
+                        }
+                      }
+                    }
+                    rhs: {
+                      literal: {
                         decimal: "3.0"
-                      >
-                    >
-                  >
-                >
-              >
-            >
-            stmt: <
-              let: <
+                      }
+                      type: {
+                        primitive: DECIMAL
+                      }
+                      source_context: {
+                        file: "tests/petshop.sysl"
+                        start: {
+                          line: 159
+                          col: 34
+                        }
+                        end: {
+                          line: 159
+                          col: 34
+                        }
+                      }
+                    }
+                  }
+                  type: {
+                    primitive: DECIMAL
+                  }
+                  source_context: {
+                    file: "tests/petshop.sysl"
+                    start: {
+                      line: 159
+                      col: 12
+                    }
+                    end: {
+                      line: 159
+                      col: 34
+                    }
+                    text: "let one_third = 1.0 / 3.0"
+                  }
+                }
+              }
+            }
+            stmt: {
+              let: {
                 name: "one_ninth"
-                expr: <
-                  binexpr: <
+                expr: {
+                  binexpr: {
                     op: POW
-                    lhs: <
+                    lhs: {
                       name: "one_third"
-                    >
-                    rhs: <
-                      literal: <
+                      source_context: {
+                        file: "tests/petshop.sysl"
+                        start: {
+                          line: 160
+                          col: 28
+                        }
+                        end: {
+                          line: 160
+                          col: 28
+                        }
+                      }
+                    }
+                    rhs: {
+                      literal: {
                         i: 2
-                      >
-                    >
-                  >
-                >
-              >
-            >
-            stmt: <
-              let: <
+                      }
+                      type: {
+                        primitive: INT
+                      }
+                      source_context: {
+                        file: "tests/petshop.sysl"
+                        start: {
+                          line: 160
+                          col: 41
+                        }
+                        end: {
+                          line: 160
+                          col: 41
+                        }
+                      }
+                    }
+                  }
+                  type: {
+                    primitive: INT
+                  }
+                  source_context: {
+                    file: "tests/petshop.sysl"
+                    start: {
+                      line: 160
+                      col: 12
+                    }
+                    end: {
+                      line: 160
+                      col: 41
+                    }
+                    text: "let one_ninth = one_third ** 2"
+                  }
+                }
+              }
+            }
+            stmt: {
+              let: {
                 name: "bruce_lee"
-                expr: <
-                  binexpr: <
+                expr: {
+                  binexpr: {
                     op: ADD
-                    lhs: <
-                      get_attr: <
-                        arg: <
-                          unexpr: <
+                    lhs: {
+                      get_attr: {
+                        arg: {
+                          unexpr: {
                             op: SINGLE_OR_NULL
-                            arg: <
+                            arg: {
                               name: "lee"
-                            >
-                          >
-                        >
+                              source_context: {
+                                file: "tests/petshop.sysl"
+                                start: {
+                                  line: 164
+                                  col: 28
+                                }
+                                end: {
+                                  line: 164
+                                  col: 28
+                                }
+                              }
+                            }
+                          }
+                          source_context: {
+                            file: "tests/petshop.sysl"
+                            start: {
+                              line: 164
+                              col: 32
+                            }
+                            end: {
+                              line: 164
+                              col: 32
+                            }
+                          }
+                        }
                         attr: "name"
                         nullsafe: true
-                      >
-                    >
-                    rhs: <
-                      call: <
+                      }
+                      source_context: {
+                        file: "tests/petshop.sysl"
+                        start: {
+                          line: 164
+                          col: 44
+                        }
+                        end: {
+                          line: 164
+                          col: 46
+                        }
+                      }
+                    }
+                    rhs: {
+                      call: {
                         func: "substr"
-                        arg: <
-                          literal: <
+                        arg: {
+                          literal: {
                             s: " Leek"
-                          >
-                        >
-                        arg: <
-                          literal: <
+                          }
+                          source_context: {
+                            file: "tests/petshop.sysl"
+                            start: {
+                              line: 164
+                              col: 60
+                            }
+                            end: {
+                              line: 164
+                              col: 60
+                            }
+                          }
+                        }
+                        arg: {
+                          literal: {
                             i: 0
-                          >
-                        >
-                        arg: <
-                          literal: <
+                          }
+                          source_context: {
+                            file: "tests/petshop.sysl"
+                            start: {
+                              line: 164
+                              col: 69
+                            }
+                            end: {
+                              line: 164
+                              col: 69
+                            }
+                          }
+                        }
+                        arg: {
+                          literal: {
                             i: 4
-                          >
-                        >
-                      >
-                    >
-                  >
-                >
-              >
-            >
-            stmt: <
-              assign: <
+                          }
+                          source_context: {
+                            file: "tests/petshop.sysl"
+                            start: {
+                              line: 164
+                              col: 72
+                            }
+                            end: {
+                              line: 164
+                              col: 72
+                            }
+                          }
+                        }
+                      }
+                      source_context: {
+                        file: "tests/petshop.sysl"
+                        start: {
+                          line: 164
+                          col: 53
+                        }
+                        end: {
+                          line: 164
+                          col: 73
+                        }
+                        text: "substr(\" Leek\", 0, 4)"
+                      }
+                    }
+                  }
+                  type: {
+                    no_type: {}
+                  }
+                  source_context: {
+                    file: "tests/petshop.sysl"
+                    start: {
+                      line: 164
+                      col: 12
+                    }
+                    end: {
+                      line: 164
+                      col: 73
+                    }
+                    text: "let bruce_lee = lee singleOrNull?.name + substr(\" Leek\", 0, 4)"
+                  }
+                }
+              }
+            }
+            stmt: {
+              assign: {
                 name: "Employee"
-                expr: <
-                  transform: <
-                    arg: <
-                      get_attr: <
-                        arg: <
+                expr: {
+                  transform: {
+                    arg: {
+                      get_attr: {
+                        arg: {
                           name: "."
-                        >
+                          source_context: {
+                            file: "tests/petshop.sysl"
+                            start: {
+                              line: 166
+                              col: 32
+                            }
+                            end: {
+                              line: 166
+                              col: 33
+                            }
+                          }
+                        }
                         attr: "employees"
-                      >
-                    >
+                      }
+                      source_context: {
+                        file: "tests/petshop.sysl"
+                        start: {
+                          line: 166
+                          col: 32
+                        }
+                        end: {
+                          line: 166
+                          col: 33
+                        }
+                      }
+                    }
                     scopevar: "."
-                    stmt: <
-                      assign: <
+                    stmt: {
+                      assign: {
                         name: "employeeId"
-                        expr: <
-                          call: <
+                        expr: {
+                          call: {
                             func: "autoinc"
-                          >
-                        >
-                      >
-                    >
-                    stmt: <
-                      assign: <
+                          }
+                          source_context: {
+                            file: "tests/petshop.sysl"
+                            start: {
+                              line: 167
+                              col: 16
+                            }
+                            end: {
+                              line: 167
+                              col: 37
+                            }
+                            text: "employeeId = autoinc()"
+                          }
+                        }
+                      }
+                    }
+                    stmt: {
+                      assign: {
                         name: "name"
-                        expr: <
-                          get_attr: <
-                            arg: <
+                        expr: {
+                          get_attr: {
+                            arg: {
                               name: "."
-                            >
+                              source_context: {
+                                file: "tests/petshop.sysl"
+                                start: {
+                                  line: 168
+                                  col: 16
+                                }
+                                end: {
+                                  line: 168
+                                  col: 16
+                                }
+                              }
+                            }
                             attr: "name"
-                          >
-                        >
-                      >
-                    >
-                    stmt: <
-                      assign: <
+                          }
+                          source_context: {
+                            file: "tests/petshop.sysl"
+                            start: {
+                              line: 168
+                              col: 16
+                            }
+                            end: {
+                              line: 168
+                              col: 16
+                            }
+                          }
+                        }
+                      }
+                    }
+                    stmt: {
+                      assign: {
                         name: "dob"
-                        expr: <
-                          get_attr: <
-                            arg: <
+                        expr: {
+                          get_attr: {
+                            arg: {
                               name: "."
-                            >
+                              source_context: {
+                                file: "tests/petshop.sysl"
+                                start: {
+                                  line: 169
+                                  col: 16
+                                }
+                                end: {
+                                  line: 169
+                                  col: 16
+                                }
+                              }
+                            }
                             attr: "dob"
-                          >
-                        >
-                      >
-                    >
-                    stmt: <
-                      assign: <
+                          }
+                          source_context: {
+                            file: "tests/petshop.sysl"
+                            start: {
+                              line: 169
+                              col: 16
+                            }
+                            end: {
+                              line: 169
+                              col: 16
+                            }
+                          }
+                        }
+                      }
+                    }
+                    stmt: {
+                      assign: {
                         name: "error"
-                        expr: <
-                          binexpr: <
+                        expr: {
+                          binexpr: {
                             op: SUB
-                            lhs: <
+                            lhs: {
                               name: "minId2"
-                            >
-                            rhs: <
+                              source_context: {
+                                file: "tests/petshop.sysl"
+                                start: {
+                                  line: 170
+                                  col: 24
+                                }
+                                end: {
+                                  line: 170
+                                  col: 24
+                                }
+                              }
+                            }
+                            rhs: {
                               name: "minId1"
-                            >
-                          >
-                        >
-                      >
-                    >
-                  >
-                  type: <
-                    set: <
-                      type_ref: <
-                        context: <
-                          appname: <
+                              source_context: {
+                                file: "tests/petshop.sysl"
+                                start: {
+                                  line: 170
+                                  col: 33
+                                }
+                                end: {
+                                  line: 170
+                                  col: 33
+                                }
+                              }
+                            }
+                          }
+                          type: {
+                            no_type: {}
+                          }
+                          source_context: {
+                            file: "tests/petshop.sysl"
+                            start: {
+                              line: 170
+                              col: 16
+                            }
+                            end: {
+                              line: 170
+                              col: 33
+                            }
+                            text: "error = minId2 - minId1"
+                          }
+                        }
+                      }
+                    }
+                  }
+                  type: {
+                    set: {
+                      type_ref: {
+                        context: {
+                          appname: {
                             part: "PetShopApiToModel"
-                          >
-                        >
-                        ref: <
-                          appname: <
+                          }
+                        }
+                        ref: {
+                          appname: {
                             part: "PetShopModel"
-                          >
+                          }
                           path: "Employee"
-                        >
-                      >
-                    >
-                  >
-                >
+                        }
+                      }
+                    }
+                  }
+                  source_context: {
+                    file: "tests/petshop.sysl"
+                    start: {
+                      line: 166
+                      col: 32
+                    }
+                    end: {
+                      line: 171
+                      col: 13
+                    }
+                  }
+                }
                 table: true
-              >
-            >
-            stmt: <
-              assign: <
+              }
+            }
+            stmt: {
+              assign: {
                 name: "Breed"
-                expr: <
-                  navigate: <
-                    arg: <
+                expr: {
+                  navigate: {
+                    arg: {
                       name: "breedsAndPets"
-                    >
+                      source_context: {
+                        file: "tests/petshop.sysl"
+                        start: {
+                          line: 172
+                          col: 29
+                        }
+                        end: {
+                          line: 172
+                          col: 29
+                        }
+                      }
+                    }
                     attr: ".breed"
                     setof: true
-                  >
-                >
+                  }
+                  source_context: {
+                    file: "tests/petshop.sysl"
+                    start: {
+                      line: 172
+                      col: 43
+                    }
+                    end: {
+                      line: 172
+                      col: 54
+                    }
+                  }
+                }
                 table: true
-              >
-            >
-            stmt: <
-              assign: <
+              }
+            }
+            stmt: {
+              assign: {
                 name: "Pet"
-                expr: <
-                  binexpr: <
+                expr: {
+                  binexpr: {
                     op: FLATTEN
-                    lhs: <
+                    lhs: {
                       name: "breedsAndPets"
-                    >
-                    rhs: <
-                      get_attr: <
-                        arg: <
+                      source_context: {
+                        file: "tests/petshop.sysl"
+                        start: {
+                          line: 173
+                          col: 27
+                        }
+                        end: {
+                          line: 173
+                          col: 27
+                        }
+                      }
+                    }
+                    rhs: {
+                      get_attr: {
+                        arg: {
                           name: "."
-                        >
+                          source_context: {
+                            file: "tests/petshop.sysl"
+                            start: {
+                              line: 173
+                              col: 49
+                            }
+                            end: {
+                              line: 173
+                              col: 50
+                            }
+                          }
+                        }
                         attr: "pets"
-                      >
-                    >
+                      }
+                      source_context: {
+                        file: "tests/petshop.sysl"
+                        start: {
+                          line: 173
+                          col: 49
+                        }
+                        end: {
+                          line: 173
+                          col: 50
+                        }
+                      }
+                    }
                     scopevar: "."
-                  >
-                >
+                  }
+                  type: {
+                    no_type: {}
+                  }
+                  source_context: {
+                    file: "tests/petshop.sysl"
+                    start: {
+                      line: 173
+                      col: 41
+                    }
+                    end: {
+                      line: 173
+                      col: 41
+                    }
+                  }
+                }
                 table: true
-              >
-            >
-          >
-          type: <
-            type_ref: <
-              context: <
-                appname: <
+              }
+            }
+          }
+          type: {
+            type_ref: {
+              context: {
+                appname: {
                   part: "PetShopApiToModel"
-                >
-              >
-              ref: <
-                appname: <
+                }
+              }
+              ref: {
+                appname: {
                   part: "PetShopModel"
-                >
-              >
-            >
-          >
-        >
-      >
-    >
-  >
->
-apps: <
+                }
+              }
+            }
+          }
+          source_context: {
+            file: "tests/petshop.sysl"
+            start: {
+              line: 126
+              col: 8
+            }
+            end: {
+              line: 174
+              col: 9
+            }
+          }
+        }
+        source_context: {
+          file: "tests/petshop.sysl"
+          start: {
+            line: 125
+            col: 4
+          }
+          end: {
+            line: 175
+          }
+          text: "!view apiToModel(petshop <: PetShopApi.PetShop):"
+        }
+      }
+    }
+    source_context: {
+      file: "tests/petshop.sysl"
+      start: {
+        line: 124
+        col: 1
+      }
+      end: {
+        line: 124
+        col: 55
+      }
+    }
+  }
+}
+apps: {
   key: "PetShopFacade"
-  value: <
-    name: <
+  value: {
+    name: {
       part: "PetShopFacade"
-    >
-    attrs: <
+    }
+    attrs: {
       key: "package"
-      value: <
+      value: {
         s: "io.sysl.demo.petshop.facade"
-      >
-    >
-    wrapped: <
-      name: <
+      }
+    }
+    wrapped: {
+      name: {
         part: "PetShopModel"
-      >
-      types: <
+      }
+      types: {
         key: "Breed"
-        value: <
-        >
-      >
-      types: <
+        value: {}
+      }
+      types: {
         key: "Employee"
-        value: <
-        >
-      >
-      types: <
+        value: {}
+      }
+      types: {
         key: "EmployeeTendsPet"
-        value: <
-        >
-      >
-      types: <
+        value: {}
+      }
+      types: {
         key: "Pet"
-        value: <
-        >
-      >
-    >
-  >
->
-apps: <
+        value: {}
+      }
+    }
+    source_context: {
+      file: "tests/petshop.sysl"
+      start: {
+        line: 29
+        col: 1
+      }
+      end: {
+        line: 29
+        col: 52
+      }
+    }
+  }
+}
+apps: {
   key: "PetShopModel"
-  value: <
-    name: <
+  value: {
+    name: {
       part: "PetShopModel"
-    >
-    attrs: <
+    }
+    attrs: {
       key: "package"
-      value: <
+      value: {
         s: "io.sysl.demo.petshop.model"
-      >
-    >
-    types: <
+      }
+    }
+    types: {
       key: "Breed"
-      value: <
-        relation: <
-          attr_defs: <
+      value: {
+        relation: {
+          attr_defs: {
             key: "avgLifespan"
-            value: <
+            value: {
               primitive: DECIMAL
-              constraint: <
-                length: <
+              constraint: {
+                length: {
                   max: 14
-                >
+                }
                 precision: 14
                 scale: 2
-              >
+              }
               opt: true
-              source_context: <
+              source_context: {
                 file: "tests/petshop.sysl"
-                start: <
+                start: {
                   line: 13
                   col: 23
-                >
-                end: <
+                }
+                end: {
                   line: 13
                   col: 36
-                >
-              >
-            >
-          >
-          attr_defs: <
+                }
+              }
+            }
+          }
+          attr_defs: {
             key: "avgWeight"
-            value: <
+            value: {
               primitive: DECIMAL
-              constraint: <
-                length: <
+              constraint: {
+                length: {
                   max: 14
-                >
-              >
+                }
+              }
               opt: true
-              source_context: <
+              source_context: {
                 file: "tests/petshop.sysl"
-                start: <
+                start: {
                   line: 14
                   col: 21
-                >
-                end: <
+                }
+                end: {
                   line: 14
                   col: 32
-                >
-              >
-            >
-          >
-          attr_defs: <
+                }
+              }
+            }
+          }
+          attr_defs: {
             key: "breedId"
-            value: <
+            value: {
               primitive: INT
-              attrs: <
+              attrs: {
                 key: "patterns"
-                value: <
-                  a: <
-                    elt: <
+                value: {
+                  a: {
+                    elt: {
                       s: "pk"
-                    >
-                    elt: <
+                    }
+                    elt: {
                       s: "autoinc"
-                    >
-                  >
-                >
-              >
-              source_context: <
+                    }
+                  }
+                }
+              }
+              source_context: {
                 file: "tests/petshop.sysl"
-                start: <
+                start: {
                   line: 9
                   col: 19
-                >
-                end: <
+                }
+                end: {
                   line: 9
                   col: 37
-                >
-              >
-            >
-          >
-          attr_defs: <
+                }
+              }
+            }
+          }
+          attr_defs: {
             key: "breedName"
-            value: <
+            value: {
               primitive: STRING
               opt: true
-              source_context: <
+              source_context: {
                 file: "tests/petshop.sysl"
-                start: <
+                start: {
                   line: 10
                   col: 21
-                >
-                end: <
+                }
+                end: {
                   line: 10
                   col: 27
-                >
-              >
-            >
-          >
-          attr_defs: <
+                }
+              }
+            }
+          }
+          attr_defs: {
             key: "legRank"
-            value: <
+            value: {
               primitive: INT
               opt: true
-              source_context: <
+              source_context: {
                 file: "tests/petshop.sysl"
-                start: <
+                start: {
                   line: 15
                   col: 19
-                >
-                end: <
+                }
+                end: {
                   line: 15
                   col: 22
-                >
-              >
-            >
-          >
-          attr_defs: <
+                }
+              }
+            }
+          }
+          attr_defs: {
             key: "numLegs"
-            value: <
+            value: {
               primitive: INT
               opt: true
-              source_context: <
+              source_context: {
                 file: "tests/petshop.sysl"
-                start: <
+                start: {
                   line: 12
                   col: 19
-                >
-                end: <
+                }
+                end: {
                   line: 12
                   col: 22
-                >
-              >
-            >
-          >
-          attr_defs: <
+                }
+              }
+            }
+          }
+          attr_defs: {
             key: "species"
-            value: <
+            value: {
               primitive: STRING
               opt: true
-              source_context: <
+              source_context: {
                 file: "tests/petshop.sysl"
-                start: <
+                start: {
                   line: 11
                   col: 19
-                >
-                end: <
+                }
+                end: {
                   line: 11
                   col: 25
-                >
-              >
-            >
-          >
-          primary_key: <
+                }
+              }
+            }
+          }
+          primary_key: {
             attr_name: "breedId"
-          >
-        >
-      >
-    >
-    types: <
+          }
+        }
+        source_context: {
+          file: "tests/petshop.sysl"
+          start: {
+            line: 8
+            col: 4
+          }
+          end: {
+            line: 17
+            col: 4
+          }
+        }
+      }
+    }
+    types: {
       key: "Employee"
-      value: <
-        relation: <
-          attr_defs: <
+      value: {
+        relation: {
+          attr_defs: {
             key: "dob"
-            value: <
+            value: {
               primitive: DATE
               opt: true
-              source_context: <
+              source_context: {
                 file: "tests/petshop.sysl"
-                start: <
+                start: {
                   line: 5
                   col: 15
-                >
-                end: <
+                }
+                end: {
                   line: 5
                   col: 19
-                >
-              >
-            >
-          >
-          attr_defs: <
+                }
+              }
+            }
+          }
+          attr_defs: {
             key: "employeeId"
-            value: <
+            value: {
               primitive: INT
-              attrs: <
+              attrs: {
                 key: "patterns"
-                value: <
-                  a: <
-                    elt: <
+                value: {
+                  a: {
+                    elt: {
                       s: "pk"
-                    >
-                    elt: <
+                    }
+                    elt: {
                       s: "autoinc"
-                    >
-                  >
-                >
-              >
-              source_context: <
+                    }
+                  }
+                }
+              }
+              source_context: {
                 file: "tests/petshop.sysl"
-                start: <
+                start: {
                   line: 3
                   col: 22
-                >
-                end: <
+                }
+                end: {
                   line: 3
                   col: 40
-                >
-              >
-            >
-          >
-          attr_defs: <
+                }
+              }
+            }
+          }
+          attr_defs: {
             key: "error"
-            value: <
+            value: {
               primitive: INT
-              source_context: <
+              source_context: {
                 file: "tests/petshop.sysl"
-                start: <
+                start: {
                   line: 6
                   col: 17
-                >
-                end: <
+                }
+                end: {
                   line: 6
                   col: 17
-                >
-              >
-            >
-          >
-          attr_defs: <
+                }
+              }
+            }
+          }
+          attr_defs: {
             key: "name"
-            value: <
+            value: {
               primitive: STRING
               opt: true
-              source_context: <
+              source_context: {
                 file: "tests/petshop.sysl"
-                start: <
+                start: {
                   line: 4
                   col: 16
-                >
-                end: <
+                }
+                end: {
                   line: 4
                   col: 22
-                >
-              >
-            >
-          >
-          primary_key: <
+                }
+              }
+            }
+          }
+          primary_key: {
             attr_name: "employeeId"
-          >
-        >
-      >
-    >
-    types: <
+          }
+        }
+        source_context: {
+          file: "tests/petshop.sysl"
+          start: {
+            line: 2
+            col: 4
+          }
+          end: {
+            line: 8
+            col: 4
+          }
+        }
+      }
+    }
+    types: {
       key: "EmployeeTendsPet"
-      value: <
-        relation: <
-          attr_defs: <
+      value: {
+        relation: {
+          attr_defs: {
             key: "employeeId"
-            value: <
-              type_ref: <
-                context: <
-                  appname: <
+            value: {
+              type_ref: {
+                context: {
+                  appname: {
                     part: "PetShopModel"
-                  >
+                  }
                   path: "EmployeeTendsPet"
-                >
-                ref: <
+                }
+                ref: {
                   path: "Employee"
                   path: "employeeId"
-                >
-              >
-              attrs: <
+                }
+              }
+              attrs: {
                 key: "patterns"
-                value: <
-                  a: <
-                    elt: <
+                value: {
+                  a: {
+                    elt: {
                       s: "pk"
-                    >
-                  >
-                >
-              >
-              source_context: <
+                    }
+                  }
+                }
+              }
+              source_context: {
                 file: "tests/petshop.sysl"
-                start: <
+                start: {
                   line: 25
                   col: 22
-                >
-                end: <
+                }
+                end: {
                   line: 25
                   col: 46
-                >
-              >
-            >
-          >
-          attr_defs: <
+                }
+              }
+            }
+          }
+          attr_defs: {
             key: "petId"
-            value: <
-              type_ref: <
-                context: <
-                  appname: <
+            value: {
+              type_ref: {
+                context: {
+                  appname: {
                     part: "PetShopModel"
-                  >
+                  }
                   path: "EmployeeTendsPet"
-                >
-                ref: <
+                }
+                ref: {
                   path: "Pet"
                   path: "petId"
-                >
-              >
-              attrs: <
+                }
+              }
+              attrs: {
                 key: "patterns"
-                value: <
-                  a: <
-                    elt: <
+                value: {
+                  a: {
+                    elt: {
                       s: "pk"
-                    >
-                  >
-                >
-              >
-              source_context: <
+                    }
+                  }
+                }
+              }
+              source_context: {
                 file: "tests/petshop.sysl"
-                start: <
+                start: {
                   line: 26
                   col: 17
-                >
-                end: <
+                }
+                end: {
                   line: 26
                   col: 31
-                >
-              >
-            >
-          >
-          primary_key: <
+                }
+              }
+            }
+          }
+          primary_key: {
             attr_name: "employeeId"
             attr_name: "petId"
-          >
-        >
-      >
-    >
-    types: <
+          }
+        }
+        source_context: {
+          file: "tests/petshop.sysl"
+          start: {
+            line: 24
+            col: 4
+          }
+          end: {
+            line: 29
+            col: 13
+          }
+        }
+      }
+    }
+    types: {
       key: "Pet"
-      value: <
-        relation: <
-          attr_defs: <
+      value: {
+        relation: {
+          attr_defs: {
             key: "breedId"
-            value: <
-              type_ref: <
-                context: <
-                  appname: <
+            value: {
+              type_ref: {
+                context: {
+                  appname: {
                     part: "PetShopModel"
-                  >
+                  }
                   path: "Pet"
-                >
-                ref: <
+                }
+                ref: {
                   path: "Breed"
                   path: "breedId"
-                >
-              >
-              source_context: <
+                }
+              }
+              source_context: {
                 file: "tests/petshop.sysl"
-                start: <
+                start: {
                   line: 19
                   col: 19
-                >
-                end: <
+                }
+                end: {
                   line: 19
                   col: 25
-                >
-              >
-            >
-          >
-          attr_defs: <
+                }
+              }
+            }
+          }
+          attr_defs: {
             key: "dob"
-            value: <
+            value: {
               primitive: DATE
               opt: true
-              source_context: <
+              source_context: {
                 file: "tests/petshop.sysl"
-                start: <
+                start: {
                   line: 21
                   col: 15
-                >
-                end: <
+                }
+                end: {
                   line: 21
                   col: 19
-                >
-              >
-            >
-          >
-          attr_defs: <
+                }
+              }
+            }
+          }
+          attr_defs: {
             key: "name"
-            value: <
+            value: {
               primitive: STRING
               opt: true
-              source_context: <
+              source_context: {
                 file: "tests/petshop.sysl"
-                start: <
+                start: {
                   line: 20
                   col: 16
-                >
-                end: <
+                }
+                end: {
                   line: 20
                   col: 22
-                >
-              >
-            >
-          >
-          attr_defs: <
+                }
+              }
+            }
+          }
+          attr_defs: {
             key: "numLegs"
-            value: <
+            value: {
               primitive: INT
               opt: true
-              source_context: <
+              source_context: {
                 file: "tests/petshop.sysl"
-                start: <
+                start: {
                   line: 22
                   col: 19
-                >
-                end: <
+                }
+                end: {
                   line: 22
                   col: 22
-                >
-              >
-            >
-          >
-          attr_defs: <
+                }
+              }
+            }
+          }
+          attr_defs: {
             key: "petId"
-            value: <
+            value: {
               primitive: INT
-              attrs: <
+              attrs: {
                 key: "patterns"
-                value: <
-                  a: <
-                    elt: <
+                value: {
+                  a: {
+                    elt: {
                       s: "pk"
-                    >
-                    elt: <
+                    }
+                    elt: {
                       s: "autoinc"
-                    >
-                  >
-                >
-              >
-              source_context: <
+                    }
+                  }
+                }
+              }
+              source_context: {
                 file: "tests/petshop.sysl"
-                start: <
+                start: {
                   line: 18
                   col: 17
-                >
-                end: <
+                }
+                end: {
                   line: 18
                   col: 35
-                >
-              >
-            >
-          >
-          primary_key: <
+                }
+              }
+            }
+          }
+          primary_key: {
             attr_name: "petId"
-          >
-        >
-      >
-    >
-  >
->
-apps: <
+          }
+        }
+        source_context: {
+          file: "tests/petshop.sysl"
+          start: {
+            line: 17
+            col: 4
+          }
+          end: {
+            line: 24
+            col: 4
+          }
+        }
+      }
+    }
+    source_context: {
+      file: "tests/petshop.sysl"
+      start: {
+        line: 1
+        col: 1
+      }
+      end: {
+        line: 1
+        col: 50
+      }
+    }
+  }
+}
+apps: {
   key: "PetShopModelToApi"
-  value: <
-    name: <
+  value: {
+    name: {
       part: "PetShopModelToApi"
-    >
-    attrs: <
+    }
+    attrs: {
       key: "package"
-      value: <
+      value: {
         s: "io.sysl.demo.petshop.views"
-      >
-    >
-    types: <
+      }
+    }
+    types: {
       key: "PetRankedByLeg"
-      value: <
-        tuple: <
-          attr_defs: <
+      value: {
+        tuple: {
+          attr_defs: {
             key: "breedId"
-            value: <
+            value: {
               primitive: INT
-              source_context: <
+              source_context: {
                 file: "tests/petshop.sysl"
-                start: <
+                start: {
                   line: 117
                   col: 19
-                >
-                end: <
+                }
+                end: {
                   line: 117
                   col: 19
-                >
-              >
-            >
-          >
-          attr_defs: <
+                }
+              }
+            }
+          }
+          attr_defs: {
             key: "dob"
-            value: <
+            value: {
               primitive: DATE
               opt: true
-              source_context: <
+              source_context: {
                 file: "tests/petshop.sysl"
-                start: <
+                start: {
                   line: 119
                   col: 15
-                >
-                end: <
+                }
+                end: {
                   line: 119
                   col: 19
-                >
-              >
-            >
-          >
-          attr_defs: <
+                }
+              }
+            }
+          }
+          attr_defs: {
             key: "legRank"
-            value: <
+            value: {
               primitive: INT
               opt: true
-              source_context: <
+              source_context: {
                 file: "tests/petshop.sysl"
-                start: <
+                start: {
                   line: 121
                   col: 19
-                >
-                end: <
+                }
+                end: {
                   line: 121
                   col: 22
-                >
-              >
-            >
-          >
-          attr_defs: <
+                }
+              }
+            }
+          }
+          attr_defs: {
             key: "name"
-            value: <
+            value: {
               primitive: STRING
               opt: true
-              source_context: <
+              source_context: {
                 file: "tests/petshop.sysl"
-                start: <
+                start: {
                   line: 118
                   col: 16
-                >
-                end: <
+                }
+                end: {
                   line: 118
                   col: 22
-                >
-              >
-            >
-          >
-          attr_defs: <
+                }
+              }
+            }
+          }
+          attr_defs: {
             key: "numLegs"
-            value: <
+            value: {
               primitive: INT
               opt: true
-              source_context: <
+              source_context: {
                 file: "tests/petshop.sysl"
-                start: <
+                start: {
                   line: 120
                   col: 19
-                >
-                end: <
+                }
+                end: {
                   line: 120
                   col: 22
-                >
-              >
-            >
-          >
-          attr_defs: <
+                }
+              }
+            }
+          }
+          attr_defs: {
             key: "petId"
-            value: <
+            value: {
               primitive: INT
-              source_context: <
+              source_context: {
                 file: "tests/petshop.sysl"
-                start: <
+                start: {
                   line: 116
                   col: 17
-                >
-                end: <
+                }
+                end: {
                   line: 116
                   col: 17
-                >
-              >
-            >
-          >
-        >
-      >
-    >
-    views: <
+                }
+              }
+            }
+          }
+        }
+        source_context: {
+          file: "tests/petshop.sysl"
+          start: {
+            line: 115
+            col: 4
+          }
+          end: {
+            line: 124
+            col: 17
+          }
+        }
+      }
+    }
+    views: {
       key: "breedToApi"
-      value: <
-        param: <
+      value: {
+        param: {
           name: "breed"
-          type: <
-            set: <
-              type_ref: <
-                ref: <
-                  appname: <
+          type: {
+            set: {
+              type_ref: {
+                ref: {
+                  appname: {
                     part: "PetShopModel"
-                  >
+                  }
                   path: "Breed"
-                >
-              >
-            >
-          >
-        >
-        param: <
+                }
+              }
+            }
+          }
+        }
+        param: {
           name: "pet"
-          type: <
-            set: <
-              type_ref: <
-                ref: <
-                  appname: <
+          type: {
+            set: {
+              type_ref: {
+                ref: {
+                  appname: {
                     part: "PetShopModelToApi"
-                  >
+                  }
                   path: "PetRankedByLeg"
-                >
-              >
-            >
-          >
-        >
-        ret_type: <
-          set: <
-            type_ref: <
-              context: <
-                appname: <
+                }
+              }
+            }
+          }
+        }
+        ret_type: {
+          set: {
+            type_ref: {
+              context: {
+                appname: {
                   part: "PetShopModelToApi"
-                >
-              >
-              ref: <
-                appname: <
+                }
+              }
+              ref: {
+                appname: {
                   part: "PetShopApi"
-                >
+                }
                 path: "Breed"
-              >
-            >
-          >
-        >
-        expr: <
-          transform: <
-            arg: <
+              }
+            }
+          }
+        }
+        expr: {
+          transform: {
+            arg: {
               name: "breed"
-            >
+              source_context: {
+                file: "tests/petshop.sysl"
+                start: {
+                  line: 97
+                  col: 8
+                }
+                end: {
+                  line: 97
+                  col: 8
+                }
+              }
+            }
             scopevar: "."
-            stmt: <
-              assign: <
+            stmt: {
+              assign: {
                 name: "name"
-                expr: <
-                  get_attr: <
-                    arg: <
+                expr: {
+                  get_attr: {
+                    arg: {
                       name: "."
-                    >
+                      source_context: {
+                        file: "tests/petshop.sysl"
+                        start: {
+                          line: 98
+                          col: 19
+                        }
+                        end: {
+                          line: 98
+                          col: 20
+                        }
+                      }
+                    }
                     attr: "breedName"
-                  >
-                >
-              >
-            >
-            stmt: <
-              assign: <
+                  }
+                  source_context: {
+                    file: "tests/petshop.sysl"
+                    start: {
+                      line: 98
+                      col: 12
+                    }
+                    end: {
+                      line: 98
+                      col: 20
+                    }
+                    text: "name = .breedName"
+                  }
+                }
+              }
+            }
+            stmt: {
+              assign: {
                 name: "species"
-                expr: <
-                  get_attr: <
-                    arg: <
+                expr: {
+                  get_attr: {
+                    arg: {
                       name: "."
-                    >
+                      source_context: {
+                        file: "tests/petshop.sysl"
+                        start: {
+                          line: 99
+                          col: 12
+                        }
+                        end: {
+                          line: 99
+                          col: 12
+                        }
+                      }
+                    }
                     attr: "species"
-                  >
-                >
-              >
-            >
-            stmt: <
-              assign: <
+                  }
+                  source_context: {
+                    file: "tests/petshop.sysl"
+                    start: {
+                      line: 99
+                      col: 12
+                    }
+                    end: {
+                      line: 99
+                      col: 12
+                    }
+                  }
+                }
+              }
+            }
+            stmt: {
+              assign: {
                 name: "pets"
-                expr: <
-                  call: <
+                expr: {
+                  call: {
                     func: "petToApi"
-                    arg: <
-                      binexpr: <
+                    arg: {
+                      binexpr: {
                         op: TO_MATCHING
-                        lhs: <
-                          navigate: <
-                            arg: <
+                        lhs: {
+                          navigate: {
+                            arg: {
                               name: "."
-                            >
+                              source_context: {
+                                file: "tests/petshop.sysl"
+                                start: {
+                                  line: 100
+                                  col: 28
+                                }
+                                end: {
+                                  line: 100
+                                  col: 38
+                                }
+                              }
+                            }
                             attr: "Pet"
                             setof: true
-                          >
-                        >
-                        rhs: <
+                          }
+                          source_context: {
+                            file: "tests/petshop.sysl"
+                            start: {
+                              line: 100
+                              col: 28
+                            }
+                            end: {
+                              line: 100
+                              col: 38
+                            }
+                          }
+                        }
+                        rhs: {
                           name: "pet"
-                        >
+                          source_context: {
+                            file: "tests/petshop.sysl"
+                            start: {
+                              line: 100
+                              col: 52
+                            }
+                            end: {
+                              line: 100
+                              col: 52
+                            }
+                          }
+                        }
                         attr_name: "petId"
-                      >
-                    >
-                  >
-                >
-              >
-            >
-            stmt: <
-              assign: <
+                      }
+                      source_context: {
+                        file: "tests/petshop.sysl"
+                        start: {
+                          line: 100
+                          col: 42
+                        }
+                        end: {
+                          line: 100
+                          col: 52
+                        }
+                      }
+                    }
+                  }
+                  source_context: {
+                    file: "tests/petshop.sysl"
+                    start: {
+                      line: 100
+                      col: 12
+                    }
+                    end: {
+                      line: 100
+                      col: 55
+                    }
+                    text: "pets = petToApi(-> set of Pet ~[petId]> pet)"
+                  }
+                }
+              }
+            }
+            stmt: {
+              assign: {
                 name: "avgLifespan"
-                expr: <
-                  unexpr: <
+                expr: {
+                  unexpr: {
                     op: NEG
-                    arg: <
-                      literal: <
+                    arg: {
+                      literal: {
                         decimal: "1.0"
-                      >
-                    >
-                  >
-                >
-              >
-            >
-            stmt: <
-              assign: <
+                      }
+                      type: {
+                        primitive: DECIMAL
+                      }
+                      source_context: {
+                        file: "tests/petshop.sysl"
+                        start: {
+                          line: 101
+                          col: 27
+                        }
+                        end: {
+                          line: 101
+                          col: 27
+                        }
+                      }
+                    }
+                  }
+                  type: {
+                    primitive: INT
+                  }
+                  source_context: {
+                    file: "tests/petshop.sysl"
+                    start: {
+                      line: 101
+                      col: 12
+                    }
+                    end: {
+                      line: 101
+                      col: 27
+                    }
+                    text: "avgLifespan = -1.0"
+                  }
+                }
+              }
+            }
+            stmt: {
+              assign: {
                 name: "index"
-                expr: <
-                  call: <
+                expr: {
+                  call: {
                     func: "autoinc"
-                    arg: <
-                      literal: <
+                    arg: {
+                      literal: {
                         s: "Breed"
-                      >
-                    >
-                  >
-                >
-              >
-            >
-          >
-          type: <
-            set: <
-              type_ref: <
-                context: <
-                  appname: <
+                      }
+                      source_context: {
+                        file: "tests/petshop.sysl"
+                        start: {
+                          line: 102
+                          col: 28
+                        }
+                        end: {
+                          line: 102
+                          col: 28
+                        }
+                      }
+                    }
+                  }
+                  source_context: {
+                    file: "tests/petshop.sysl"
+                    start: {
+                      line: 102
+                      col: 12
+                    }
+                    end: {
+                      line: 102
+                      col: 35
+                    }
+                    text: "index = autoinc(\"Breed\")"
+                  }
+                }
+              }
+            }
+          }
+          type: {
+            set: {
+              type_ref: {
+                context: {
+                  appname: {
                     part: "PetShopModelToApi"
-                  >
-                >
-                ref: <
-                  appname: <
+                  }
+                }
+                ref: {
+                  appname: {
                     part: "PetShopApi"
-                  >
+                  }
                   path: "Breed"
-                >
-              >
-            >
-          >
-        >
-      >
-    >
-    views: <
+                }
+              }
+            }
+          }
+          source_context: {
+            file: "tests/petshop.sysl"
+            start: {
+              line: 97
+              col: 8
+            }
+            end: {
+              line: 103
+              col: 9
+            }
+          }
+        }
+        source_context: {
+          file: "tests/petshop.sysl"
+          start: {
+            line: 96
+            col: 4
+          }
+          end: {
+            line: 105
+            col: 4
+          }
+          text: "!view breedToApi(breed <: set of PetShopModel.Breed, pet <: set of PetShopModelToApi.PetRankedByLeg):"
+        }
+      }
+    }
+    views: {
       key: "employeeToApi"
-      value: <
-        param: <
+      value: {
+        param: {
           name: "employee"
-          type: <
-            set: <
-              type_ref: <
-                ref: <
-                  appname: <
+          type: {
+            set: {
+              type_ref: {
+                ref: {
+                  appname: {
                     part: "PetShopModel"
-                  >
+                  }
                   path: "Employee"
-                >
-              >
-            >
-          >
-        >
-        ret_type: <
-          set: <
-            type_ref: <
-              context: <
-                appname: <
+                }
+              }
+            }
+          }
+        }
+        ret_type: {
+          set: {
+            type_ref: {
+              context: {
+                appname: {
                   part: "PetShopModelToApi"
-                >
-              >
-              ref: <
-                appname: <
+                }
+              }
+              ref: {
+                appname: {
                   part: "PetShopApi"
-                >
+                }
                 path: "Employee"
-              >
-            >
-          >
-        >
-        expr: <
-          transform: <
-            arg: <
+              }
+            }
+          }
+        }
+        expr: {
+          transform: {
+            arg: {
               name: "employee"
-            >
+              source_context: {
+                file: "tests/petshop.sysl"
+                start: {
+                  line: 90
+                  col: 8
+                }
+                end: {
+                  line: 90
+                  col: 8
+                }
+              }
+            }
             scopevar: "."
-            stmt: <
-              assign: <
+            stmt: {
+              assign: {
                 name: "name"
-                expr: <
-                  get_attr: <
-                    arg: <
+                expr: {
+                  get_attr: {
+                    arg: {
                       name: "."
-                    >
+                      source_context: {
+                        file: "tests/petshop.sysl"
+                        start: {
+                          line: 91
+                          col: 12
+                        }
+                        end: {
+                          line: 91
+                          col: 12
+                        }
+                      }
+                    }
                     attr: "name"
-                  >
-                >
-              >
-            >
-            stmt: <
-              assign: <
+                  }
+                  source_context: {
+                    file: "tests/petshop.sysl"
+                    start: {
+                      line: 91
+                      col: 12
+                    }
+                    end: {
+                      line: 91
+                      col: 12
+                    }
+                  }
+                }
+              }
+            }
+            stmt: {
+              assign: {
                 name: "dob"
-                expr: <
-                  get_attr: <
-                    arg: <
+                expr: {
+                  get_attr: {
+                    arg: {
                       name: "."
-                    >
+                      source_context: {
+                        file: "tests/petshop.sysl"
+                        start: {
+                          line: 92
+                          col: 12
+                        }
+                        end: {
+                          line: 92
+                          col: 12
+                        }
+                      }
+                    }
                     attr: "dob"
-                  >
-                >
-              >
-            >
-            stmt: <
-              assign: <
+                  }
+                  source_context: {
+                    file: "tests/petshop.sysl"
+                    start: {
+                      line: 92
+                      col: 12
+                    }
+                    end: {
+                      line: 92
+                      col: 12
+                    }
+                  }
+                }
+              }
+            }
+            stmt: {
+              assign: {
                 name: "index"
-                expr: <
-                  call: <
+                expr: {
+                  call: {
                     func: "autoinc"
-                    arg: <
-                      literal: <
+                    arg: {
+                      literal: {
                         s: "Employee"
-                      >
-                    >
-                  >
-                >
-              >
-            >
-          >
-          type: <
-            set: <
-              type_ref: <
-                context: <
-                  appname: <
+                      }
+                      source_context: {
+                        file: "tests/petshop.sysl"
+                        start: {
+                          line: 93
+                          col: 28
+                        }
+                        end: {
+                          line: 93
+                          col: 28
+                        }
+                      }
+                    }
+                  }
+                  source_context: {
+                    file: "tests/petshop.sysl"
+                    start: {
+                      line: 93
+                      col: 12
+                    }
+                    end: {
+                      line: 93
+                      col: 38
+                    }
+                    text: "index = autoinc(\"Employee\")"
+                  }
+                }
+              }
+            }
+          }
+          type: {
+            set: {
+              type_ref: {
+                context: {
+                  appname: {
                     part: "PetShopModelToApi"
-                  >
-                >
-                ref: <
-                  appname: <
+                  }
+                }
+                ref: {
+                  appname: {
                     part: "PetShopApi"
-                  >
+                  }
                   path: "Employee"
-                >
-              >
-            >
-          >
-        >
-      >
-    >
-    views: <
+                }
+              }
+            }
+          }
+          source_context: {
+            file: "tests/petshop.sysl"
+            start: {
+              line: 90
+              col: 8
+            }
+            end: {
+              line: 94
+              col: 9
+            }
+          }
+        }
+        source_context: {
+          file: "tests/petshop.sysl"
+          start: {
+            line: 89
+            col: 4
+          }
+          end: {
+            line: 96
+            col: 4
+          }
+          text: "!view employeeToApi(employee <: set of PetShopModel.Employee):"
+        }
+      }
+    }
+    views: {
       key: "fibonacci"
-      value: <
-        param: <
+      value: {
+        param: {
           name: "n"
-          type: <
+          type: {
             primitive: INT
-          >
-        >
-        ret_type: <
+          }
+        }
+        ret_type: {
           primitive: INT
-        >
-        attrs: <
+        }
+        attrs: {
           key: "patterns"
-          value: <
-            a: <
-              elt: <
+          value: {
+            a: {
+              elt: {
                 s: "abstract"
-              >
-            >
-          >
-        >
-      >
-    >
-    views: <
+              }
+            }
+          }
+        }
+        source_context: {
+          file: "tests/petshop.sysl"
+          start: {
+            line: 113
+            col: 4
+          }
+          end: {
+            line: 113
+            col: 37
+          }
+          text: "!view fibonacci(n <: int) -> int [~abstract]"
+        }
+      }
+    }
+    views: {
       key: "modelToApi"
-      value: <
-        param: <
+      value: {
+        param: {
           name: "petshop"
-          type: <
-            type_ref: <
-              ref: <
-                appname: <
+          type: {
+            type_ref: {
+              ref: {
+                appname: {
                   part: "PetShopModel"
-                >
-              >
-            >
-          >
-        >
-        ret_type: <
-          type_ref: <
-            context: <
-              appname: <
+                }
+              }
+            }
+          }
+        }
+        ret_type: {
+          type_ref: {
+            context: {
+              appname: {
                 part: "PetShopModelToApi"
-              >
-            >
-            ref: <
-              appname: <
+              }
+            }
+            ref: {
+              appname: {
                 part: "PetShopApi"
-              >
+              }
               path: "PetShop"
-            >
-          >
-        >
-        expr: <
-          transform: <
-            arg: <
+            }
+          }
+        }
+        expr: {
+          transform: {
+            arg: {
               name: "petshop"
-            >
+              source_context: {
+                file: "tests/petshop.sysl"
+                start: {
+                  line: 68
+                  col: 8
+                }
+                end: {
+                  line: 68
+                  col: 8
+                }
+              }
+            }
             scopevar: "."
-            stmt: <
-              let: <
+            stmt: {
+              let: {
                 name: "rankedPets"
-                expr: <
-                  relexpr: <
+                expr: {
+                  relexpr: {
                     op: RANK
-                    target: <
-                      get_attr: <
-                        arg: <
+                    target: {
+                      get_attr: {
+                        arg: {
                           name: "."
-                        >
+                          source_context: {
+                            file: "tests/petshop.sysl"
+                            start: {
+                              line: 69
+                              col: 29
+                            }
+                            end: {
+                              line: 69
+                              col: 39
+                            }
+                          }
+                        }
                         attr: "Pet"
                         setof: true
-                      >
-                    >
-                    arg: <
-                      get_attr: <
-                        arg: <
+                      }
+                      source_context: {
+                        file: "tests/petshop.sysl"
+                        start: {
+                          line: 69
+                          col: 29
+                        }
+                        end: {
+                          line: 69
+                          col: 39
+                        }
+                      }
+                    }
+                    arg: {
+                      get_attr: {
+                        arg: {
                           name: "."
-                        >
+                          source_context: {
+                            file: "tests/petshop.sysl"
+                            start: {
+                              line: 69
+                              col: 82
+                            }
+                            end: {
+                              line: 69
+                              col: 83
+                            }
+                          }
+                        }
                         attr: "numLegs"
-                      >
-                    >
-                    arg: <
-                      get_attr: <
-                        arg: <
+                      }
+                      source_context: {
+                        file: "tests/petshop.sysl"
+                        start: {
+                          line: 69
+                          col: 82
+                        }
+                        end: {
+                          line: 69
+                          col: 83
+                        }
+                      }
+                    }
+                    arg: {
+                      get_attr: {
+                        arg: {
                           name: "."
-                        >
+                          source_context: {
+                            file: "tests/petshop.sysl"
+                            start: {
+                              line: 69
+                              col: 82
+                            }
+                            end: {
+                              line: 69
+                              col: 83
+                            }
+                          }
+                        }
                         attr: "numLegs"
-                      >
-                    >
+                      }
+                      source_context: {
+                        file: "tests/petshop.sysl"
+                        start: {
+                          line: 69
+                          col: 82
+                        }
+                        end: {
+                          line: 69
+                          col: 83
+                        }
+                      }
+                    }
                     scopevar: "."
                     descending: false
                     attr_name: "legRank"
-                  >
-                  type: <
-                    set: <
-                      type_ref: <
-                        ref: <
-                          appname: <
+                  }
+                  type: {
+                    set: {
+                      type_ref: {
+                        ref: {
+                          appname: {
                             part: "PetShopModelToApi"
-                          >
+                          }
                           path: "PetRankedByLeg"
-                        >
-                      >
-                    >
-                  >
-                >
-              >
-            >
-            stmt: <
-              assign: <
+                        }
+                      }
+                    }
+                  }
+                  source_context: {
+                    file: "tests/petshop.sysl"
+                    start: {
+                      line: 69
+                      col: 12
+                    }
+                    end: {
+                      line: 69
+                      col: 101
+                    }
+                    text: "let rankedPets = .table of Pet rank<PetShopModelToApi.PetRankedByLeg>(.numLegs as legRank)"
+                  }
+                }
+              }
+            }
+            stmt: {
+              assign: {
                 name: "employees"
-                expr: <
-                  call: <
+                expr: {
+                  call: {
                     func: "employeeToApi"
-                    arg: <
-                      get_attr: <
-                        arg: <
+                    arg: {
+                      get_attr: {
+                        arg: {
                           name: "."
-                        >
+                          source_context: {
+                            file: "tests/petshop.sysl"
+                            start: {
+                              line: 71
+                              col: 38
+                            }
+                            end: {
+                              line: 71
+                              col: 48
+                            }
+                          }
+                        }
                         attr: "Employee"
                         setof: true
-                      >
-                    >
-                  >
-                >
-              >
-            >
-            stmt: <
-              assign: <
+                      }
+                      source_context: {
+                        file: "tests/petshop.sysl"
+                        start: {
+                          line: 71
+                          col: 38
+                        }
+                        end: {
+                          line: 71
+                          col: 48
+                        }
+                      }
+                    }
+                  }
+                  source_context: {
+                    file: "tests/petshop.sysl"
+                    start: {
+                      line: 71
+                      col: 12
+                    }
+                    end: {
+                      line: 71
+                      col: 56
+                    }
+                    text: "employees = employeeToApi(.table of Employee)"
+                  }
+                }
+              }
+            }
+            stmt: {
+              assign: {
                 name: "breeds"
-                expr: <
-                  call: <
+                expr: {
+                  call: {
                     func: "breedToApi"
-                    arg: <
-                      get_attr: <
-                        arg: <
+                    arg: {
+                      get_attr: {
+                        arg: {
                           name: "."
-                        >
+                          source_context: {
+                            file: "tests/petshop.sysl"
+                            start: {
+                              line: 72
+                              col: 32
+                            }
+                            end: {
+                              line: 72
+                              col: 42
+                            }
+                          }
+                        }
                         attr: "Breed"
                         setof: true
-                      >
-                    >
-                    arg: <
+                      }
+                      source_context: {
+                        file: "tests/petshop.sysl"
+                        start: {
+                          line: 72
+                          col: 32
+                        }
+                        end: {
+                          line: 72
+                          col: 42
+                        }
+                      }
+                    }
+                    arg: {
                       name: "rankedPets"
-                    >
-                  >
-                >
-              >
-            >
-            stmt: <
-              assign: <
+                      source_context: {
+                        file: "tests/petshop.sysl"
+                        start: {
+                          line: 72
+                          col: 49
+                        }
+                        end: {
+                          line: 72
+                          col: 49
+                        }
+                      }
+                    }
+                  }
+                  source_context: {
+                    file: "tests/petshop.sysl"
+                    start: {
+                      line: 72
+                      col: 12
+                    }
+                    end: {
+                      line: 72
+                      col: 59
+                    }
+                    text: "breeds = breedToApi(.table of Breed, rankedPets)"
+                  }
+                }
+              }
+            }
+            stmt: {
+              assign: {
                 name: "numLegs"
-                expr: <
-                  relexpr: <
+                expr: {
+                  relexpr: {
                     op: SUM
-                    target: <
-                      get_attr: <
-                        arg: <
+                    target: {
+                      get_attr: {
+                        arg: {
                           name: "."
-                        >
+                          source_context: {
+                            file: "tests/petshop.sysl"
+                            start: {
+                              line: 73
+                              col: 22
+                            }
+                            end: {
+                              line: 73
+                              col: 32
+                            }
+                          }
+                        }
                         attr: "Pet"
                         setof: true
-                      >
-                    >
-                    arg: <
-                      binexpr: <
+                      }
+                      source_context: {
+                        file: "tests/petshop.sysl"
+                        start: {
+                          line: 73
+                          col: 22
+                        }
+                        end: {
+                          line: 73
+                          col: 32
+                        }
+                      }
+                    }
+                    arg: {
+                      binexpr: {
                         op: COALESCE
-                        lhs: <
-                          get_attr: <
-                            arg: <
+                        lhs: {
+                          get_attr: {
+                            arg: {
                               name: "."
-                            >
+                              source_context: {
+                                file: "tests/petshop.sysl"
+                                start: {
+                                  line: 73
+                                  col: 40
+                                }
+                                end: {
+                                  line: 73
+                                  col: 41
+                                }
+                              }
+                            }
                             attr: "numLegs"
-                          >
-                        >
-                        rhs: <
-                          literal: <
+                          }
+                          source_context: {
+                            file: "tests/petshop.sysl"
+                            start: {
+                              line: 73
+                              col: 40
+                            }
+                            end: {
+                              line: 73
+                              col: 41
+                            }
+                          }
+                        }
+                        rhs: {
+                          literal: {
                             i: 0
-                          >
-                        >
-                      >
-                    >
+                          }
+                          source_context: {
+                            file: "tests/petshop.sysl"
+                            start: {
+                              line: 73
+                              col: 52
+                            }
+                            end: {
+                              line: 73
+                              col: 52
+                            }
+                          }
+                        }
+                      }
+                      source_context: {
+                        file: "tests/petshop.sysl"
+                        start: {
+                          line: 73
+                          col: 40
+                        }
+                        end: {
+                          line: 73
+                          col: 52
+                        }
+                      }
+                    }
                     scopevar: "."
-                  >
-                >
-              >
-            >
-            stmt: <
-              let: <
+                  }
+                  source_context: {
+                    file: "tests/petshop.sysl"
+                    start: {
+                      line: 73
+                      col: 12
+                    }
+                    end: {
+                      line: 73
+                      col: 53
+                    }
+                    text: "numLegs = .table of Pet sum(.numLegs ?? 0)"
+                  }
+                }
+              }
+            }
+            stmt: {
+              let: {
                 name: "m"
-                expr: <
-                  relexpr: <
+                expr: {
+                  relexpr: {
                     op: MIN
-                    target: <
-                      get_attr: <
-                        arg: <
+                    target: {
+                      get_attr: {
+                        arg: {
                           name: "."
-                        >
+                          source_context: {
+                            file: "tests/petshop.sysl"
+                            start: {
+                              line: 75
+                              col: 20
+                            }
+                            end: {
+                              line: 75
+                              col: 30
+                            }
+                          }
+                        }
                         attr: "Pet"
                         setof: true
-                      >
-                    >
-                    arg: <
-                      binexpr: <
+                      }
+                      source_context: {
+                        file: "tests/petshop.sysl"
+                        start: {
+                          line: 75
+                          col: 20
+                        }
+                        end: {
+                          line: 75
+                          col: 30
+                        }
+                      }
+                    }
+                    arg: {
+                      binexpr: {
                         op: COALESCE
-                        lhs: <
-                          get_attr: <
-                            arg: <
+                        lhs: {
+                          get_attr: {
+                            arg: {
                               name: "."
-                            >
+                              source_context: {
+                                file: "tests/petshop.sysl"
+                                start: {
+                                  line: 75
+                                  col: 38
+                                }
+                                end: {
+                                  line: 75
+                                  col: 39
+                                }
+                              }
+                            }
                             attr: "numLegs"
-                          >
-                        >
-                        rhs: <
-                          literal: <
+                          }
+                          source_context: {
+                            file: "tests/petshop.sysl"
+                            start: {
+                              line: 75
+                              col: 38
+                            }
+                            end: {
+                              line: 75
+                              col: 39
+                            }
+                          }
+                        }
+                        rhs: {
+                          literal: {
                             i: 0
-                          >
-                        >
-                      >
-                    >
+                          }
+                          source_context: {
+                            file: "tests/petshop.sysl"
+                            start: {
+                              line: 75
+                              col: 50
+                            }
+                            end: {
+                              line: 75
+                              col: 50
+                            }
+                          }
+                        }
+                      }
+                      source_context: {
+                        file: "tests/petshop.sysl"
+                        start: {
+                          line: 75
+                          col: 38
+                        }
+                        end: {
+                          line: 75
+                          col: 50
+                        }
+                      }
+                    }
                     scopevar: "."
-                  >
-                >
-              >
-            >
-            stmt: <
-              let: <
+                  }
+                  source_context: {
+                    file: "tests/petshop.sysl"
+                    start: {
+                      line: 75
+                      col: 12
+                    }
+                    end: {
+                      line: 75
+                      col: 51
+                    }
+                    text: "let m = .table of Pet min(.numLegs ?? 0)"
+                  }
+                }
+              }
+            }
+            stmt: {
+              let: {
                 name: "a"
-                expr: <
-                  relexpr: <
+                expr: {
+                  relexpr: {
                     op: AVERAGE
-                    target: <
-                      get_attr: <
-                        arg: <
+                    target: {
+                      get_attr: {
+                        arg: {
                           name: "."
-                        >
+                          source_context: {
+                            file: "tests/petshop.sysl"
+                            start: {
+                              line: 76
+                              col: 20
+                            }
+                            end: {
+                              line: 76
+                              col: 30
+                            }
+                          }
+                        }
                         attr: "Pet"
                         setof: true
-                      >
-                    >
-                    arg: <
-                      binexpr: <
+                      }
+                      source_context: {
+                        file: "tests/petshop.sysl"
+                        start: {
+                          line: 76
+                          col: 20
+                        }
+                        end: {
+                          line: 76
+                          col: 30
+                        }
+                      }
+                    }
+                    arg: {
+                      binexpr: {
                         op: COALESCE
-                        lhs: <
-                          get_attr: <
-                            arg: <
+                        lhs: {
+                          get_attr: {
+                            arg: {
                               name: "."
-                            >
+                              source_context: {
+                                file: "tests/petshop.sysl"
+                                start: {
+                                  line: 76
+                                  col: 42
+                                }
+                                end: {
+                                  line: 76
+                                  col: 43
+                                }
+                              }
+                            }
                             attr: "numLegs"
-                          >
-                        >
-                        rhs: <
-                          literal: <
+                          }
+                          source_context: {
+                            file: "tests/petshop.sysl"
+                            start: {
+                              line: 76
+                              col: 42
+                            }
+                            end: {
+                              line: 76
+                              col: 43
+                            }
+                          }
+                        }
+                        rhs: {
+                          literal: {
                             i: 0
-                          >
-                        >
-                      >
-                    >
+                          }
+                          source_context: {
+                            file: "tests/petshop.sysl"
+                            start: {
+                              line: 76
+                              col: 54
+                            }
+                            end: {
+                              line: 76
+                              col: 54
+                            }
+                          }
+                        }
+                      }
+                      source_context: {
+                        file: "tests/petshop.sysl"
+                        start: {
+                          line: 76
+                          col: 42
+                        }
+                        end: {
+                          line: 76
+                          col: 54
+                        }
+                      }
+                    }
                     scopevar: "."
-                  >
-                >
-              >
-            >
-            stmt: <
-              let: <
+                  }
+                  source_context: {
+                    file: "tests/petshop.sysl"
+                    start: {
+                      line: 76
+                      col: 12
+                    }
+                    end: {
+                      line: 76
+                      col: 55
+                    }
+                    text: "let a = .table of Pet average(.numLegs ?? 0)"
+                  }
+                }
+              }
+            }
+            stmt: {
+              let: {
                 name: "pp"
-                expr: <
-                  get_attr: <
-                    arg: <
+                expr: {
+                  get_attr: {
+                    arg: {
                       name: "."
-                    >
+                      source_context: {
+                        file: "tests/petshop.sysl"
+                        start: {
+                          line: 79
+                          col: 21
+                        }
+                        end: {
+                          line: 79
+                          col: 31
+                        }
+                      }
+                    }
                     attr: "Pet"
                     setof: true
-                  >
-                >
-              >
-            >
-            stmt: <
-              let: <
+                  }
+                  source_context: {
+                    file: "tests/petshop.sysl"
+                    start: {
+                      line: 79
+                      col: 12
+                    }
+                    end: {
+                      line: 79
+                      col: 31
+                    }
+                    text: "let pp = .table of Pet"
+                  }
+                }
+              }
+            }
+            stmt: {
+              let: {
                 name: "bb"
-                expr: <
-                  binexpr: <
+                expr: {
+                  binexpr: {
                     op: TO_MATCHING
-                    lhs: <
+                    lhs: {
                       name: "pp"
-                    >
-                    rhs: <
-                      get_attr: <
-                        arg: <
+                      source_context: {
+                        file: "tests/petshop.sysl"
+                        start: {
+                          line: 80
+                          col: 21
+                        }
+                        end: {
+                          line: 80
+                          col: 21
+                        }
+                      }
+                    }
+                    rhs: {
+                      get_attr: {
+                        arg: {
                           name: "."
-                        >
+                          source_context: {
+                            file: "tests/petshop.sysl"
+                            start: {
+                              line: 80
+                              col: 27
+                            }
+                            end: {
+                              line: 80
+                              col: 37
+                            }
+                          }
+                        }
                         attr: "Breed"
                         setof: true
-                      >
-                    >
+                      }
+                      source_context: {
+                        file: "tests/petshop.sysl"
+                        start: {
+                          line: 80
+                          col: 27
+                        }
+                        end: {
+                          line: 80
+                          col: 37
+                        }
+                      }
+                    }
                     attr_name: "*"
-                  >
-                >
-              >
-            >
-            stmt: <
-              let: <
+                  }
+                  type: {
+                    no_type: {}
+                  }
+                  source_context: {
+                    file: "tests/petshop.sysl"
+                    start: {
+                      line: 80
+                      col: 12
+                    }
+                    end: {
+                      line: 80
+                      col: 37
+                    }
+                    text: "let bb = pp ~> .table of Breed"
+                  }
+                }
+              }
+            }
+            stmt: {
+              let: {
                 name: "yy"
-                expr: <
-                  binexpr: <
+                expr: {
+                  binexpr: {
                     op: TO_NOT_MATCHING
-                    lhs: <
+                    lhs: {
                       name: "pp"
-                    >
-                    rhs: <
-                      get_attr: <
-                        arg: <
+                      source_context: {
+                        file: "tests/petshop.sysl"
+                        start: {
+                          line: 81
+                          col: 21
+                        }
+                        end: {
+                          line: 81
+                          col: 21
+                        }
+                      }
+                    }
+                    rhs: {
+                      get_attr: {
+                        arg: {
                           name: "."
-                        >
+                          source_context: {
+                            file: "tests/petshop.sysl"
+                            start: {
+                              line: 81
+                              col: 28
+                            }
+                            end: {
+                              line: 81
+                              col: 38
+                            }
+                          }
+                        }
                         attr: "Breed"
                         setof: true
-                      >
-                    >
+                      }
+                      source_context: {
+                        file: "tests/petshop.sysl"
+                        start: {
+                          line: 81
+                          col: 28
+                        }
+                        end: {
+                          line: 81
+                          col: 38
+                        }
+                      }
+                    }
                     attr_name: "*"
-                  >
-                >
-              >
-            >
-            stmt: <
-              let: <
+                  }
+                  type: {
+                    no_type: {}
+                  }
+                  source_context: {
+                    file: "tests/petshop.sysl"
+                    start: {
+                      line: 81
+                      col: 12
+                    }
+                    end: {
+                      line: 81
+                      col: 38
+                    }
+                    text: "let yy = pp !~> .table of Breed"
+                  }
+                }
+              }
+            }
+            stmt: {
+              let: {
                 name: "p"
-                expr: <
-                  unexpr: <
+                expr: {
+                  unexpr: {
                     op: SINGLE_OR_NULL
-                    arg: <
-                      call: <
+                    arg: {
+                      call: {
                         func: ".any"
-                        arg: <
+                        arg: {
                           name: "pp"
-                        >
-                        arg: <
-                          literal: <
+                          source_context: {
+                            file: "tests/petshop.sysl"
+                            start: {
+                              line: 83
+                              col: 20
+                            }
+                            end: {
+                              line: 83
+                              col: 20
+                            }
+                          }
+                        }
+                        arg: {
+                          literal: {
                             i: 1
-                          >
-                        >
-                      >
-                    >
-                  >
-                >
-              >
-            >
-            stmt: <
-              let: <
+                          }
+                          source_context: {
+                            file: "tests/petshop.sysl"
+                            start: {
+                              line: 83
+                              col: 27
+                            }
+                            end: {
+                              line: 83
+                              col: 27
+                            }
+                          }
+                        }
+                      }
+                      source_context: {
+                        file: "tests/petshop.sysl"
+                        start: {
+                          line: 83
+                          col: 23
+                        }
+                        end: {
+                          line: 83
+                          col: 28
+                        }
+                      }
+                    }
+                  }
+                  type: {
+                    no_type: {}
+                  }
+                  source_context: {
+                    file: "tests/petshop.sysl"
+                    start: {
+                      line: 83
+                      col: 12
+                    }
+                    end: {
+                      line: 83
+                      col: 30
+                    }
+                    text: "let p = pp any(1) singleOrNull"
+                  }
+                }
+              }
+            }
+            stmt: {
+              let: {
                 name: "b"
-                expr: <
-                  navigate: <
-                    arg: <
+                expr: {
+                  navigate: {
+                    arg: {
                       name: "p"
-                    >
+                      source_context: {
+                        file: "tests/petshop.sysl"
+                        start: {
+                          line: 84
+                          col: 20
+                        }
+                        end: {
+                          line: 84
+                          col: 20
+                        }
+                      }
+                    }
                     attr: "Breed"
-                  >
-                >
-              >
-            >
-            stmt: <
-              let: <
+                  }
+                  source_context: {
+                    file: "tests/petshop.sysl"
+                    start: {
+                      line: 84
+                      col: 12
+                    }
+                    end: {
+                      line: 84
+                      col: 25
+                    }
+                    text: "let b = p -> Breed"
+                  }
+                }
+              }
+            }
+            stmt: {
+              let: {
                 name: "pp2"
-                expr: <
-                  navigate: <
-                    arg: <
+                expr: {
+                  navigate: {
+                    arg: {
                       name: "b"
-                    >
+                      source_context: {
+                        file: "tests/petshop.sysl"
+                        start: {
+                          line: 85
+                          col: 22
+                        }
+                        end: {
+                          line: 85
+                          col: 22
+                        }
+                      }
+                    }
                     attr: "Pet"
                     nullsafe: true
                     setof: true
-                  >
-                >
-              >
-            >
-          >
-          type: <
-            type_ref: <
-              context: <
-                appname: <
+                  }
+                  source_context: {
+                    file: "tests/petshop.sysl"
+                    start: {
+                      line: 85
+                      col: 12
+                    }
+                    end: {
+                      line: 85
+                      col: 35
+                    }
+                    text: "let pp2 = b ?-> set of Pet"
+                  }
+                }
+              }
+            }
+          }
+          type: {
+            type_ref: {
+              context: {
+                appname: {
                   part: "PetShopModelToApi"
-                >
-              >
-              ref: <
-                appname: <
+                }
+              }
+              ref: {
+                appname: {
                   part: "PetShopApi"
-                >
+                }
                 path: "PetShop"
-              >
-            >
-          >
-        >
-      >
-    >
-    views: <
+              }
+            }
+          }
+          source_context: {
+            file: "tests/petshop.sysl"
+            start: {
+              line: 68
+              col: 8
+            }
+            end: {
+              line: 87
+              col: 9
+            }
+          }
+        }
+        source_context: {
+          file: "tests/petshop.sysl"
+          start: {
+            line: 67
+            col: 4
+          }
+          end: {
+            line: 89
+            col: 4
+          }
+          text: "!view modelToApi(petshop <: PetShopModel):"
+        }
+      }
+    }
+    views: {
       key: "petToApi"
-      value: <
-        param: <
+      value: {
+        param: {
           name: "pet"
-          type: <
-            set: <
-              type_ref: <
-                ref: <
-                  appname: <
+          type: {
+            set: {
+              type_ref: {
+                ref: {
+                  appname: {
                     part: "PetShopModelToApi"
-                  >
+                  }
                   path: "PetRankedByLeg"
-                >
-              >
-            >
-          >
-        >
-        ret_type: <
-          set: <
-            type_ref: <
-              context: <
-                appname: <
+                }
+              }
+            }
+          }
+        }
+        ret_type: {
+          set: {
+            type_ref: {
+              context: {
+                appname: {
                   part: "PetShopModelToApi"
-                >
-              >
-              ref: <
-                appname: <
+                }
+              }
+              ref: {
+                appname: {
                   part: "PetShopApi"
-                >
+                }
                 path: "Pet"
-              >
-            >
-          >
-        >
-        expr: <
-          transform: <
-            arg: <
+              }
+            }
+          }
+        }
+        expr: {
+          transform: {
+            arg: {
               name: "pet"
-            >
+              source_context: {
+                file: "tests/petshop.sysl"
+                start: {
+                  line: 106
+                  col: 8
+                }
+                end: {
+                  line: 106
+                  col: 8
+                }
+              }
+            }
             scopevar: "."
-            stmt: <
-              assign: <
+            stmt: {
+              assign: {
                 name: "name"
-                expr: <
-                  get_attr: <
-                    arg: <
+                expr: {
+                  get_attr: {
+                    arg: {
                       name: "."
-                    >
+                      source_context: {
+                        file: "tests/petshop.sysl"
+                        start: {
+                          line: 107
+                          col: 12
+                        }
+                        end: {
+                          line: 107
+                          col: 12
+                        }
+                      }
+                    }
                     attr: "name"
-                  >
-                >
-              >
-            >
-            stmt: <
-              assign: <
+                  }
+                  source_context: {
+                    file: "tests/petshop.sysl"
+                    start: {
+                      line: 107
+                      col: 12
+                    }
+                    end: {
+                      line: 107
+                      col: 12
+                    }
+                  }
+                }
+              }
+            }
+            stmt: {
+              assign: {
                 name: "dob"
-                expr: <
-                  get_attr: <
-                    arg: <
+                expr: {
+                  get_attr: {
+                    arg: {
                       name: "."
-                    >
+                      source_context: {
+                        file: "tests/petshop.sysl"
+                        start: {
+                          line: 108
+                          col: 12
+                        }
+                        end: {
+                          line: 108
+                          col: 12
+                        }
+                      }
+                    }
                     attr: "dob"
-                  >
-                >
-              >
-            >
-            stmt: <
-              assign: <
+                  }
+                  source_context: {
+                    file: "tests/petshop.sysl"
+                    start: {
+                      line: 108
+                      col: 12
+                    }
+                    end: {
+                      line: 108
+                      col: 12
+                    }
+                  }
+                }
+              }
+            }
+            stmt: {
+              assign: {
                 name: "numLegs"
-                expr: <
-                  get_attr: <
-                    arg: <
+                expr: {
+                  get_attr: {
+                    arg: {
                       name: "."
-                    >
+                      source_context: {
+                        file: "tests/petshop.sysl"
+                        start: {
+                          line: 109
+                          col: 12
+                        }
+                        end: {
+                          line: 109
+                          col: 12
+                        }
+                      }
+                    }
                     attr: "numLegs"
-                  >
-                >
-              >
-            >
-            stmt: <
-              assign: <
+                  }
+                  source_context: {
+                    file: "tests/petshop.sysl"
+                    start: {
+                      line: 109
+                      col: 12
+                    }
+                    end: {
+                      line: 109
+                      col: 12
+                    }
+                  }
+                }
+              }
+            }
+            stmt: {
+              assign: {
                 name: "legRank"
-                expr: <
-                  call: <
+                expr: {
+                  call: {
                     func: "fibonacci"
-                    arg: <
-                      get_attr: <
-                        arg: <
+                    arg: {
+                      get_attr: {
+                        arg: {
                           name: "."
-                        >
+                          source_context: {
+                            file: "tests/petshop.sysl"
+                            start: {
+                              line: 110
+                              col: 32
+                            }
+                            end: {
+                              line: 110
+                              col: 33
+                            }
+                          }
+                        }
                         attr: "legRank"
-                      >
-                    >
-                  >
-                >
-              >
-            >
-          >
-          type: <
-            set: <
-              type_ref: <
-                context: <
-                  appname: <
+                      }
+                      source_context: {
+                        file: "tests/petshop.sysl"
+                        start: {
+                          line: 110
+                          col: 32
+                        }
+                        end: {
+                          line: 110
+                          col: 33
+                        }
+                      }
+                    }
+                  }
+                  source_context: {
+                    file: "tests/petshop.sysl"
+                    start: {
+                      line: 110
+                      col: 12
+                    }
+                    end: {
+                      line: 110
+                      col: 40
+                    }
+                    text: "legRank = fibonacci(.legRank)"
+                  }
+                }
+              }
+            }
+          }
+          type: {
+            set: {
+              type_ref: {
+                context: {
+                  appname: {
                     part: "PetShopModelToApi"
-                  >
-                >
-                ref: <
-                  appname: <
+                  }
+                }
+                ref: {
+                  appname: {
                     part: "PetShopApi"
-                  >
+                  }
                   path: "Pet"
-                >
-              >
-            >
-          >
-        >
-      >
-    >
-  >
->
+                }
+              }
+            }
+          }
+          source_context: {
+            file: "tests/petshop.sysl"
+            start: {
+              line: 106
+              col: 8
+            }
+            end: {
+              line: 111
+              col: 9
+            }
+          }
+        }
+        source_context: {
+          file: "tests/petshop.sysl"
+          start: {
+            line: 105
+            col: 4
+          }
+          end: {
+            line: 113
+            col: 4
+          }
+          text: "!view petToApi(pet <: set of PetShopModelToApi.PetRankedByLeg):"
+        }
+      }
+    }
+    source_context: {
+      file: "tests/petshop.sysl"
+      start: {
+        line: 66
+        col: 1
+      }
+      end: {
+        line: 66
+        col: 55
+      }
+    }
+  }
+}

--- a/pkg/parse/tests/project.sysl.golden.textpb
+++ b/pkg/parse/tests/project.sysl.golden.textpb
@@ -1,785 +1,1119 @@
-apps: <
+apps: {
   key: "A_B"
-  value: <
-    name: <
+  value: {
+    name: {
       part: "A_B"
-    >
-    endpoints: <
+    }
+    endpoints: {
       key: "C_D"
-      value: <
+      value: {
         name: "C_D"
-        stmt: <
-          call: <
-            target: <
+        stmt: {
+          call: {
+            target: {
               part: "anz_com"
-            >
+            }
             endpoint: "homepage"
-          >
-        >
-        stmt: <
-          call: <
-            target: <
+          }
+        }
+        stmt: {
+          call: {
+            target: {
               part: "Test - App"
-            >
+            }
             endpoint: "Test - Endpoint"
-          >
-        >
-      >
-    >
-    endpoints: <
+          }
+        }
+        source_context: {
+          file: "tests/test1.sysl"
+          start: {
+            line: 67
+            col: 4
+          }
+          end: {
+            line: 70
+            col: 4
+          }
+        }
+      }
+    }
+    endpoints: {
       key: "DDD"
-      value: <
+      value: {
         name: "DDD"
-        stmt: <
-          cond: <
+        stmt: {
+          cond: {
             test: "some condition is true"
-            stmt: <
-              action: <
+            stmt: {
+              action: {
                 action: "Test - App -> eventName"
-              >
-            >
-            stmt: <
-              call: <
-                target: <
+              }
+            }
+            stmt: {
+              call: {
+                target: {
                   part: "Test - App"
-                >
+                }
                 endpoint: "Endpoint2"
-              >
-            >
-            stmt: <
-              cond: <
+              }
+            }
+            stmt: {
+              cond: {
                 test: "result not ok"
-                stmt: <
-                  ret: <
+                stmt: {
+                  ret: {
                     payload: "not ok1"
-                  >
-                >
-              >
-            >
-            stmt: <
-              group: <
+                  }
+                }
+              }
+            }
+            stmt: {
+              group: {
                 title: "else"
-                stmt: <
-                  ret: <
+                stmt: {
+                  ret: {
                     payload: "ok"
-                  >
-                >
-              >
-            >
-          >
-        >
-        stmt: <
-          group: <
+                  }
+                }
+              }
+            }
+          }
+        }
+        stmt: {
+          group: {
             title: "else some other condition"
-            stmt: <
-              action: <
+            stmt: {
+              action: {
                 action: "top level else_statment"
-              >
-            >
-            stmt: <
-              cond: <
+              }
+            }
+            stmt: {
+              cond: {
                 test: "\"some constraint\""
-                stmt: <
-                  ret: <
+                stmt: {
+                  ret: {
                     payload: "ok"
-                  >
-                >
-              >
-            >
-            stmt: <
-              group: <
+                  }
+                }
+              }
+            }
+            stmt: {
+              group: {
                 title: "Else"
-                stmt: <
-                  ret: <
+                stmt: {
+                  ret: {
                     payload: "not ok"
-                  >
-                >
-              >
-            >
-          >
-        >
-        stmt: <
-          action: <
+                  }
+                }
+              }
+            }
+          }
+        }
+        stmt: {
+          action: {
             action: "do some more stuff"
-          >
-        >
-      >
-    >
-    endpoints: <
+          }
+        }
+        source_context: {
+          file: "tests/test1.sysl"
+          start: {
+            line: 70
+            col: 4
+          }
+          end: {
+            line: 87
+            col: 4
+          }
+        }
+      }
+    }
+    endpoints: {
       key: "EEE"
-      value: <
+      value: {
         name: "EEE"
-        stmt: <
-          action: <
+        stmt: {
+          action: {
             action: "..."
-          >
-        >
-      >
-    >
-    endpoints: <
+          }
+        }
+        source_context: {
+          file: "tests/test1.sysl"
+          start: {
+            line: 87
+            col: 4
+          }
+          end: {
+            line: 90
+            col: 4
+          }
+        }
+      }
+    }
+    endpoints: {
       key: "Send document to customer"
-      value: <
+      value: {
         name: "Send document to customer"
-      >
-    >
-  >
->
-apps: <
+        source_context: {
+          file: "tests/test1.sysl"
+          start: {
+            line: 90
+            col: 4
+          }
+          end: {
+            line: 90
+            col: 31
+          }
+        }
+      }
+    }
+    source_context: {
+      file: "tests/test1.sysl"
+      start: {
+        line: 66
+        col: 1
+      }
+      end: {
+        line: 66
+      }
+    }
+  }
+}
+apps: {
   key: "External :: App"
-  value: <
-    name: <
+  value: {
+    name: {
       part: "External"
       part: "App"
-    >
-    endpoints: <
+    }
+    endpoints: {
       key: "Endpoint"
-      value: <
+      value: {
         name: "Endpoint"
-        stmt: <
-          action: <
+        stmt: {
+          action: {
             action: "..."
-          >
-        >
-      >
-    >
-    types: <
+          }
+        }
+        source_context: {
+          file: "tests/test1.sysl"
+          start: {
+            line: 48
+            col: 4
+          }
+          end: {
+            line: 51
+            col: 4
+          }
+        }
+      }
+    }
+    types: {
       key: "Request"
-      value: <
-        tuple: <
-          attr_defs: <
+      value: {
+        tuple: {
+          attr_defs: {
             key: "id"
-            value: <
+            value: {
               primitive: INT
-              source_context: <
+              source_context: {
                 file: "tests/test1.sysl"
-                start: <
+                start: {
                   line: 52
                   col: 14
-                >
-                end: <
+                }
+                end: {
                   line: 52
                   col: 14
-                >
-              >
-            >
-          >
-          attr_defs: <
+                }
+              }
+            }
+          }
+          attr_defs: {
             key: "val"
-            value: <
+            value: {
               primitive: STRING
-              source_context: <
+              source_context: {
                 file: "tests/test1.sysl"
-                start: <
+                start: {
                   line: 53
                   col: 15
-                >
-                end: <
+                }
+                end: {
                   line: 53
                   col: 15
-                >
-              >
-            >
-          >
-        >
-      >
-    >
-    types: <
+                }
+              }
+            }
+          }
+        }
+        source_context: {
+          file: "tests/test1.sysl"
+          start: {
+            line: 51
+            col: 4
+          }
+          end: {
+            line: 54
+            col: 4
+          }
+        }
+      }
+    }
+    types: {
       key: "Response"
-      value: <
-        tuple: <
-          attr_defs: <
+      value: {
+        tuple: {
+          attr_defs: {
             key: "val"
-            value: <
+            value: {
               primitive: STRING
-              source_context: <
+              source_context: {
                 file: "tests/test1.sysl"
-                start: <
+                start: {
                   line: 55
                   col: 15
-                >
-                end: <
+                }
+                end: {
                   line: 55
                   col: 15
-                >
-              >
-            >
-          >
-        >
-      >
-    >
-  >
->
-apps: <
+                }
+              }
+            }
+          }
+        }
+        source_context: {
+          file: "tests/test1.sysl"
+          start: {
+            line: 54
+            col: 4
+          }
+          end: {
+            line: 57
+            col: 11
+          }
+        }
+      }
+    }
+    source_context: {
+      file: "tests/test1.sysl"
+      start: {
+        line: 47
+        col: 1
+      }
+      end: {
+        line: 47
+        col: 12
+      }
+    }
+  }
+}
+apps: {
   key: "My Todo App"
-  value: <
-    name: <
+  value: {
+    name: {
       part: "My Todo App"
-    >
-    attrs: <
+    }
+    attrs: {
       key: "patterns"
-      value: <
-        a: <
-          elt: <
+      value: {
+        a: {
+          elt: {
             s: "webapp"
-          >
-        >
-      >
-    >
-    endpoints: <
+          }
+        }
+      }
+    }
+    endpoints: {
       key: "Add Note"
-      value: <
+      value: {
         name: "Add Note"
-        attrs: <
+        attrs: {
           key: "patterns"
-          value: <
-            a: <
-              elt: <
+          value: {
+            a: {
+              elt: {
                 s: "somepattern"
-              >
-            >
-          >
-        >
-      >
-    >
-  >
->
-apps: <
+              }
+            }
+          }
+        }
+        source_context: {
+          file: "tests/test1.sysl"
+          start: {
+            line: 58
+            col: 4
+          }
+          end: {
+            line: 58
+            col: 29
+          }
+        }
+      }
+    }
+    source_context: {
+      file: "tests/test1.sysl"
+      start: {
+        line: 57
+        col: 1
+      }
+      end: {
+        line: 57
+        col: 20
+      }
+    }
+  }
+}
+apps: {
   key: "Project :: Integrations"
-  value: <
-    name: <
+  value: {
+    name: {
       part: "Project"
       part: "Integrations"
-    >
-    attrs: <
+    }
+    attrs: {
       key: "title"
-      value: <
+      value: {
         s: "%(epname): %(eplongname)"
-      >
-    >
-    endpoints: <
+      }
+    }
+    endpoints: {
       key: "PROJECT-E2E"
-      value: <
+      value: {
         name: "PROJECT-E2E"
         long_name: "End to End Integrations"
-        attrs: <
+        attrs: {
           key: "page"
-          value: <
+          value: {
             s: "Solution Design Doc"
-          >
-        >
-        attrs: <
+          }
+        }
+        attrs: {
           key: "passthrough"
-          value: <
-            a: <
-              elt: <
+          value: {
+            a: {
+              elt: {
                 s: "anz_com"
-              >
-              elt: <
+              }
+              elt: {
                 s: "My Todo App"
-              >
-              elt: <
+              }
+              elt: {
                 s: "A_B"
-              >
-            >
-          >
-        >
-        stmt: <
-          action: <
+              }
+            }
+          }
+        }
+        stmt: {
+          action: {
             action: "SomeApp"
-          >
-        >
-        stmt: <
-          action: <
+          }
+        }
+        stmt: {
+          action: {
             action: "Test - App"
-          >
-        >
-      >
-    >
-  >
->
-apps: <
+          }
+        }
+        source_context: {
+          file: "tests/project.sysl"
+          start: {
+            line: 5
+            col: 4
+          }
+          end: {
+            line: 9
+            col: 7
+          }
+        }
+      }
+    }
+    source_context: {
+      file: "tests/project.sysl"
+      start: {
+        line: 3
+        col: 1
+      }
+      end: {
+        line: 3
+        col: 57
+      }
+    }
+  }
+}
+apps: {
   key: "Project :: Sequences"
-  value: <
-    name: <
+  value: {
+    name: {
       part: "Project"
       part: "Sequences"
-    >
-    endpoints: <
+    }
+    endpoints: {
       key: "SEQ-One"
-      value: <
+      value: {
         name: "SEQ-One"
-        stmt: <
-          call: <
-            target: <
+        stmt: {
+          call: {
+            target: {
               part: "SomeApp"
-            >
+            }
             endpoint: "FooEndpoint"
-          >
-        >
-      >
-    >
-  >
->
-apps: <
+          }
+        }
+        source_context: {
+          file: "tests/project.sysl"
+          start: {
+            line: 11
+            col: 4
+          }
+          end: {
+            line: 15
+            col: 7
+          }
+        }
+      }
+    }
+    source_context: {
+      file: "tests/project.sysl"
+      start: {
+        line: 9
+        col: 1
+      }
+      end: {
+        line: 9
+        col: 11
+      }
+    }
+  }
+}
+apps: {
   key: "Rest Service"
-  value: <
-    name: <
+  value: {
+    name: {
       part: "Rest Service"
-    >
-    endpoints: <
+    }
+    endpoints: {
       key: ".. * <- *"
-      value: <
+      value: {
         name: ".. * <- *"
-        stmt: <
-          action: <
+        stmt: {
+          action: {
             action: "GET /foo"
-          >
-          attrs: <
+          }
+          attrs: {
             key: "some_id"
-            value: <
+            value: {
               s: "project_id"
-            >
-          >
-        >
-      >
-    >
-    endpoints: <
+            }
+          }
+        }
+        source_context: {
+          file: "tests/project.sysl"
+          start: {
+            line: 21
+            col: 4
+          }
+          end: {
+            line: 23
+          }
+        }
+      }
+    }
+    endpoints: {
       key: "GET /foo"
-      value: <
+      value: {
         name: "GET /foo"
-        attrs: <
+        attrs: {
           key: "patterns"
-          value: <
-            a: <
-              elt: <
+          value: {
+            a: {
+              elt: {
                 s: "rest"
-              >
-            >
-          >
-        >
-        attrs: <
+              }
+            }
+          }
+        }
+        attrs: {
           key: "some_id"
-          value: <
+          value: {
             s: "project_id"
-          >
-        >
-        stmt: <
-          action: <
+          }
+        }
+        stmt: {
+          action: {
             action: "..."
-          >
-        >
-        rest_params: <
+          }
+        }
+        rest_params: {
           method: GET
           path: "/foo"
-        >
-      >
-    >
-  >
->
-apps: <
+        }
+        source_context: {
+          file: "tests/test1.sysl"
+          start: {
+            line: 94
+            col: 8
+          }
+          end: {
+            line: 96
+          }
+        }
+      }
+    }
+    source_context: {
+      file: "tests/test1.sysl"
+      start: {
+        line: 92
+        col: 1
+      }
+      end: {
+        line: 92
+      }
+    }
+  }
+}
+apps: {
   key: "SomeApp"
-  value: <
-    name: <
+  value: {
+    name: {
       part: "SomeApp"
-    >
-    attrs: <
+    }
+    attrs: {
       key: "app_desc"
-      value: <
+      value: {
         s: "this comment belongs to the app defined 'above'"
-      >
-    >
-    attrs: <
+      }
+    }
+    attrs: {
       key: "array"
-      value: <
-        a: <
-          elt: <
+      value: {
+        a: {
+          elt: {
             s: "one"
-          >
-          elt: <
+          }
+          elt: {
             s: "two"
-          >
-        >
-      >
-    >
-    attrs: <
+          }
+        }
+      }
+    }
+    attrs: {
       key: "array_of_arrays"
-      value: <
-        a: <
-          elt: <
-            a: <
-              elt: <
+      value: {
+        a: {
+          elt: {
+            a: {
+              elt: {
                 s: "one"
-              >
-              elt: <
+              }
+              elt: {
                 s: "two"
-              >
-            >
-          >
-        >
-      >
-    >
-    attrs: <
+              }
+            }
+          }
+        }
+      }
+    }
+    attrs: {
       key: "comment"
-      value: <
+      value: {
         s: ""
-      >
-    >
-    attrs: <
+      }
+    }
+    attrs: {
       key: "comment.second"
-      value: <
+      value: {
         s: ""
-      >
-    >
-    attrs: <
+      }
+    }
+    attrs: {
       key: "package"
-      value: <
+      value: {
         s: ""
-      >
-    >
-    attrs: <
+      }
+    }
+    attrs: {
       key: "version"
-      value: <
+      value: {
         s: "1.1.1"
-      >
-    >
-    endpoints: <
+      }
+    }
+    endpoints: {
       key: ".. * <- *"
-      value: <
+      value: {
         name: ".. * <- *"
-        stmt: <
-          action: <
+        stmt: {
+          action: {
             action: "FooEndpoint"
-          >
-          attrs: <
+          }
+          attrs: {
             key: "some_id"
-            value: <
+            value: {
               s: "project_id"
-            >
-          >
-        >
-        stmt: <
-          call: <
-            target: <
+            }
+          }
+        }
+        stmt: {
+          call: {
+            target: {
               part: "Test - App"
-            >
+            }
             endpoint: "Test - Endpoint"
-          >
-          attrs: <
+          }
+          attrs: {
             key: "some_id"
-            value: <
+            value: {
               s: "project_id"
-            >
-          >
-        >
-      >
-    >
-    endpoints: <
+            }
+          }
+        }
+        source_context: {
+          file: "tests/project.sysl"
+          start: {
+            line: 16
+            col: 4
+          }
+          end: {
+            line: 20
+            col: 12
+          }
+        }
+      }
+    }
+    endpoints: {
       key: "Endpoint"
-      value: <
+      value: {
         name: "Endpoint"
-        stmt: <
-          action: <
+        stmt: {
+          action: {
             action: "..."
-          >
-        >
-      >
-    >
-    endpoints: <
+          }
+        }
+        source_context: {
+          file: "tests/test1.sysl"
+          start: {
+            line: 9
+            col: 4
+          }
+          end: {
+            line: 12
+            col: 4
+          }
+        }
+      }
+    }
+    endpoints: {
       key: "Event"
-      value: <
+      value: {
         name: "Event"
         is_pubsub: true
-        param: <
+        param: {
           name: "App.member"
-          type: <
-            no_type: <
-            >
-          >
-        >
-        param: <
+          type: {
+            no_type: {}
+          }
+        }
+        param: {
           name: "request"
-          type: <
-            type_ref: <
-              ref: <
-                appname: <
+          type: {
+            type_ref: {
+              ref: {
+                appname: {
                   part: "SomeApp"
-                >
+                }
                 path: "SomeType"
-              >
-            >
-          >
-        >
-        stmt: <
-          ret: <
+              }
+            }
+          }
+        }
+        stmt: {
+          ret: {
             payload: "\"customer details\""
-          >
-        >
-      >
-    >
-    endpoints: <
+          }
+        }
+        source_context: {
+          file: "tests/test1.sysl"
+          start: {
+            line: 6
+            col: 4
+          }
+          end: {
+            line: 9
+            col: 4
+          }
+        }
+      }
+    }
+    endpoints: {
       key: "FooEndpoint"
-      value: <
+      value: {
         name: "FooEndpoint"
-        attrs: <
+        attrs: {
           key: "some_id"
-          value: <
+          value: {
             s: "project_id"
-          >
-        >
-        stmt: <
-          call: <
-            target: <
+          }
+        }
+        stmt: {
+          call: {
+            target: {
               part: "Test - App"
-            >
+            }
             endpoint: "Test - Endpoint"
-          >
-          attrs: <
+          }
+          attrs: {
             key: "some_id"
-            value: <
+            value: {
               s: "project_id"
-            >
-          >
-        >
-      >
-    >
-    endpoints: <
+            }
+          }
+        }
+        source_context: {
+          file: "tests/test1.sysl"
+          start: {
+            line: 12
+            col: 4
+          }
+          end: {
+            line: 16
+            col: 4
+          }
+        }
+      }
+    }
+    endpoints: {
       key: "Test - App -> eventName"
-      value: <
+      value: {
         name: "Test - App -> eventName"
-        attrs: <
+        attrs: {
           key: "patterns"
-          value: <
-            a: <
-              elt: <
+          value: {
+            a: {
+              elt: {
                 s: "mq"
-              >
-            >
-          >
-        >
-        source: <
+              }
+            }
+          }
+        }
+        source: {
           part: "Test - App"
-        >
-        stmt: <
-          action: <
+        }
+        stmt: {
+          action: {
             action: "\"\""
-          >
-        >
-        stmt: <
-          action: <
+          }
+        }
+        stmt: {
+          action: {
             action: "''"
-          >
-        >
-        stmt: <
-          action: <
+          }
+        }
+        stmt: {
+          action: {
             action: "'asdf'"
-          >
-        >
-        stmt: <
-          action: <
+          }
+        }
+        stmt: {
+          action: {
             action: "\"quoted statement: use special chars here like ?? :: etc\""
-          >
-        >
-        stmt: <
-          action: <
+          }
+        }
+        stmt: {
+          action: {
             action: "\"test: single quotes 'above'\""
-          >
-        >
-        stmt: <
-          action: <
+          }
+        }
+        stmt: {
+          action: {
             action: "do something"
-          >
-        >
-        stmt: <
-          action: <
+          }
+        }
+        stmt: {
+          action: {
             action: "| Some multiline comments that you can use for documentation. This is last line."
-          >
-        >
-        stmt: <
-          action: <
+          }
+        }
+        stmt: {
+          action: {
             action: "handle event eventName"
-          >
-        >
-      >
-    >
-  >
->
-apps: <
+          }
+        }
+        source_context: {
+          file: "tests/test1.sysl"
+          start: {
+            line: 16
+            col: 4
+          }
+          end: {
+            line: 28
+            col: 10
+          }
+        }
+      }
+    }
+    source_context: {
+      file: "tests/test1.sysl"
+      start: {
+        line: 1
+        col: 1
+      }
+      end: {
+        line: 1
+        col: 92
+      }
+    }
+  }
+}
+apps: {
   key: "Test - App"
-  value: <
-    name: <
+  value: {
+    name: {
       part: "Test - App"
-    >
-    endpoints: <
+    }
+    endpoints: {
       key: "Endpoint2"
-      value: <
+      value: {
         name: "Endpoint2"
-        attrs: <
+        attrs: {
           key: "ep_desc"
-          value: <
+          value: {
             s: "this comment belongs to the Endpoint2 defined above"
-          >
-        >
-        param: <
+          }
+        }
+        param: {
           name: "request"
-          type: <
-            set: <
-              type_ref: <
-                ref: <
-                  appname: <
+          type: {
+            set: {
+              type_ref: {
+                ref: {
+                  appname: {
                     part: "SomeApp"
-                  >
+                  }
                   path: "SomeType"
-                >
-              >
-            >
-          >
-        >
-        stmt: <
-          action: <
+                }
+              }
+            }
+          }
+        }
+        stmt: {
+          action: {
             action: "| Single line statement"
-          >
-        >
-        stmt: <
-          call: <
-            target: <
+          }
+        }
+        stmt: {
+          call: {
+            target: {
               part: "Test - App"
-            >
+            }
             endpoint: "eventName"
-          >
-        >
-      >
-    >
-    endpoints: <
+          }
+        }
+        source_context: {
+          file: "tests/test1.sysl"
+          start: {
+            line: 39
+            col: 4
+          }
+          end: {
+            line: 44
+            col: 4
+          }
+        }
+      }
+    }
+    endpoints: {
       key: "Test - Endpoint"
-      value: <
+      value: {
         name: "Test - Endpoint"
-        param: <
+        param: {
           name: "request"
-          type: <
-            type_ref: <
-              ref: <
-                appname: <
+          type: {
+            type_ref: {
+              ref: {
+                appname: {
                   part: "SomeApp"
-                >
+                }
                 path: "SomeType"
-              >
-            >
-          >
-        >
-        stmt: <
-          call: <
-            target: <
+              }
+            }
+          }
+        }
+        stmt: {
+          call: {
+            target: {
               part: "External"
               part: "App"
-            >
+            }
             endpoint: "Endpoint"
-          >
-        >
-        stmt: <
-          call: <
-            target: <
+          }
+        }
+        stmt: {
+          call: {
+            target: {
               part: "Rest Service"
-            >
+            }
             endpoint: "GET /foo"
-          >
-        >
-        stmt: <
-          cond: <
+          }
+        }
+        stmt: {
+          cond: {
             test: "value == one"
-            stmt: <
-              action: <
+            stmt: {
+              action: {
                 action: "do something"
-              >
-            >
-          >
-        >
-        stmt: <
-          group: <
+              }
+            }
+          }
+        }
+        stmt: {
+          group: {
             title: "else if value == two"
-            stmt: <
-              action: <
+            stmt: {
+              action: {
                 action: "do something else"
-              >
-            >
-          >
-        >
-        stmt: <
-          group: <
+              }
+            }
+          }
+        }
+        stmt: {
+          group: {
             title: "else"
-            stmt: <
-              ret: <
+            stmt: {
+              ret: {
                 payload: "ok"
-              >
-            >
-          >
-        >
-      >
-    >
-    endpoints: <
+              }
+            }
+          }
+        }
+        source_context: {
+          file: "tests/test1.sysl"
+          start: {
+            line: 29
+            col: 4
+          }
+          end: {
+            line: 39
+            col: 4
+          }
+        }
+      }
+    }
+    endpoints: {
       key: "another event"
-      value: <
+      value: {
         name: "another event"
         is_pubsub: true
-      >
-    >
-    endpoints: <
+        source_context: {
+          file: "tests/test1.sysl"
+          start: {
+            line: 45
+            col: 4
+          }
+          end: {
+            line: 45
+            col: 23
+          }
+        }
+      }
+    }
+    endpoints: {
       key: "eventName"
-      value: <
+      value: {
         name: "eventName"
         is_pubsub: true
-        param: <
+        param: {
           name: "in"
-          type: <
+          type: {
             primitive: STRING
-          >
-        >
-        stmt: <
-          call: <
-            target: <
+          }
+        }
+        stmt: {
+          call: {
+            target: {
               part: "SomeApp"
-            >
+            }
             endpoint: "Test - App -> eventName"
-          >
-        >
-      >
-    >
-  >
->
-apps: <
+          }
+        }
+      }
+    }
+    source_context: {
+      file: "tests/test1.sysl"
+      start: {
+        line: 28
+        col: 1
+      }
+      end: {
+        line: 28
+      }
+    }
+  }
+}
+apps: {
   key: "anz_com"
-  value: <
-    name: <
+  value: {
+    name: {
       part: "anz_com"
-    >
-    endpoints: <
+    }
+    endpoints: {
       key: "homepage"
-      value: <
+      value: {
         name: "homepage"
-      >
-    >
-    types: <
+        source_context: {
+          file: "tests/test1.sysl"
+          start: {
+            line: 61
+            col: 4
+          }
+          end: {
+            line: 61
+            col: 14
+          }
+        }
+      }
+    }
+    types: {
       key: "Response"
-      value: <
-        tuple: <
-          attr_defs: <
+      value: {
+        tuple: {
+          attr_defs: {
             key: "val"
-            value: <
+            value: {
               primitive: STRING
-              source_context: <
+              source_context: {
                 file: "tests/test1.sysl"
-                start: <
+                start: {
                   line: 64
                   col: 15
-                >
-                end: <
+                }
+                end: {
                   line: 64
                   col: 15
-                >
-              >
-            >
-          >
-        >
-      >
-    >
-  >
->
+                }
+              }
+            }
+          }
+        }
+        source_context: {
+          file: "tests/test1.sysl"
+          start: {
+            line: 63
+            col: 4
+          }
+          end: {
+            line: 66
+            col: 3
+          }
+        }
+      }
+    }
+    source_context: {
+      file: "tests/test1.sysl"
+      start: {
+        line: 60
+        col: 1
+      }
+      end: {
+        line: 60
+      }
+    }
+  }
+}

--- a/pkg/parse/tests/pubsub_collector.sysl.golden.textpb
+++ b/pkg/parse/tests/pubsub_collector.sysl.golden.textpb
@@ -1,232 +1,394 @@
-apps {
+apps: {
   key: "Another :: Publisher"
-  value {
-    name {
+  value: {
+    name: {
       part: "Another"
       part: "Publisher"
     }
-    endpoints {
+    endpoints: {
       key: ".. * <- *"
-      value {
+      value: {
         name: ".. * <- *"
-        stmt {
-          call {
-            target {
+        stmt: {
+          call: {
+            target: {
               part: "My"
               part: "Subscriber"
             }
             endpoint: "Another :: Publisher -> BusinessEvent"
           }
-          attrs {
+          attrs: {
             key: "id"
-            value {
+            value: {
               s: "two"
             }
           }
         }
+        source_context: {
+          file: "tests/pubsub_collector.sysl"
+          start: {
+            line: 28
+            col: 4
+          }
+          end: {
+            line: 31
+            col: 3
+          }
+        }
       }
     }
-    endpoints {
+    endpoints: {
       key: "BusinessEvent"
-      value {
+      value: {
         name: "BusinessEvent"
         is_pubsub: true
-        stmt {
-          call {
-            target {
+        stmt: {
+          call: {
+            target: {
               part: "My"
               part: "Subscriber"
             }
             endpoint: "Another :: Publisher -> BusinessEvent"
           }
-          attrs {
+          attrs: {
             key: "id"
-            value {
+            value: {
               s: "two"
             }
           }
         }
+        source_context: {
+          file: "tests/pubsub_collector.sysl"
+          start: {
+            line: 8
+            col: 4
+          }
+          end: {
+            line: 8
+            col: 23
+          }
+        }
+      }
+    }
+    source_context: {
+      file: "tests/pubsub_collector.sysl"
+      start: {
+        line: 27
+        col: 1
+      }
+      end: {
+        line: 27
+        col: 11
       }
     }
   }
 }
-apps {
+apps: {
   key: "External"
-  value {
-    name {
+  value: {
+    name: {
       part: "External"
     }
-    endpoints {
+    endpoints: {
       key: "Endpoint"
-      value {
+      value: {
         name: "Endpoint"
+        source_context: {
+          file: "tests/pubsub_collector.sysl"
+          start: {
+            line: 5
+            col: 4
+          }
+          end: {
+            line: 5
+            col: 14
+          }
+        }
+      }
+    }
+    source_context: {
+      file: "tests/pubsub_collector.sysl"
+      start: {
+        line: 4
+        col: 1
+      }
+      end: {
+        line: 4
       }
     }
   }
 }
-apps {
+apps: {
   key: "My :: Subscriber"
-  value {
-    name {
+  value: {
+    name: {
       part: "My"
       part: "Subscriber"
     }
-    endpoints {
+    endpoints: {
       key: "Another :: Publisher -> BusinessEvent"
-      value {
+      value: {
         name: "Another :: Publisher -> BusinessEvent"
-        source {
+        source: {
           part: "Another"
           part: "Publisher"
         }
-        stmt {
-          call {
-            target {
+        stmt: {
+          call: {
+            target: {
               part: "External"
             }
             endpoint: "Endpoint"
           }
         }
+        source_context: {
+          file: "tests/pubsub_collector.sysl"
+          start: {
+            line: 17
+            col: 4
+          }
+          end: {
+            line: 20
+            col: 4
+          }
+        }
       }
     }
-    endpoints {
+    endpoints: {
       key: "Publisher -> BusinessEvent"
-      value {
+      value: {
         name: "Publisher -> BusinessEvent"
-        source {
+        source: {
           part: "Publisher"
         }
-        stmt {
-          call {
-            target {
+        stmt: {
+          call: {
+            target: {
               part: "External"
             }
             endpoint: "Endpoint"
           }
         }
+        source_context: {
+          file: "tests/pubsub_collector.sysl"
+          start: {
+            line: 14
+            col: 4
+          }
+          end: {
+            line: 17
+            col: 4
+          }
+        }
       }
     }
-    endpoints {
+    endpoints: {
       key: "Yet :: Another :: Publisher -> BusinessEvent"
-      value {
+      value: {
         name: "Yet :: Another :: Publisher -> BusinessEvent"
-        source {
+        source: {
           part: "Yet"
           part: "Another"
           part: "Publisher"
         }
-        stmt {
-          call {
-            target {
+        stmt: {
+          call: {
+            target: {
               part: "External"
             }
             endpoint: "Endpoint"
           }
         }
+        source_context: {
+          file: "tests/pubsub_collector.sysl"
+          start: {
+            line: 20
+            col: 4
+          }
+          end: {
+            line: 23
+            col: 9
+          }
+        }
+      }
+    }
+    source_context: {
+      file: "tests/pubsub_collector.sysl"
+      start: {
+        line: 13
+        col: 1
+      }
+      end: {
+        line: 13
+        col: 6
       }
     }
   }
 }
-apps {
+apps: {
   key: "Publisher"
-  value {
-    name {
+  value: {
+    name: {
       part: "Publisher"
     }
-    endpoints {
+    endpoints: {
       key: ".. * <- *"
-      value {
+      value: {
         name: ".. * <- *"
-        stmt {
-          call {
-            target {
+        stmt: {
+          call: {
+            target: {
               part: "My"
               part: "Subscriber"
             }
             endpoint: "Publisher -> BusinessEvent"
           }
-          attrs {
+          attrs: {
             key: "id"
-            value {
+            value: {
               s: "one"
             }
+          }
+        }
+        source_context: {
+          file: "tests/pubsub_collector.sysl"
+          start: {
+            line: 24
+            col: 4
+          }
+          end: {
+            line: 27
+            col: 7
           }
         }
       }
     }
-    endpoints {
+    endpoints: {
       key: "BusinessEvent"
-      value {
+      value: {
         name: "BusinessEvent"
         is_pubsub: true
-        stmt {
-          call {
-            target {
+        stmt: {
+          call: {
+            target: {
               part: "My"
               part: "Subscriber"
             }
             endpoint: "Publisher -> BusinessEvent"
           }
-          attrs {
+          attrs: {
             key: "id"
-            value {
+            value: {
               s: "one"
             }
           }
         }
+        source_context: {
+          file: "tests/pubsub_collector.sysl"
+          start: {
+            line: 2
+            col: 4
+          }
+          end: {
+            line: 2
+            col: 23
+          }
+        }
+      }
+    }
+    source_context: {
+      file: "tests/pubsub_collector.sysl"
+      start: {
+        line: 23
+        col: 1
+      }
+      end: {
+        line: 23
       }
     }
   }
 }
-apps {
+apps: {
   key: "Yet :: Another :: Publisher"
-  value {
-    name {
+  value: {
+    name: {
       part: "Yet"
       part: "Another"
       part: "Publisher"
     }
-    endpoints {
+    endpoints: {
       key: ".. * <- *"
-      value {
+      value: {
         name: ".. * <- *"
-        stmt {
-          call {
-            target {
+        stmt: {
+          call: {
+            target: {
               part: "My"
               part: "Subscriber"
             }
             endpoint: "Yet :: Another :: Publisher -> BusinessEvent"
           }
-          attrs {
+          attrs: {
             key: "id"
-            value {
+            value: {
               s: "three"
             }
+          }
+        }
+        source_context: {
+          file: "tests/pubsub_collector.sysl"
+          start: {
+            line: 32
+            col: 4
+          }
+          end: {
+            line: 35
           }
         }
       }
     }
-    endpoints {
+    endpoints: {
       key: "BusinessEvent"
-      value {
+      value: {
         name: "BusinessEvent"
         is_pubsub: true
-        stmt {
-          call {
-            target {
+        stmt: {
+          call: {
+            target: {
               part: "My"
               part: "Subscriber"
             }
             endpoint: "Yet :: Another :: Publisher -> BusinessEvent"
           }
-          attrs {
+          attrs: {
             key: "id"
-            value {
+            value: {
               s: "three"
             }
           }
         }
+        source_context: {
+          file: "tests/pubsub_collector.sysl"
+          start: {
+            line: 11
+            col: 4
+          }
+          end: {
+            line: 11
+            col: 23
+          }
+        }
+      }
+    }
+    source_context: {
+      file: "tests/pubsub_collector.sysl"
+      start: {
+        line: 31
+        col: 1
+      }
+      end: {
+        line: 31
+        col: 18
       }
     }
   }

--- a/pkg/parse/tests/rank.sysl.golden.textpb
+++ b/pkg/parse/tests/rank.sysl.golden.textpb
@@ -1,351 +1,976 @@
-apps {
+apps: {
   key: "TransformationTest"
-  value {
-    name {
+  value: {
+    name: {
       part: "TransformationTest"
     }
-    attrs {
+    attrs: {
       key: "package"
-      value {
+      value: {
         s: "io.sysl.test.views"
       }
     }
-    views {
+    views: {
       key: "TestRank"
-      value {
-        param {
+      value: {
+        param: {
           name: "number"
-          type {
+          type: {
             primitive: INT
           }
         }
-        ret_type {
+        ret_type: {
           primitive: INT
         }
-        expr {
-          transform {
-            arg {
+        expr: {
+          transform: {
+            arg: {
               name: "number"
+              source_context: {
+                file: "tests/rank.sysl"
+                start: {
+                  line: 3
+                  col: 4
+                }
+                end: {
+                  line: 3
+                  col: 4
+                }
+              }
             }
             scopevar: "."
-            stmt {
-              let {
+            stmt: {
+              let: {
                 name: "out1"
-                expr {
-                  relexpr {
+                expr: {
+                  relexpr: {
                     op: RANK
-                    target {
+                    target: {
                       name: "."
+                      source_context: {
+                        file: "tests/rank.sysl"
+                        start: {
+                          line: 4
+                          col: 17
+                        }
+                        end: {
+                          line: 4
+                          col: 34
+                        }
+                      }
                     }
-                    arg {
+                    arg: {
                       name: "abc"
+                      source_context: {
+                        file: "tests/rank.sysl"
+                        start: {
+                          line: 4
+                          col: 24
+                        }
+                        end: {
+                          line: 4
+                          col: 24
+                        }
+                      }
                     }
-                    arg {
+                    arg: {
                       name: "abc"
+                      source_context: {
+                        file: "tests/rank.sysl"
+                        start: {
+                          line: 4
+                          col: 24
+                        }
+                        end: {
+                          line: 4
+                          col: 24
+                        }
+                      }
                     }
                     scopevar: "."
                     descending: false
                     attr_name: "foo"
                   }
-                  type {
-                    set {
+                  type: {
+                    set: {}
+                  }
+                  source_context: {
+                    file: "tests/rank.sysl"
+                    start: {
+                      line: 4
+                      col: 6
                     }
+                    end: {
+                      line: 4
+                      col: 34
+                    }
+                    text: "let out1 = . rank(abc as foo)"
                   }
                 }
               }
             }
-            stmt {
-              let {
+            stmt: {
+              let: {
                 name: "out2"
-                expr {
-                  relexpr {
+                expr: {
+                  relexpr: {
                     op: RANK
-                    target {
-                      get_attr {
-                        arg {
+                    target: {
+                      get_attr: {
+                        arg: {
                           name: "."
+                          source_context: {
+                            file: "tests/rank.sysl"
+                            start: {
+                              line: 5
+                              col: 17
+                            }
+                            end: {
+                              line: 5
+                              col: 18
+                            }
+                          }
                         }
                         attr: "abc"
                       }
+                      source_context: {
+                        file: "tests/rank.sysl"
+                        start: {
+                          line: 5
+                          col: 17
+                        }
+                        end: {
+                          line: 5
+                          col: 18
+                        }
+                      }
                     }
-                    arg {
+                    arg: {
                       name: "abc"
+                      source_context: {
+                        file: "tests/rank.sysl"
+                        start: {
+                          line: 5
+                          col: 27
+                        }
+                        end: {
+                          line: 5
+                          col: 27
+                        }
+                      }
                     }
-                    arg {
+                    arg: {
                       name: "abc"
+                      source_context: {
+                        file: "tests/rank.sysl"
+                        start: {
+                          line: 5
+                          col: 27
+                        }
+                        end: {
+                          line: 5
+                          col: 27
+                        }
+                      }
                     }
                     scopevar: "."
                     descending: false
                     attr_name: "foo"
                   }
-                  type {
-                    set {
+                  type: {
+                    set: {}
+                  }
+                  source_context: {
+                    file: "tests/rank.sysl"
+                    start: {
+                      line: 5
+                      col: 6
                     }
+                    end: {
+                      line: 5
+                      col: 37
+                    }
+                    text: "let out2 = .abc rank(abc as foo)"
                   }
                 }
               }
             }
-            stmt {
-              let {
+            stmt: {
+              let: {
                 name: "out3"
-                expr {
-                  relexpr {
+                expr: {
+                  relexpr: {
                     op: RANK
-                    target {
-                      get_attr {
-                        arg {
+                    target: {
+                      get_attr: {
+                        arg: {
                           name: "input"
+                          source_context: {
+                            file: "tests/rank.sysl"
+                            start: {
+                              line: 6
+                              col: 17
+                            }
+                            end: {
+                              line: 6
+                              col: 17
+                            }
+                          }
                         }
                         attr: "abc"
                       }
+                      source_context: {
+                        file: "tests/rank.sysl"
+                        start: {
+                          line: 6
+                          col: 22
+                        }
+                        end: {
+                          line: 6
+                          col: 23
+                        }
+                      }
                     }
-                    arg {
+                    arg: {
                       name: "abc"
+                      source_context: {
+                        file: "tests/rank.sysl"
+                        start: {
+                          line: 6
+                          col: 32
+                        }
+                        end: {
+                          line: 6
+                          col: 32
+                        }
+                      }
                     }
-                    arg {
+                    arg: {
                       name: "abc"
+                      source_context: {
+                        file: "tests/rank.sysl"
+                        start: {
+                          line: 6
+                          col: 32
+                        }
+                        end: {
+                          line: 6
+                          col: 32
+                        }
+                      }
                     }
                     scopevar: "."
                     descending: false
                     attr_name: "foo"
                   }
-                  type {
-                    set {
+                  type: {
+                    set: {}
+                  }
+                  source_context: {
+                    file: "tests/rank.sysl"
+                    start: {
+                      line: 6
+                      col: 6
                     }
+                    end: {
+                      line: 6
+                      col: 42
+                    }
+                    text: "let out3 = input.abc rank(abc as foo)"
                   }
                 }
               }
             }
-            stmt {
-              let {
+            stmt: {
+              let: {
                 name: "out4"
-                expr {
-                  relexpr {
+                expr: {
+                  relexpr: {
                     op: RANK
-                    target {
-                      literal {
+                    target: {
+                      literal: {
                         i: 1
                       }
+                      source_context: {
+                        file: "tests/rank.sysl"
+                        start: {
+                          line: 7
+                          col: 17
+                        }
+                        end: {
+                          line: 7
+                          col: 17
+                        }
+                      }
                     }
-                    arg {
+                    arg: {
                       name: "abc"
+                      source_context: {
+                        file: "tests/rank.sysl"
+                        start: {
+                          line: 7
+                          col: 24
+                        }
+                        end: {
+                          line: 7
+                          col: 24
+                        }
+                      }
                     }
-                    arg {
+                    arg: {
                       name: "abc"
+                      source_context: {
+                        file: "tests/rank.sysl"
+                        start: {
+                          line: 7
+                          col: 24
+                        }
+                        end: {
+                          line: 7
+                          col: 24
+                        }
+                      }
                     }
                     scopevar: "."
                     descending: false
                     attr_name: "foo"
                   }
-                  type {
-                    set {
+                  type: {
+                    set: {}
+                  }
+                  source_context: {
+                    file: "tests/rank.sysl"
+                    start: {
+                      line: 7
+                      col: 6
                     }
+                    end: {
+                      line: 7
+                      col: 34
+                    }
+                    text: "let out4 = 1 rank(abc as foo)"
                   }
                 }
               }
             }
-            stmt {
-              let {
+            stmt: {
+              let: {
                 name: "out5"
-                expr {
-                  relexpr {
+                expr: {
+                  relexpr: {
                     op: RANK
-                    target {
+                    target: {
                       name: "foo"
+                      source_context: {
+                        file: "tests/rank.sysl"
+                        start: {
+                          line: 8
+                          col: 17
+                        }
+                        end: {
+                          line: 8
+                          col: 17
+                        }
+                      }
                     }
-                    arg {
+                    arg: {
                       name: "abc"
+                      source_context: {
+                        file: "tests/rank.sysl"
+                        start: {
+                          line: 8
+                          col: 26
+                        }
+                        end: {
+                          line: 8
+                          col: 26
+                        }
+                      }
                     }
-                    arg {
+                    arg: {
                       name: "abc"
+                      source_context: {
+                        file: "tests/rank.sysl"
+                        start: {
+                          line: 8
+                          col: 26
+                        }
+                        end: {
+                          line: 8
+                          col: 26
+                        }
+                      }
                     }
                     scopevar: "."
                     descending: false
                     attr_name: "foo"
                   }
-                  type {
-                    set {
+                  type: {
+                    set: {}
+                  }
+                  source_context: {
+                    file: "tests/rank.sysl"
+                    start: {
+                      line: 8
+                      col: 6
                     }
+                    end: {
+                      line: 8
+                      col: 36
+                    }
+                    text: "let out5 = foo rank(abc as foo)"
                   }
                 }
               }
             }
-            stmt {
-              let {
+            stmt: {
+              let: {
                 name: "out6"
-                expr {
-                  get_attr {
-                    arg {
-                      relexpr {
+                expr: {
+                  get_attr: {
+                    arg: {
+                      relexpr: {
                         op: RANK
-                        target {
+                        target: {
                           name: "foo"
+                          source_context: {
+                            file: "tests/rank.sysl"
+                            start: {
+                              line: 9
+                              col: 17
+                            }
+                            end: {
+                              line: 9
+                              col: 17
+                            }
+                          }
                         }
-                        arg {
+                        arg: {
                           name: "abc"
+                          source_context: {
+                            file: "tests/rank.sysl"
+                            start: {
+                              line: 9
+                              col: 26
+                            }
+                            end: {
+                              line: 9
+                              col: 26
+                            }
+                          }
                         }
-                        arg {
+                        arg: {
                           name: "abc"
+                          source_context: {
+                            file: "tests/rank.sysl"
+                            start: {
+                              line: 9
+                              col: 26
+                            }
+                            end: {
+                              line: 9
+                              col: 26
+                            }
+                          }
                         }
                         scopevar: "."
                         descending: false
                         attr_name: "foo"
                       }
-                      type {
-                        set {
+                      type: {
+                        set: {}
+                      }
+                      source_context: {
+                        file: "tests/rank.sysl"
+                        start: {
+                          line: 9
+                          col: 21
+                        }
+                        end: {
+                          line: 9
+                          col: 36
                         }
                       }
                     }
                     attr: "bar"
                   }
+                  source_context: {
+                    file: "tests/rank.sysl"
+                    start: {
+                      line: 9
+                      col: 6
+                    }
+                    end: {
+                      line: 9
+                      col: 39
+                    }
+                    text: "let out6 = foo rank(abc as foo) .bar"
+                  }
                 }
               }
             }
-            stmt {
-              let {
+            stmt: {
+              let: {
                 name: "out7"
-                expr {
-                  binexpr {
+                expr: {
+                  binexpr: {
                     op: TO_MATCHING
-                    lhs {
-                      relexpr {
+                    lhs: {
+                      relexpr: {
                         op: RANK
-                        target {
+                        target: {
                           name: "foo"
+                          source_context: {
+                            file: "tests/rank.sysl"
+                            start: {
+                              line: 10
+                              col: 17
+                            }
+                            end: {
+                              line: 10
+                              col: 17
+                            }
+                          }
                         }
-                        arg {
+                        arg: {
                           name: "abc"
+                          source_context: {
+                            file: "tests/rank.sysl"
+                            start: {
+                              line: 10
+                              col: 26
+                            }
+                            end: {
+                              line: 10
+                              col: 26
+                            }
+                          }
                         }
-                        arg {
+                        arg: {
                           name: "abc"
+                          source_context: {
+                            file: "tests/rank.sysl"
+                            start: {
+                              line: 10
+                              col: 26
+                            }
+                            end: {
+                              line: 10
+                              col: 26
+                            }
+                          }
                         }
                         scopevar: "."
                         descending: false
                         attr_name: "foo"
                       }
-                      type {
-                        set {
+                      type: {
+                        set: {}
+                      }
+                      source_context: {
+                        file: "tests/rank.sysl"
+                        start: {
+                          line: 10
+                          col: 21
+                        }
+                        end: {
+                          line: 10
+                          col: 36
                         }
                       }
                     }
-                    rhs {
+                    rhs: {
                       name: "bar"
+                      source_context: {
+                        file: "tests/rank.sysl"
+                        start: {
+                          line: 10
+                          col: 41
+                        }
+                        end: {
+                          line: 10
+                          col: 41
+                        }
+                      }
                     }
                     attr_name: "*"
+                  }
+                  type: {
+                    no_type: {}
+                  }
+                  source_context: {
+                    file: "tests/rank.sysl"
+                    start: {
+                      line: 10
+                      col: 6
+                    }
+                    end: {
+                      line: 10
+                      col: 41
+                    }
+                    text: "let out7 = foo rank(abc as foo) ~> bar"
                   }
                 }
               }
             }
-            stmt {
-              let {
+            stmt: {
+              let: {
                 name: "out8"
-                expr {
-                  binexpr {
+                expr: {
+                  binexpr: {
                     op: TO_MATCHING
-                    lhs {
-                      relexpr {
+                    lhs: {
+                      relexpr: {
                         op: RANK
-                        target {
-                          get_attr {
-                            arg {
+                        target: {
+                          get_attr: {
+                            arg: {
                               name: "."
+                              source_context: {
+                                file: "tests/rank.sysl"
+                                start: {
+                                  line: 11
+                                  col: 17
+                                }
+                                end: {
+                                  line: 11
+                                  col: 27
+                                }
+                              }
                             }
                             attr: "Pet"
                             setof: true
                           }
+                          source_context: {
+                            file: "tests/rank.sysl"
+                            start: {
+                              line: 11
+                              col: 17
+                            }
+                            end: {
+                              line: 11
+                              col: 27
+                            }
+                          }
                         }
-                        arg {
-                          get_attr {
-                            arg {
+                        arg: {
+                          get_attr: {
+                            arg: {
                               name: "."
+                              source_context: {
+                                file: "tests/rank.sysl"
+                                start: {
+                                  line: 11
+                                  col: 36
+                                }
+                                end: {
+                                  line: 11
+                                  col: 37
+                                }
+                              }
                             }
                             attr: "numLegs"
                           }
+                          source_context: {
+                            file: "tests/rank.sysl"
+                            start: {
+                              line: 11
+                              col: 36
+                            }
+                            end: {
+                              line: 11
+                              col: 37
+                            }
+                          }
                         }
-                        arg {
-                          get_attr {
-                            arg {
+                        arg: {
+                          get_attr: {
+                            arg: {
                               name: "."
+                              source_context: {
+                                file: "tests/rank.sysl"
+                                start: {
+                                  line: 11
+                                  col: 36
+                                }
+                                end: {
+                                  line: 11
+                                  col: 37
+                                }
+                              }
                             }
                             attr: "numLegs"
+                          }
+                          source_context: {
+                            file: "tests/rank.sysl"
+                            start: {
+                              line: 11
+                              col: 36
+                            }
+                            end: {
+                              line: 11
+                              col: 37
+                            }
                           }
                         }
                         scopevar: "."
                         descending: false
                         attr_name: "legRank"
                       }
-                      type {
-                        set {
+                      type: {
+                        set: {}
+                      }
+                      source_context: {
+                        file: "tests/rank.sysl"
+                        start: {
+                          line: 11
+                          col: 31
+                        }
+                        end: {
+                          line: 11
+                          col: 55
                         }
                       }
                     }
-                    rhs {
+                    rhs: {
                       name: "bar"
+                      source_context: {
+                        file: "tests/rank.sysl"
+                        start: {
+                          line: 11
+                          col: 60
+                        }
+                        end: {
+                          line: 11
+                          col: 60
+                        }
+                      }
                     }
                     attr_name: "*"
+                  }
+                  type: {
+                    no_type: {}
+                  }
+                  source_context: {
+                    file: "tests/rank.sysl"
+                    start: {
+                      line: 11
+                      col: 6
+                    }
+                    end: {
+                      line: 11
+                      col: 60
+                    }
+                    text: "let out8 = .table of Pet rank(.numLegs as legRank) ~> bar"
                   }
                 }
               }
             }
-            stmt {
-              let {
+            stmt: {
+              let: {
                 name: "out9"
-                expr {
-                  binexpr {
+                expr: {
+                  binexpr: {
                     op: TO_MATCHING
-                    lhs {
-                      relexpr {
+                    lhs: {
+                      relexpr: {
                         op: RANK
-                        target {
-                          get_attr {
-                            arg {
+                        target: {
+                          get_attr: {
+                            arg: {
                               name: "."
+                              source_context: {
+                                file: "tests/rank.sysl"
+                                start: {
+                                  line: 12
+                                  col: 17
+                                }
+                                end: {
+                                  line: 12
+                                  col: 27
+                                }
+                              }
                             }
                             attr: "Pet"
                             setof: true
                           }
+                          source_context: {
+                            file: "tests/rank.sysl"
+                            start: {
+                              line: 12
+                              col: 17
+                            }
+                            end: {
+                              line: 12
+                              col: 27
+                            }
+                          }
                         }
-                        arg {
-                          get_attr {
-                            arg {
+                        arg: {
+                          get_attr: {
+                            arg: {
                               name: "."
+                              source_context: {
+                                file: "tests/rank.sysl"
+                                start: {
+                                  line: 12
+                                  col: 36
+                                }
+                                end: {
+                                  line: 12
+                                  col: 37
+                                }
+                              }
                             }
                             attr: "numLegs"
                           }
+                          source_context: {
+                            file: "tests/rank.sysl"
+                            start: {
+                              line: 12
+                              col: 36
+                            }
+                            end: {
+                              line: 12
+                              col: 37
+                            }
+                          }
                         }
-                        arg {
-                          get_attr {
-                            arg {
+                        arg: {
+                          get_attr: {
+                            arg: {
                               name: "."
+                              source_context: {
+                                file: "tests/rank.sysl"
+                                start: {
+                                  line: 12
+                                  col: 36
+                                }
+                                end: {
+                                  line: 12
+                                  col: 37
+                                }
+                              }
                             }
                             attr: "numLegs"
+                          }
+                          source_context: {
+                            file: "tests/rank.sysl"
+                            start: {
+                              line: 12
+                              col: 36
+                            }
+                            end: {
+                              line: 12
+                              col: 37
+                            }
                           }
                         }
                         scopevar: "."
                         descending: false
                         attr_name: "legRank"
                       }
-                      type {
-                        set {
+                      type: {
+                        set: {}
+                      }
+                      source_context: {
+                        file: "tests/rank.sysl"
+                        start: {
+                          line: 12
+                          col: 31
+                        }
+                        end: {
+                          line: 12
+                          col: 55
                         }
                       }
                     }
-                    rhs {
-                      get_attr {
-                        arg {
+                    rhs: {
+                      get_attr: {
+                        arg: {
                           name: "."
+                          source_context: {
+                            file: "tests/rank.sysl"
+                            start: {
+                              line: 12
+                              col: 60
+                            }
+                            end: {
+                              line: 12
+                              col: 70
+                            }
+                          }
                         }
                         attr: "Bar"
                         setof: true
                       }
+                      source_context: {
+                        file: "tests/rank.sysl"
+                        start: {
+                          line: 12
+                          col: 60
+                        }
+                        end: {
+                          line: 12
+                          col: 70
+                        }
+                      }
                     }
                     attr_name: "*"
+                  }
+                  type: {
+                    no_type: {}
+                  }
+                  source_context: {
+                    file: "tests/rank.sysl"
+                    start: {
+                      line: 12
+                      col: 6
+                    }
+                    end: {
+                      line: 12
+                      col: 70
+                    }
+                    text: "let out9 = .table of Pet rank(.numLegs as legRank) ~> .table of Bar"
                   }
                 }
               }
             }
           }
+          source_context: {
+            file: "tests/rank.sysl"
+            start: {
+              line: 3
+              col: 4
+            }
+            end: {
+              line: 13
+              col: 5
+            }
+          }
         }
+        source_context: {
+          file: "tests/rank.sysl"
+          start: {
+            line: 2
+            col: 2
+          }
+          end: {
+            line: 14
+          }
+          text: "!view TestRank(number <: int) -> int:"
+        }
+      }
+    }
+    source_context: {
+      file: "tests/rank.sysl"
+      start: {
+        line: 1
+        col: 1
+      }
+      end: {
+        line: 1
+        col: 47
       }
     }
   }

--- a/pkg/parse/tests/rest_api_query_params.sysl.golden.textpb
+++ b/pkg/parse/tests/rest_api_query_params.sysl.golden.textpb
@@ -1,272 +1,272 @@
-apps: <
+apps: {
   key: "My :: Server"
-  value: <
-    name: <
+  value: {
+    name: {
       part: "My"
       part: "Server"
-    >
-    attrs: <
+    }
+    attrs: {
       key: "patterns"
-      value: <
-        a: <
-          elt: <
+      value: {
+        a: {
+          elt: {
             s: "rest"
-          >
-        >
-      >
-    >
-    endpoints: <
+          }
+        }
+      }
+    }
+    endpoints: {
       key: "GET /first"
-      value: <
+      value: {
         name: "GET /first"
-        attrs: <
+        attrs: {
           key: "patterns"
-          value: <
-            a: <
-              elt: <
+          value: {
+            a: {
+              elt: {
                 s: "rest"
-              >
-            >
-          >
-        >
-        stmt: <
-          action: <
+              }
+            }
+          }
+        }
+        stmt: {
+          action: {
             action: "..."
-          >
-        >
-        rest_params: <
+          }
+        }
+        rest_params: {
           method: GET
           path: "/first"
-          query_param: <
+          query_param: {
             name: "depth"
-            type: <
+            type: {
               primitive: INT
-              source_context: <
+              source_context: {
                 file: "tests/rest_api_query_params.sysl"
-                start: <
+                start: {
                   line: 3
                   col: 13
-                >
-                end: <
+                }
+                end: {
                   line: 3
                   col: 19
-                >
-              >
-            >
-          >
-          query_param: <
+                }
+              }
+            }
+          }
+          query_param: {
             name: "limit"
-            type: <
+            type: {
               primitive: INT
               opt: true
-              source_context: <
+              source_context: {
                 file: "tests/rest_api_query_params.sysl"
-                start: <
+                start: {
                   line: 3
                   col: 23
-                >
-                end: <
+                }
+                end: {
                   line: 3
                   col: 32
-                >
-              >
-            >
-          >
-          query_param: <
+                }
+              }
+            }
+          }
+          query_param: {
             name: "offset"
-            type: <
+            type: {
               primitive: INT
               opt: true
-              source_context: <
+              source_context: {
                 file: "tests/rest_api_query_params.sysl"
-                start: <
+                start: {
                   line: 3
                   col: 34
-                >
-                end: <
+                }
+                end: {
                   line: 3
                   col: 44
-                >
-              >
-            >
-          >
-        >
-        source_context: <
+                }
+              }
+            }
+          }
+        }
+        source_context: {
           file: "tests/rest_api_query_params.sysl"
-          start: <
+          start: {
             line: 3
             col: 8
-          >
-          end: <
+          }
+          end: {
             line: 5
             col: 8
-          >
-        >
-      >
-    >
-    endpoints: <
+          }
+        }
+      }
+    }
+    endpoints: {
       key: "GET /first/{id}"
-      value: <
+      value: {
         name: "GET /first/{id}"
-        attrs: <
+        attrs: {
           key: "patterns"
-          value: <
-            a: <
-              elt: <
+          value: {
+            a: {
+              elt: {
                 s: "rest"
-              >
-            >
-          >
-        >
-        stmt: <
-          action: <
+              }
+            }
+          }
+        }
+        stmt: {
+          action: {
             action: "..."
-          >
-        >
-        rest_params: <
+          }
+        }
+        rest_params: {
           method: GET
           path: "/first/{id}"
-          url_param: <
+          url_param: {
             name: "id"
-            type: <
-              type_ref: <
-                context: <
-                  appname: <
+            type: {
+              type_ref: {
+                context: {
+                  appname: {
                     part: "My"
                     part: "Server"
-                  >
-                >
-                ref: <
+                  }
+                }
+                ref: {
                   path: "App"
                   path: "Token"
-                >
-              >
-              source_context: <
+                }
+              }
+              source_context: {
                 file: "tests/rest_api_query_params.sysl"
-                start: <
+                start: {
                   line: 5
                   col: 9
-                >
-                end: <
+                }
+                end: {
                   line: 5
                   col: 23
-                >
-              >
-            >
-          >
-        >
-        source_context: <
+                }
+              }
+            }
+          }
+        }
+        source_context: {
           file: "tests/rest_api_query_params.sysl"
-          start: <
+          start: {
             line: 6
             col: 10
-          >
-          end: <
+          }
+          end: {
             line: 8
             col: 10
-          >
-        >
-      >
-    >
-    endpoints: <
+          }
+        }
+      }
+    }
+    endpoints: {
       key: "GET /first/{id}/second"
-      value: <
+      value: {
         name: "GET /first/{id}/second"
-        attrs: <
+        attrs: {
           key: "patterns"
-          value: <
-            a: <
-              elt: <
+          value: {
+            a: {
+              elt: {
                 s: "rest"
-              >
-              elt: <
+              }
+              elt: {
                 s: "bar"
-              >
-            >
-          >
-        >
-        param: <
+              }
+            }
+          }
+        }
+        param: {
           name: "foo"
-          type: <
+          type: {
             primitive: INT
-          >
-        >
-        stmt: <
-          action: <
+          }
+        }
+        stmt: {
+          action: {
             action: "..."
-          >
-        >
-        rest_params: <
+          }
+        }
+        rest_params: {
           method: GET
           path: "/first/{id}/second"
-          query_param: <
+          query_param: {
             name: "depth"
-            type: <
+            type: {
               primitive: INT
-              source_context: <
+              source_context: {
                 file: "tests/rest_api_query_params.sysl"
-                start: <
+                start: {
                   line: 9
                   col: 32
-                >
-                end: <
+                }
+                end: {
                   line: 9
                   col: 38
-                >
-              >
-            >
-          >
-          url_param: <
+                }
+              }
+            }
+          }
+          url_param: {
             name: "id"
-            type: <
-              type_ref: <
-                context: <
-                  appname: <
+            type: {
+              type_ref: {
+                context: {
+                  appname: {
                     part: "My"
                     part: "Server"
-                  >
-                >
-                ref: <
+                  }
+                }
+                ref: {
                   path: "App"
                   path: "Token"
-                >
-              >
-              source_context: <
+                }
+              }
+              source_context: {
                 file: "tests/rest_api_query_params.sysl"
-                start: <
+                start: {
                   line: 5
                   col: 9
-                >
-                end: <
+                }
+                end: {
                   line: 5
                   col: 23
-                >
-              >
-            >
-          >
-        >
-        source_context: <
+                }
+              }
+            }
+          }
+        }
+        source_context: {
           file: "tests/rest_api_query_params.sysl"
-          start: <
+          start: {
             line: 9
             col: 14
-          >
-          end: <
+          }
+          end: {
             line: 11
-          >
-        >
-      >
-    >
-    source_context: <
+          }
+        }
+      }
+    }
+    source_context: {
       file: "tests/rest_api_query_params.sysl"
-      start: <
+      start: {
         line: 1
         col: 1
-      >
-      end: <
+      }
+      end: {
         line: 1
         col: 19
-      >
-    >
-  >
->
+      }
+    }
+  }
+}

--- a/pkg/parse/tests/rest_url_params.sysl.golden.textpb
+++ b/pkg/parse/tests/rest_url_params.sysl.golden.textpb
@@ -1,138 +1,138 @@
-apps: <
+apps: {
   key: "Server"
-  value: <
-    name: <
+  value: {
+    name: {
       part: "Server"
-    >
-    endpoints: <
+    }
+    endpoints: {
       key: "GET /{id1}/{id2}/{aid3}/{id4}/{bid5}"
-      value: <
+      value: {
         name: "GET /{id1}/{id2}/{aid3}/{id4}/{bid5}"
-        attrs: <
+        attrs: {
           key: "patterns"
-          value: <
-            a: <
-              elt: <
+          value: {
+            a: {
+              elt: {
                 s: "rest"
-              >
-            >
-          >
-        >
-        stmt: <
-          action: <
+              }
+            }
+          }
+        }
+        stmt: {
+          action: {
             action: "..."
-          >
-        >
-        rest_params: <
+          }
+        }
+        rest_params: {
           method: GET
           path: "/{id1}/{id2}/{aid3}/{id4}/{bid5}"
-          url_param: <
+          url_param: {
             name: "id1"
-            type: <
+            type: {
               primitive: INT
-              source_context: <
+              source_context: {
                 file: "tests/rest_url_params.sysl"
-                start: <
+                start: {
                   line: 2
                   col: 5
-                >
-                end: <
+                }
+                end: {
                   line: 2
                   col: 14
-                >
-              >
-            >
-          >
-          url_param: <
+                }
+              }
+            }
+          }
+          url_param: {
             name: "id2"
-            type: <
+            type: {
               primitive: INT
-              source_context: <
+              source_context: {
                 file: "tests/rest_url_params.sysl"
-                start: <
+                start: {
                   line: 3
                   col: 9
-                >
-                end: <
+                }
+                end: {
                   line: 3
                   col: 18
-                >
-              >
-            >
-          >
-          url_param: <
+                }
+              }
+            }
+          }
+          url_param: {
             name: "aid3"
-            type: <
+            type: {
               primitive: INT
-              source_context: <
+              source_context: {
                 file: "tests/rest_url_params.sysl"
-                start: <
+                start: {
                   line: 4
                   col: 13
-                >
-                end: <
+                }
+                end: {
                   line: 4
                   col: 23
-                >
-              >
-            >
-          >
-          url_param: <
+                }
+              }
+            }
+          }
+          url_param: {
             name: "id4"
-            type: <
+            type: {
               primitive: INT
-              source_context: <
+              source_context: {
                 file: "tests/rest_url_params.sysl"
-                start: <
+                start: {
                   line: 5
                   col: 17
-                >
-                end: <
+                }
+                end: {
                   line: 5
                   col: 26
-                >
-              >
-            >
-          >
-          url_param: <
+                }
+              }
+            }
+          }
+          url_param: {
             name: "bid5"
-            type: <
+            type: {
               primitive: INT
-              source_context: <
+              source_context: {
                 file: "tests/rest_url_params.sysl"
-                start: <
+                start: {
                   line: 6
                   col: 21
-                >
-                end: <
+                }
+                end: {
                   line: 6
                   col: 31
-                >
-              >
-            >
-          >
-        >
-        source_context: <
+                }
+              }
+            }
+          }
+        }
+        source_context: {
           file: "tests/rest_url_params.sysl"
-          start: <
+          start: {
             line: 7
             col: 24
-          >
-          end: <
+          }
+          end: {
             line: 9
-          >
-        >
-      >
-    >
-    source_context: <
+          }
+        }
+      }
+    }
+    source_context: {
       file: "tests/rest_url_params.sysl"
-      start: <
+      start: {
         line: 1
         col: 1
-      >
-      end: <
+      }
+      end: {
         line: 1
-      >
-    >
-  >
->
+      }
+    }
+  }
+}

--- a/pkg/parse/tests/school.sysl.golden.textpb
+++ b/pkg/parse/tests/school.sysl.golden.textpb
@@ -1,131 +1,162 @@
-apps: <
+apps: {
   key: "School"
-  value: <
-    name: <
+  value: {
+    name: {
       part: "School"
-    >
-    types: <
+    }
+    types: {
       key: "Class"
-      value: <
-        relation: <
-          attr_defs: <
+      value: {
+        relation: {
+          attr_defs: {
             key: "Id"
-            value: <
+            value: {
               primitive: INT
-              attrs: <
+              attrs: {
                 key: "patterns"
-                value: <
-                  a: <
-                    elt: <
+                value: {
+                  a: {
+                    elt: {
                       s: "pk"
-                    >
-                    elt: <
+                    }
+                    elt: {
                       s: "autoinc"
-                    >
-                  >
-                >
-              >
-              source_context: <
-                file: "school.sysl"
-                start: <
+                    }
+                  }
+                }
+              }
+              source_context: {
+                file: "tests/school.sysl"
+                start: {
                   line: 3
                   col: 14
-                >
-                end: <
+                }
+                end: {
                   line: 3
                   col: 32
-                >
-              >
-            >
-          >
-          primary_key: <
+                }
+              }
+            }
+          }
+          primary_key: {
             attr_name: "Id"
-          >
-        >
-      >
-    >
-    types: <
+          }
+        }
+        source_context: {
+          file: "tests/school.sysl"
+          start: {
+            line: 2
+            col: 4
+          }
+          end: {
+            line: 4
+            col: 4
+          }
+        }
+      }
+    }
+    types: {
       key: "Student"
-      value: <
-        relation: <
-          attr_defs: <
+      value: {
+        relation: {
+          attr_defs: {
             key: "ClassId"
-            value: <
-              type_ref: <
-                context: <
-                  appname: <
+            value: {
+              type_ref: {
+                context: {
+                  appname: {
                     part: "School"
-                  >
+                  }
                   path: "Student"
-                >
-                ref: <
+                }
+                ref: {
                   path: "Class"
                   path: "Idd"
-                >
-              >
-              attrs: <
+                }
+              }
+              attrs: {
                 key: "description"
-                value: <
+                value: {
                   s: "describe the table"
-                >
-              >
-              source_context: <
-                file: "school.sysl"
-                start: <
+                }
+              }
+              source_context: {
+                file: "tests/school.sysl"
+                start: {
                   line: 7
                   col: 19
-                >
-                end: <
+                }
+                end: {
                   line: 7
                   col: 25
-                >
-              >
-            >
-          >
-          attr_defs: <
+                }
+              }
+            }
+          }
+          attr_defs: {
             key: "Id"
-            value: <
+            value: {
               primitive: INT
-              attrs: <
+              attrs: {
                 key: "description"
-                value: <
+                value: {
                   s: "describe the table"
-                >
-              >
-              attrs: <
+                }
+              }
+              attrs: {
                 key: "patterns"
-                value: <
-                  a: <
-                    elt: <
+                value: {
+                  a: {
+                    elt: {
                       s: "pk"
-                    >
-                  >
-                >
-              >
-              source_context: <
-                file: "school.sysl"
-                start: <
+                    }
+                  }
+                }
+              }
+              source_context: {
+                file: "tests/school.sysl"
+                start: {
                   line: 6
                   col: 14
-                >
-                end: <
+                }
+                end: {
                   line: 6
                   col: 22
-                >
-              >
-            >
-          >
-          primary_key: <
+                }
+              }
+            }
+          }
+          primary_key: {
             attr_name: "Id"
-          >
-        >
-        attrs: <
+          }
+        }
+        attrs: {
           key: "description"
-          value: <
+          value: {
             s: "describe the table"
-          >
-        >
-      >
-    >
-  >
->
+          }
+        }
+        source_context: {
+          file: "tests/school.sysl"
+          start: {
+            line: 5
+            col: 4
+          }
+          end: {
+            line: 8
+          }
+        }
+      }
+    }
+    source_context: {
+      file: "tests/school.sysl"
+      start: {
+        line: 1
+        col: 1
+      }
+      end: {
+        line: 1
+      }
+    }
+  }
+}

--- a/pkg/parse/tests/sequence_type.sysl.golden.textpb
+++ b/pkg/parse/tests/sequence_type.sysl.golden.textpb
@@ -1,70 +1,70 @@
-apps: <
+apps: {
   key: "SequenceType"
-  value: <
-    name: <
+  value: {
+    name: {
       part: "SequenceType"
-    >
-    types: <
+    }
+    types: {
       key: "A"
-      value: <
-        tuple: <
-          attr_defs: <
+      value: {
+        tuple: {
+          attr_defs: {
             key: "x"
-            value: <
-              sequence: <
+            value: {
+              sequence: {
                 primitive: INT
-                source_context: <
+                source_context: {
                   file: "tests/sequence_type.sysl"
-                  start: <
+                  start: {
                     line: 4
                     col: 13
-                  >
-                  end: <
+                  }
+                  end: {
                     line: 5
-                  >
-                >
-              >
-              attrs: <
+                  }
+                }
+              }
+              attrs: {
                 key: "comment"
-                value: <
+                value: {
                   s: "array of int"
-                >
-              >
+                }
+              }
               opt: true
-              source_context: <
+              source_context: {
                 file: "tests/sequence_type.sysl"
-                start: <
+                start: {
                   line: 4
                   col: 13
-                >
-                end: <
+                }
+                end: {
                   line: 5
-                >
-              >
-            >
-          >
-        >
-        source_context: <
+                }
+              }
+            }
+          }
+        }
+        source_context: {
           file: "tests/sequence_type.sysl"
-          start: <
+          start: {
             line: 2
             col: 4
-          >
-          end: <
+          }
+          end: {
             line: 5
-          >
-        >
-      >
-    >
-    source_context: <
+          }
+        }
+      }
+    }
+    source_context: {
       file: "tests/sequence_type.sysl"
-      start: <
+      start: {
         line: 1
         col: 1
-      >
-      end: <
+      }
+      end: {
         line: 1
-      >
-    >
-  >
->
+      }
+    }
+  }
+}

--- a/pkg/parse/tests/stmts.sysl.golden.textpb
+++ b/pkg/parse/tests/stmts.sysl.golden.textpb
@@ -1,917 +1,2903 @@
-apps {
+apps: {
   key: "TransformationTest"
-  value {
-    name {
+  value: {
+    name: {
       part: "TransformationTest"
     }
-    attrs {
+    attrs: {
       key: "package"
-      value {
+      value: {
         s: "io.sysl.test.views"
       }
     }
-    views {
+    views: {
       key: "TestStatements"
-      value {
-        param {
+      value: {
+        param: {
           name: "number"
-          type {
+          type: {
             primitive: INT
           }
         }
-        ret_type {
+        ret_type: {
           primitive: INT
         }
-        expr {
-          transform {
-            arg {
+        expr: {
+          transform: {
+            arg: {
               name: "number"
+              source_context: {
+                file: "tests/stmts.sysl"
+                start: {
+                  line: 3
+                  col: 4
+                }
+                end: {
+                  line: 3
+                  col: 4
+                }
+              }
             }
             scopevar: "."
-            stmt {
-              assign {
+            stmt: {
+              assign: {
                 name: "abcdef"
-                expr {
-                  get_attr {
-                    arg {
+                expr: {
+                  get_attr: {
+                    arg: {
                       name: "."
+                      source_context: {
+                        file: "tests/stmts.sysl"
+                        start: {
+                          line: 4
+                          col: 6
+                        }
+                        end: {
+                          line: 4
+                          col: 6
+                        }
+                      }
                     }
                     attr: "abcdef"
+                  }
+                  source_context: {
+                    file: "tests/stmts.sysl"
+                    start: {
+                      line: 4
+                      col: 6
+                    }
+                    end: {
+                      line: 4
+                      col: 6
+                    }
                   }
                 }
               }
             }
-            stmt {
-              assign {
+            stmt: {
+              assign: {
                 name: "abc"
-                expr {
-                  get_attr {
-                    arg {
+                expr: {
+                  get_attr: {
+                    arg: {
                       name: "."
+                      source_context: {
+                        file: "tests/stmts.sysl"
+                        start: {
+                          line: 5
+                          col: 6
+                        }
+                        end: {
+                          line: 5
+                          col: 6
+                        }
+                      }
                     }
                     attr: "abc"
                   }
+                  source_context: {
+                    file: "tests/stmts.sysl"
+                    start: {
+                      line: 5
+                      col: 6
+                    }
+                    end: {
+                      line: 5
+                      col: 6
+                    }
+                  }
                 }
               }
             }
-            stmt {
-              assign {
+            stmt: {
+              assign: {
                 name: "abcdef"
-                expr {
-                  get_attr {
-                    arg {
+                expr: {
+                  get_attr: {
+                    arg: {
                       name: "name"
+                      source_context: {
+                        file: "tests/stmts.sysl"
+                        start: {
+                          line: 6
+                          col: 6
+                        }
+                        end: {
+                          line: 6
+                          col: 6
+                        }
+                      }
                     }
                     attr: "abcdef"
                   }
-                }
-              }
-            }
-            stmt {
-              let {
-                name: "out"
-                expr {
-                  binexpr {
-                    op: ADD
-                    lhs {
-                      get_attr {
-                        arg {
-                          name: "."
-                        }
-                        attr: "a"
-                      }
+                  source_context: {
+                    file: "tests/stmts.sysl"
+                    start: {
+                      line: 6
+                      col: 6
                     }
-                    rhs {
-                      literal {
-                        i: 2
-                      }
+                    end: {
+                      line: 6
+                      col: 6
                     }
                   }
                 }
               }
             }
-            stmt {
-              assign {
+            stmt: {
+              let: {
+                name: "out"
+                expr: {
+                  binexpr: {
+                    op: ADD
+                    lhs: {
+                      get_attr: {
+                        arg: {
+                          name: "."
+                          source_context: {
+                            file: "tests/stmts.sysl"
+                            start: {
+                              line: 7
+                              col: 16
+                            }
+                            end: {
+                              line: 7
+                              col: 17
+                            }
+                          }
+                        }
+                        attr: "a"
+                      }
+                      source_context: {
+                        file: "tests/stmts.sysl"
+                        start: {
+                          line: 7
+                          col: 16
+                        }
+                        end: {
+                          line: 7
+                          col: 17
+                        }
+                      }
+                    }
+                    rhs: {
+                      literal: {
+                        i: 2
+                      }
+                      type: {
+                        primitive: INT
+                      }
+                      source_context: {
+                        file: "tests/stmts.sysl"
+                        start: {
+                          line: 7
+                          col: 21
+                        }
+                        end: {
+                          line: 7
+                          col: 21
+                        }
+                      }
+                    }
+                  }
+                  type: {
+                    primitive: INT
+                  }
+                  source_context: {
+                    file: "tests/stmts.sysl"
+                    start: {
+                      line: 7
+                      col: 6
+                    }
+                    end: {
+                      line: 7
+                      col: 21
+                    }
+                    text: "let out = .a + 2"
+                  }
+                }
+              }
+            }
+            stmt: {
+              assign: {
                 name: "abc"
-                expr {
+                expr: {
                   name: "number"
+                  source_context: {
+                    file: "tests/stmts.sysl"
+                    start: {
+                      line: 8
+                      col: 21
+                    }
+                    end: {
+                      line: 8
+                      col: 21
+                    }
+                  }
                 }
                 table: true
               }
             }
-            stmt {
-              assign {
+            stmt: {
+              assign: {
                 name: "foo1"
-                expr {
-                  ifelse {
-                    cond {
-                      binexpr {
+                expr: {
+                  ifelse: {
+                    cond: {
+                      binexpr: {
                         op: NE
-                        lhs {
-                          get_attr {
-                            arg {
+                        lhs: {
+                          get_attr: {
+                            arg: {
                               name: "bar"
+                              source_context: {
+                                file: "tests/stmts.sysl"
+                                start: {
+                                  line: 9
+                                  col: 17
+                                }
+                                end: {
+                                  line: 9
+                                  col: 17
+                                }
+                              }
                             }
                             attr: "baz"
                           }
-                        }
-                        rhs {
-                          literal {
-                            null {
+                          source_context: {
+                            file: "tests/stmts.sysl"
+                            start: {
+                              line: 9
+                              col: 20
+                            }
+                            end: {
+                              line: 9
+                              col: 21
                             }
                           }
-                          type {
+                        }
+                        rhs: {
+                          literal: {
+                            null: {}
+                          }
+                          type: {
                             primitive: EMPTY
+                          }
+                          source_context: {
+                            file: "tests/stmts.sysl"
+                            start: {
+                              line: 9
+                              col: 28
+                            }
+                            end: {
+                              line: 9
+                              col: 28
+                            }
                           }
                         }
                       }
+                      source_context: {
+                        file: "tests/stmts.sysl"
+                        start: {
+                          line: 9
+                          col: 17
+                        }
+                        end: {
+                          line: 9
+                          col: 28
+                        }
+                      }
                     }
-                    if_true {
-                      literal {
+                    if_true: {
+                      literal: {
                         s: "Y"
                       }
-                    }
-                    if_false {
-                      literal {
-                        s: "N"
+                      type: {
+                        primitive: STRING
+                      }
+                      source_context: {
+                        file: "tests/stmts.sysl"
+                        start: {
+                          line: 9
+                          col: 39
+                        }
+                        end: {
+                          line: 9
+                          col: 39
+                        }
                       }
                     }
+                    if_false: {
+                      literal: {
+                        s: "N"
+                      }
+                      type: {
+                        primitive: STRING
+                      }
+                      source_context: {
+                        file: "tests/stmts.sysl"
+                        start: {
+                          line: 9
+                          col: 48
+                        }
+                        end: {
+                          line: 9
+                          col: 48
+                        }
+                      }
+                    }
+                  }
+                  type: {
+                    primitive: STRING
+                  }
+                  source_context: {
+                    file: "tests/stmts.sysl"
+                    start: {
+                      line: 9
+                      col: 6
+                    }
+                    end: {
+                      line: 9
+                      col: 48
+                    }
+                    text: "foo1 = if (bar.baz != null) then \"Y\" else \"N\""
                   }
                 }
               }
             }
-            stmt {
-              assign {
+            stmt: {
+              assign: {
                 name: "foo2"
-                expr {
-                  ifelse {
-                    cond {
-                      get_attr {
-                        arg {
+                expr: {
+                  ifelse: {
+                    cond: {
+                      get_attr: {
+                        arg: {
                           name: "bar"
+                          source_context: {
+                            file: "tests/stmts.sysl"
+                            start: {
+                              line: 10
+                              col: 16
+                            }
+                            end: {
+                              line: 10
+                              col: 16
+                            }
+                          }
                         }
                         attr: "baz"
                       }
-                    }
-                    if_true {
-                      literal {
-                        s: "Y"
+                      source_context: {
+                        file: "tests/stmts.sysl"
+                        start: {
+                          line: 10
+                          col: 19
+                        }
+                        end: {
+                          line: 10
+                          col: 20
+                        }
                       }
                     }
-                    if_false {
-                      literal {
+                    if_true: {
+                      literal: {
+                        s: "Y"
+                      }
+                      type: {
+                        primitive: STRING
+                      }
+                      source_context: {
+                        file: "tests/stmts.sysl"
+                        start: {
+                          line: 10
+                          col: 30
+                        }
+                        end: {
+                          line: 10
+                          col: 30
+                        }
+                      }
+                    }
+                    if_false: {
+                      literal: {
                         s: "N"
+                      }
+                      type: {
+                        primitive: STRING
+                      }
+                      source_context: {
+                        file: "tests/stmts.sysl"
+                        start: {
+                          line: 10
+                          col: 39
+                        }
+                        end: {
+                          line: 10
+                          col: 39
+                        }
                       }
                     }
                     nullsafe: true
                   }
+                  type: {
+                    primitive: STRING
+                  }
+                  source_context: {
+                    file: "tests/stmts.sysl"
+                    start: {
+                      line: 10
+                      col: 6
+                    }
+                    end: {
+                      line: 10
+                      col: 39
+                    }
+                    text: "foo2 = if bar.baz? then \"Y\" else \"N\""
+                  }
                 }
               }
             }
-            stmt {
-              assign {
+            stmt: {
+              assign: {
                 name: "foo3"
-                expr {
-                  ifelse {
-                    cond {
-                      binexpr {
+                expr: {
+                  ifelse: {
+                    cond: {
+                      binexpr: {
                         op: EQ
-                        lhs {
-                          get_attr {
-                            arg {
+                        lhs: {
+                          get_attr: {
+                            arg: {
                               name: "bar"
+                              source_context: {
+                                file: "tests/stmts.sysl"
+                                start: {
+                                  line: 11
+                                  col: 16
+                                }
+                                end: {
+                                  line: 11
+                                  col: 16
+                                }
+                              }
                             }
                             attr: "id"
                           }
-                        }
-                        rhs {
-                          literal {
-                            null {
+                          source_context: {
+                            file: "tests/stmts.sysl"
+                            start: {
+                              line: 11
+                              col: 19
+                            }
+                            end: {
+                              line: 11
+                              col: 20
                             }
                           }
-                          type {
+                        }
+                        rhs: {
+                          literal: {
+                            null: {}
+                          }
+                          type: {
+                            primitive: EMPTY
+                          }
+                          source_context: {
+                            file: "tests/stmts.sysl"
+                            start: {
+                              line: 11
+                              col: 26
+                            }
+                            end: {
+                              line: 11
+                              col: 26
+                            }
+                          }
+                        }
+                      }
+                      source_context: {
+                        file: "tests/stmts.sysl"
+                        start: {
+                          line: 11
+                          col: 16
+                        }
+                        end: {
+                          line: 11
+                          col: 26
+                        }
+                      }
+                    }
+                    if_true: {
+                      literal: {
+                        null: {}
+                      }
+                      type: {
+                        primitive: EMPTY
+                      }
+                      source_context: {
+                        file: "tests/stmts.sysl"
+                        start: {
+                          line: 11
+                          col: 36
+                        }
+                        end: {
+                          line: 11
+                          col: 36
+                        }
+                      }
+                    }
+                    if_false: {
+                      call: {
+                        func: "transform"
+                        arg: {
+                          get_attr: {
+                            arg: {
+                              name: "bar"
+                              source_context: {
+                                file: "tests/stmts.sysl"
+                                start: {
+                                  line: 11
+                                  col: 56
+                                }
+                                end: {
+                                  line: 11
+                                  col: 56
+                                }
+                              }
+                            }
+                            attr: "id"
+                          }
+                          source_context: {
+                            file: "tests/stmts.sysl"
+                            start: {
+                              line: 11
+                              col: 59
+                            }
+                            end: {
+                              line: 11
+                              col: 60
+                            }
+                          }
+                        }
+                      }
+                      source_context: {
+                        file: "tests/stmts.sysl"
+                        start: {
+                          line: 11
+                          col: 46
+                        }
+                        end: {
+                          line: 11
+                          col: 62
+                        }
+                        text: "transform(bar.id)"
+                      }
+                    }
+                  }
+                  type: {
+                    no_type: {}
+                  }
+                  source_context: {
+                    file: "tests/stmts.sysl"
+                    start: {
+                      line: 11
+                      col: 6
+                    }
+                    end: {
+                      line: 11
+                      col: 62
+                    }
+                    text: "foo3 = if bar.id == null then null else transform(bar.id)"
+                  }
+                }
+              }
+            }
+            stmt: {
+              assign: {
+                name: "foo4"
+                expr: {
+                  ifelse: {
+                    cond: {
+                      call: {
+                        func: "bool"
+                        arg: {
+                          binexpr: {
+                            op: EQ
+                            lhs: {
+                              get_attr: {
+                                arg: {
+                                  name: "."
+                                  source_context: {
+                                    file: "tests/stmts.sysl"
+                                    start: {
+                                      line: 13
+                                      col: 8
+                                    }
+                                    end: {
+                                      line: 13
+                                      col: 9
+                                    }
+                                  }
+                                }
+                                attr: "a1"
+                              }
+                              source_context: {
+                                file: "tests/stmts.sysl"
+                                start: {
+                                  line: 13
+                                  col: 8
+                                }
+                                end: {
+                                  line: 13
+                                  col: 9
+                                }
+                              }
+                            }
+                            rhs: {
+                              literal: {
+                                b: true
+                              }
+                              type: {
+                                primitive: BOOL
+                              }
+                              source_context: {
+                                file: "tests/stmts.sysl"
+                                start: {
+                                  line: 13
+                                  col: 15
+                                }
+                                end: {
+                                  line: 13
+                                  col: 15
+                                }
+                              }
+                            }
+                          }
+                          source_context: {
+                            file: "tests/stmts.sysl"
+                            start: {
+                              line: 13
+                              col: 8
+                            }
+                            end: {
+                              line: 13
+                              col: 15
+                            }
+                          }
+                        }
+                      }
+                      source_context: {
+                        file: "tests/stmts.sysl"
+                        start: {
+                          line: 12
+                          col: 15
+                        }
+                        end: {
+                          line: 16
+                          col: 6
+                        }
+                      }
+                    }
+                    if_true: {
+                      binexpr: {
+                        op: ADD
+                        lhs: {
+                          get_attr: {
+                            arg: {
+                              name: "."
+                              source_context: {
+                                file: "tests/stmts.sysl"
+                                start: {
+                                  line: 13
+                                  col: 23
+                                }
+                                end: {
+                                  line: 13
+                                  col: 24
+                                }
+                              }
+                            }
+                            attr: "aa"
+                          }
+                          source_context: {
+                            file: "tests/stmts.sysl"
+                            start: {
+                              line: 13
+                              col: 23
+                            }
+                            end: {
+                              line: 13
+                              col: 24
+                            }
+                          }
+                        }
+                        rhs: {
+                          get_attr: {
+                            arg: {
+                              literal: {
+                                i: 3
+                              }
+                              source_context: {
+                                file: "tests/stmts.sysl"
+                                start: {
+                                  line: 13
+                                  col: 29
+                                }
+                                end: {
+                                  line: 13
+                                  col: 29
+                                }
+                              }
+                            }
+                            attr: "pqr"
+                          }
+                          source_context: {
+                            file: "tests/stmts.sysl"
+                            start: {
+                              line: 13
+                              col: 31
+                            }
+                            end: {
+                              line: 13
+                              col: 32
+                            }
+                          }
+                        }
+                      }
+                      type: {
+                        no_type: {}
+                      }
+                      source_context: {
+                        file: "tests/stmts.sysl"
+                        start: {
+                          line: 13
+                          col: 27
+                        }
+                        end: {
+                          line: 13
+                          col: 32
+                        }
+                      }
+                    }
+                    if_false: {
+                      ifelse: {
+                        cond: {
+                          call: {
+                            func: "bool"
+                            arg: {
+                              get_attr: {
+                                arg: {
+                                  name: "."
+                                  source_context: {
+                                    file: "tests/stmts.sysl"
+                                    start: {
+                                      line: 14
+                                      col: 8
+                                    }
+                                    end: {
+                                      line: 14
+                                      col: 9
+                                    }
+                                  }
+                                }
+                                attr: "a2"
+                              }
+                              source_context: {
+                                file: "tests/stmts.sysl"
+                                start: {
+                                  line: 14
+                                  col: 8
+                                }
+                                end: {
+                                  line: 14
+                                  col: 9
+                                }
+                              }
+                            }
+                          }
+                          source_context: {
+                            file: "tests/stmts.sysl"
+                            start: {
+                              line: 14
+                              col: 8
+                            }
+                            end: {
+                              line: 14
+                              col: 9
+                            }
+                          }
+                        }
+                        if_true: {
+                          ifelse: {
+                            cond: {
+                              call: {
+                                func: "bool"
+                                arg: {
+                                  get_attr: {
+                                    arg: {
+                                      name: "."
+                                      source_context: {
+                                        file: "tests/stmts.sysl"
+                                        start: {
+                                          line: 15
+                                          col: 10
+                                        }
+                                        end: {
+                                          line: 15
+                                          col: 11
+                                        }
+                                      }
+                                    }
+                                    attr: "bar"
+                                  }
+                                  source_context: {
+                                    file: "tests/stmts.sysl"
+                                    start: {
+                                      line: 15
+                                      col: 10
+                                    }
+                                    end: {
+                                      line: 15
+                                      col: 11
+                                    }
+                                  }
+                                }
+                              }
+                              source_context: {
+                                file: "tests/stmts.sysl"
+                                start: {
+                                  line: 14
+                                  col: 17
+                                }
+                                end: {
+                                  line: 16
+                                  col: 6
+                                }
+                              }
+                            }
+                            if_true: {
+                              binexpr: {
+                                op: ADD
+                                lhs: {
+                                  get_attr: {
+                                    arg: {
+                                      name: "."
+                                      source_context: {
+                                        file: "tests/stmts.sysl"
+                                        start: {
+                                          line: 15
+                                          col: 18
+                                        }
+                                        end: {
+                                          line: 15
+                                          col: 19
+                                        }
+                                      }
+                                    }
+                                    attr: "a3"
+                                  }
+                                  source_context: {
+                                    file: "tests/stmts.sysl"
+                                    start: {
+                                      line: 15
+                                      col: 18
+                                    }
+                                    end: {
+                                      line: 15
+                                      col: 19
+                                    }
+                                  }
+                                }
+                                rhs: {
+                                  literal: {
+                                    i: 4
+                                  }
+                                  type: {
+                                    primitive: INT
+                                  }
+                                  source_context: {
+                                    file: "tests/stmts.sysl"
+                                    start: {
+                                      line: 15
+                                      col: 24
+                                    }
+                                    end: {
+                                      line: 15
+                                      col: 24
+                                    }
+                                  }
+                                }
+                              }
+                              type: {
+                                primitive: INT
+                              }
+                              source_context: {
+                                file: "tests/stmts.sysl"
+                                start: {
+                                  line: 15
+                                  col: 22
+                                }
+                                end: {
+                                  line: 15
+                                  col: 24
+                                }
+                              }
+                            }
+                          }
+                          type: {
+                            primitive: INT
+                          }
+                        }
+                      }
+                      type: {
+                        primitive: INT
+                      }
+                    }
+                  }
+                  type: {
+                    primitive: INT
+                  }
+                  source_context: {
+                    file: "tests/stmts.sysl"
+                    start: {
+                      line: 12
+                      col: 6
+                    }
+                    end: {
+                      line: 16
+                      col: 6
+                    }
+                    text: "foo4 = if:\n        .a1 == true => .aa + 3 .pqr\n        .a2 => if:\n          .bar => .a3 + 4\n      foo5 = if:\n        .a1 == 2 => .aa + 2 .pqr\n        .a1 == 3 => .aa + 3 .pqr\n      foo6 = if .a1 ==:\n        2 => .aa + 2 .pqr\n        3 => .aa + 3 .pqr\n      foo7 = if .a1 ==:\n        2, 3 => .aa + 3 .pqr\n        4 => if:\n          .aa == \"b\" => .bb\n          else null\n        else null\n      foo8 = if .a1 ==:\n        2, 3 => .aa + 3 .pqr\n        else if .a1 ==:\n          2, 3 => .aa + 3 .pqr\n          else null\n      funccall(\"arg\").*\n    )\n"
+                  }
+                }
+              }
+            }
+            stmt: {
+              assign: {
+                name: "foo5"
+                expr: {
+                  ifelse: {
+                    cond: {
+                      call: {
+                        func: "bool"
+                        arg: {
+                          binexpr: {
+                            op: EQ
+                            lhs: {
+                              get_attr: {
+                                arg: {
+                                  name: "."
+                                  source_context: {
+                                    file: "tests/stmts.sysl"
+                                    start: {
+                                      line: 17
+                                      col: 8
+                                    }
+                                    end: {
+                                      line: 17
+                                      col: 9
+                                    }
+                                  }
+                                }
+                                attr: "a1"
+                              }
+                              source_context: {
+                                file: "tests/stmts.sysl"
+                                start: {
+                                  line: 17
+                                  col: 8
+                                }
+                                end: {
+                                  line: 17
+                                  col: 9
+                                }
+                              }
+                            }
+                            rhs: {
+                              literal: {
+                                i: 2
+                              }
+                              source_context: {
+                                file: "tests/stmts.sysl"
+                                start: {
+                                  line: 17
+                                  col: 15
+                                }
+                                end: {
+                                  line: 17
+                                  col: 15
+                                }
+                              }
+                            }
+                          }
+                          source_context: {
+                            file: "tests/stmts.sysl"
+                            start: {
+                              line: 17
+                              col: 8
+                            }
+                            end: {
+                              line: 17
+                              col: 15
+                            }
+                          }
+                        }
+                      }
+                      source_context: {
+                        file: "tests/stmts.sysl"
+                        start: {
+                          line: 16
+                          col: 15
+                        }
+                        end: {
+                          line: 19
+                          col: 6
+                        }
+                      }
+                    }
+                    if_true: {
+                      binexpr: {
+                        op: ADD
+                        lhs: {
+                          get_attr: {
+                            arg: {
+                              name: "."
+                              source_context: {
+                                file: "tests/stmts.sysl"
+                                start: {
+                                  line: 17
+                                  col: 20
+                                }
+                                end: {
+                                  line: 17
+                                  col: 21
+                                }
+                              }
+                            }
+                            attr: "aa"
+                          }
+                          source_context: {
+                            file: "tests/stmts.sysl"
+                            start: {
+                              line: 17
+                              col: 20
+                            }
+                            end: {
+                              line: 17
+                              col: 21
+                            }
+                          }
+                        }
+                        rhs: {
+                          get_attr: {
+                            arg: {
+                              literal: {
+                                i: 2
+                              }
+                              source_context: {
+                                file: "tests/stmts.sysl"
+                                start: {
+                                  line: 17
+                                  col: 26
+                                }
+                                end: {
+                                  line: 17
+                                  col: 26
+                                }
+                              }
+                            }
+                            attr: "pqr"
+                          }
+                          source_context: {
+                            file: "tests/stmts.sysl"
+                            start: {
+                              line: 17
+                              col: 28
+                            }
+                            end: {
+                              line: 17
+                              col: 29
+                            }
+                          }
+                        }
+                      }
+                      type: {
+                        no_type: {}
+                      }
+                      source_context: {
+                        file: "tests/stmts.sysl"
+                        start: {
+                          line: 17
+                          col: 24
+                        }
+                        end: {
+                          line: 17
+                          col: 29
+                        }
+                      }
+                    }
+                    if_false: {
+                      ifelse: {
+                        cond: {
+                          call: {
+                            func: "bool"
+                            arg: {
+                              binexpr: {
+                                op: EQ
+                                lhs: {
+                                  get_attr: {
+                                    arg: {
+                                      name: "."
+                                      source_context: {
+                                        file: "tests/stmts.sysl"
+                                        start: {
+                                          line: 18
+                                          col: 8
+                                        }
+                                        end: {
+                                          line: 18
+                                          col: 9
+                                        }
+                                      }
+                                    }
+                                    attr: "a1"
+                                  }
+                                  source_context: {
+                                    file: "tests/stmts.sysl"
+                                    start: {
+                                      line: 18
+                                      col: 8
+                                    }
+                                    end: {
+                                      line: 18
+                                      col: 9
+                                    }
+                                  }
+                                }
+                                rhs: {
+                                  literal: {
+                                    i: 3
+                                  }
+                                  source_context: {
+                                    file: "tests/stmts.sysl"
+                                    start: {
+                                      line: 18
+                                      col: 15
+                                    }
+                                    end: {
+                                      line: 18
+                                      col: 15
+                                    }
+                                  }
+                                }
+                              }
+                              source_context: {
+                                file: "tests/stmts.sysl"
+                                start: {
+                                  line: 18
+                                  col: 8
+                                }
+                                end: {
+                                  line: 18
+                                  col: 15
+                                }
+                              }
+                            }
+                          }
+                          source_context: {
+                            file: "tests/stmts.sysl"
+                            start: {
+                              line: 18
+                              col: 8
+                            }
+                            end: {
+                              line: 18
+                              col: 15
+                            }
+                          }
+                        }
+                        if_true: {
+                          binexpr: {
+                            op: ADD
+                            lhs: {
+                              get_attr: {
+                                arg: {
+                                  name: "."
+                                  source_context: {
+                                    file: "tests/stmts.sysl"
+                                    start: {
+                                      line: 18
+                                      col: 20
+                                    }
+                                    end: {
+                                      line: 18
+                                      col: 21
+                                    }
+                                  }
+                                }
+                                attr: "aa"
+                              }
+                              source_context: {
+                                file: "tests/stmts.sysl"
+                                start: {
+                                  line: 18
+                                  col: 20
+                                }
+                                end: {
+                                  line: 18
+                                  col: 21
+                                }
+                              }
+                            }
+                            rhs: {
+                              get_attr: {
+                                arg: {
+                                  literal: {
+                                    i: 3
+                                  }
+                                  source_context: {
+                                    file: "tests/stmts.sysl"
+                                    start: {
+                                      line: 18
+                                      col: 26
+                                    }
+                                    end: {
+                                      line: 18
+                                      col: 26
+                                    }
+                                  }
+                                }
+                                attr: "pqr"
+                              }
+                              source_context: {
+                                file: "tests/stmts.sysl"
+                                start: {
+                                  line: 18
+                                  col: 28
+                                }
+                                end: {
+                                  line: 18
+                                  col: 29
+                                }
+                              }
+                            }
+                          }
+                          type: {
+                            no_type: {}
+                          }
+                          source_context: {
+                            file: "tests/stmts.sysl"
+                            start: {
+                              line: 18
+                              col: 24
+                            }
+                            end: {
+                              line: 18
+                              col: 29
+                            }
+                          }
+                        }
+                      }
+                      type: {
+                        no_type: {}
+                      }
+                    }
+                  }
+                  type: {
+                    no_type: {}
+                  }
+                  source_context: {
+                    file: "tests/stmts.sysl"
+                    start: {
+                      line: 16
+                      col: 6
+                    }
+                    end: {
+                      line: 19
+                      col: 6
+                    }
+                    text: "foo5 = if:\n        .a1 == 2 => .aa + 2 .pqr\n        .a1 == 3 => .aa + 3 .pqr\n      foo6 = if .a1 ==:\n        2 => .aa + 2 .pqr\n        3 => .aa + 3 .pqr\n      foo7 = if .a1 ==:\n        2, 3 => .aa + 3 .pqr\n        4 => if:\n          .aa == \"b\" => .bb\n          else null\n        else null\n      foo8 = if .a1 ==:\n        2, 3 => .aa + 3 .pqr\n        else if .a1 ==:\n          2, 3 => .aa + 3 .pqr\n          else null\n      funccall(\"arg\").*\n    )\n"
+                  }
+                }
+              }
+            }
+            stmt: {
+              assign: {
+                name: "foo6"
+                expr: {
+                  ifelse: {
+                    cond: {
+                      binexpr: {
+                        op: EQ
+                        lhs: {
+                          get_attr: {
+                            arg: {
+                              name: "."
+                              source_context: {
+                                file: "tests/stmts.sysl"
+                                start: {
+                                  line: 19
+                                  col: 16
+                                }
+                                end: {
+                                  line: 19
+                                  col: 17
+                                }
+                              }
+                            }
+                            attr: "a1"
+                          }
+                          source_context: {
+                            file: "tests/stmts.sysl"
+                            start: {
+                              line: 19
+                              col: 16
+                            }
+                            end: {
+                              line: 19
+                              col: 17
+                            }
+                          }
+                        }
+                        rhs: {
+                          literal: {
+                            i: 2
+                          }
+                          source_context: {
+                            file: "tests/stmts.sysl"
+                            start: {
+                              line: 20
+                              col: 8
+                            }
+                            end: {
+                              line: 20
+                              col: 8
+                            }
+                          }
+                        }
+                      }
+                      source_context: {
+                        file: "tests/stmts.sysl"
+                        start: {
+                          line: 19
+                          col: 16
+                        }
+                        end: {
+                          line: 19
+                          col: 20
+                        }
+                      }
+                    }
+                    if_true: {
+                      binexpr: {
+                        op: ADD
+                        lhs: {
+                          get_attr: {
+                            arg: {
+                              name: "."
+                              source_context: {
+                                file: "tests/stmts.sysl"
+                                start: {
+                                  line: 20
+                                  col: 13
+                                }
+                                end: {
+                                  line: 20
+                                  col: 14
+                                }
+                              }
+                            }
+                            attr: "aa"
+                          }
+                          source_context: {
+                            file: "tests/stmts.sysl"
+                            start: {
+                              line: 20
+                              col: 13
+                            }
+                            end: {
+                              line: 20
+                              col: 14
+                            }
+                          }
+                        }
+                        rhs: {
+                          get_attr: {
+                            arg: {
+                              literal: {
+                                i: 2
+                              }
+                              source_context: {
+                                file: "tests/stmts.sysl"
+                                start: {
+                                  line: 20
+                                  col: 19
+                                }
+                                end: {
+                                  line: 20
+                                  col: 19
+                                }
+                              }
+                            }
+                            attr: "pqr"
+                          }
+                          source_context: {
+                            file: "tests/stmts.sysl"
+                            start: {
+                              line: 20
+                              col: 21
+                            }
+                            end: {
+                              line: 20
+                              col: 22
+                            }
+                          }
+                        }
+                      }
+                      type: {
+                        no_type: {}
+                      }
+                      source_context: {
+                        file: "tests/stmts.sysl"
+                        start: {
+                          line: 20
+                          col: 17
+                        }
+                        end: {
+                          line: 20
+                          col: 22
+                        }
+                      }
+                    }
+                    if_false: {
+                      ifelse: {
+                        cond: {
+                          binexpr: {
+                            op: EQ
+                            lhs: {
+                              get_attr: {
+                                arg: {
+                                  name: "."
+                                  source_context: {
+                                    file: "tests/stmts.sysl"
+                                    start: {
+                                      line: 19
+                                      col: 16
+                                    }
+                                    end: {
+                                      line: 19
+                                      col: 17
+                                    }
+                                  }
+                                }
+                                attr: "a1"
+                              }
+                              source_context: {
+                                file: "tests/stmts.sysl"
+                                start: {
+                                  line: 19
+                                  col: 16
+                                }
+                                end: {
+                                  line: 19
+                                  col: 17
+                                }
+                              }
+                            }
+                            rhs: {
+                              literal: {
+                                i: 3
+                              }
+                              source_context: {
+                                file: "tests/stmts.sysl"
+                                start: {
+                                  line: 21
+                                  col: 8
+                                }
+                                end: {
+                                  line: 21
+                                  col: 8
+                                }
+                              }
+                            }
+                          }
+                          source_context: {
+                            file: "tests/stmts.sysl"
+                            start: {
+                              line: 21
+                              col: 8
+                            }
+                            end: {
+                              line: 21
+                              col: 8
+                            }
+                          }
+                        }
+                        if_true: {
+                          binexpr: {
+                            op: ADD
+                            lhs: {
+                              get_attr: {
+                                arg: {
+                                  name: "."
+                                  source_context: {
+                                    file: "tests/stmts.sysl"
+                                    start: {
+                                      line: 21
+                                      col: 13
+                                    }
+                                    end: {
+                                      line: 21
+                                      col: 14
+                                    }
+                                  }
+                                }
+                                attr: "aa"
+                              }
+                              source_context: {
+                                file: "tests/stmts.sysl"
+                                start: {
+                                  line: 21
+                                  col: 13
+                                }
+                                end: {
+                                  line: 21
+                                  col: 14
+                                }
+                              }
+                            }
+                            rhs: {
+                              get_attr: {
+                                arg: {
+                                  literal: {
+                                    i: 3
+                                  }
+                                  source_context: {
+                                    file: "tests/stmts.sysl"
+                                    start: {
+                                      line: 21
+                                      col: 19
+                                    }
+                                    end: {
+                                      line: 21
+                                      col: 19
+                                    }
+                                  }
+                                }
+                                attr: "pqr"
+                              }
+                              source_context: {
+                                file: "tests/stmts.sysl"
+                                start: {
+                                  line: 21
+                                  col: 21
+                                }
+                                end: {
+                                  line: 21
+                                  col: 22
+                                }
+                              }
+                            }
+                          }
+                          type: {
+                            no_type: {}
+                          }
+                          source_context: {
+                            file: "tests/stmts.sysl"
+                            start: {
+                              line: 21
+                              col: 17
+                            }
+                            end: {
+                              line: 21
+                              col: 22
+                            }
+                          }
+                        }
+                      }
+                      type: {
+                        no_type: {}
+                      }
+                    }
+                  }
+                  type: {
+                    no_type: {}
+                  }
+                  source_context: {
+                    file: "tests/stmts.sysl"
+                    start: {
+                      line: 19
+                      col: 6
+                    }
+                    end: {
+                      line: 22
+                      col: 6
+                    }
+                    text: "foo6 = if .a1 ==:\n        2 => .aa + 2 .pqr\n        3 => .aa + 3 .pqr\n      foo7 = if .a1 ==:\n        2, 3 => .aa + 3 .pqr\n        4 => if:\n          .aa == \"b\" => .bb\n          else null\n        else null\n      foo8 = if .a1 ==:\n        2, 3 => .aa + 3 .pqr\n        else if .a1 ==:\n          2, 3 => .aa + 3 .pqr\n          else null\n      funccall(\"arg\").*\n    )\n"
+                  }
+                }
+              }
+            }
+            stmt: {
+              assign: {
+                name: "foo7"
+                expr: {
+                  ifelse: {
+                    cond: {
+                      binexpr: {
+                        op: EQ
+                        lhs: {
+                          get_attr: {
+                            arg: {
+                              name: "."
+                              source_context: {
+                                file: "tests/stmts.sysl"
+                                start: {
+                                  line: 22
+                                  col: 16
+                                }
+                                end: {
+                                  line: 22
+                                  col: 17
+                                }
+                              }
+                            }
+                            attr: "a1"
+                          }
+                          source_context: {
+                            file: "tests/stmts.sysl"
+                            start: {
+                              line: 22
+                              col: 16
+                            }
+                            end: {
+                              line: 22
+                              col: 17
+                            }
+                          }
+                        }
+                        rhs: {
+                          literal: {
+                            i: 2
+                          }
+                          source_context: {
+                            file: "tests/stmts.sysl"
+                            start: {
+                              line: 23
+                              col: 8
+                            }
+                            end: {
+                              line: 23
+                              col: 8
+                            }
+                          }
+                        }
+                      }
+                      source_context: {
+                        file: "tests/stmts.sysl"
+                        start: {
+                          line: 22
+                          col: 16
+                        }
+                        end: {
+                          line: 22
+                          col: 20
+                        }
+                      }
+                    }
+                    if_true: {
+                      binexpr: {
+                        op: ADD
+                        lhs: {
+                          get_attr: {
+                            arg: {
+                              name: "."
+                              source_context: {
+                                file: "tests/stmts.sysl"
+                                start: {
+                                  line: 23
+                                  col: 16
+                                }
+                                end: {
+                                  line: 23
+                                  col: 17
+                                }
+                              }
+                            }
+                            attr: "aa"
+                          }
+                          source_context: {
+                            file: "tests/stmts.sysl"
+                            start: {
+                              line: 23
+                              col: 16
+                            }
+                            end: {
+                              line: 23
+                              col: 17
+                            }
+                          }
+                        }
+                        rhs: {
+                          get_attr: {
+                            arg: {
+                              literal: {
+                                i: 3
+                              }
+                              source_context: {
+                                file: "tests/stmts.sysl"
+                                start: {
+                                  line: 23
+                                  col: 22
+                                }
+                                end: {
+                                  line: 23
+                                  col: 22
+                                }
+                              }
+                            }
+                            attr: "pqr"
+                          }
+                          source_context: {
+                            file: "tests/stmts.sysl"
+                            start: {
+                              line: 23
+                              col: 24
+                            }
+                            end: {
+                              line: 23
+                              col: 25
+                            }
+                          }
+                        }
+                      }
+                      type: {
+                        no_type: {}
+                      }
+                      source_context: {
+                        file: "tests/stmts.sysl"
+                        start: {
+                          line: 23
+                          col: 20
+                        }
+                        end: {
+                          line: 23
+                          col: 25
+                        }
+                      }
+                    }
+                    if_false: {
+                      ifelse: {
+                        cond: {
+                          binexpr: {
+                            op: EQ
+                            lhs: {
+                              get_attr: {
+                                arg: {
+                                  name: "."
+                                  source_context: {
+                                    file: "tests/stmts.sysl"
+                                    start: {
+                                      line: 22
+                                      col: 16
+                                    }
+                                    end: {
+                                      line: 22
+                                      col: 17
+                                    }
+                                  }
+                                }
+                                attr: "a1"
+                              }
+                              source_context: {
+                                file: "tests/stmts.sysl"
+                                start: {
+                                  line: 22
+                                  col: 16
+                                }
+                                end: {
+                                  line: 22
+                                  col: 17
+                                }
+                              }
+                            }
+                            rhs: {
+                              literal: {
+                                i: 3
+                              }
+                              source_context: {
+                                file: "tests/stmts.sysl"
+                                start: {
+                                  line: 23
+                                  col: 11
+                                }
+                                end: {
+                                  line: 23
+                                  col: 11
+                                }
+                              }
+                            }
+                          }
+                          source_context: {
+                            file: "tests/stmts.sysl"
+                            start: {
+                              line: 23
+                              col: 11
+                            }
+                            end: {
+                              line: 23
+                              col: 11
+                            }
+                          }
+                        }
+                        if_true: {
+                          binexpr: {
+                            op: ADD
+                            lhs: {
+                              get_attr: {
+                                arg: {
+                                  name: "."
+                                  source_context: {
+                                    file: "tests/stmts.sysl"
+                                    start: {
+                                      line: 23
+                                      col: 16
+                                    }
+                                    end: {
+                                      line: 23
+                                      col: 17
+                                    }
+                                  }
+                                }
+                                attr: "aa"
+                              }
+                              source_context: {
+                                file: "tests/stmts.sysl"
+                                start: {
+                                  line: 23
+                                  col: 16
+                                }
+                                end: {
+                                  line: 23
+                                  col: 17
+                                }
+                              }
+                            }
+                            rhs: {
+                              get_attr: {
+                                arg: {
+                                  literal: {
+                                    i: 3
+                                  }
+                                  source_context: {
+                                    file: "tests/stmts.sysl"
+                                    start: {
+                                      line: 23
+                                      col: 22
+                                    }
+                                    end: {
+                                      line: 23
+                                      col: 22
+                                    }
+                                  }
+                                }
+                                attr: "pqr"
+                              }
+                              source_context: {
+                                file: "tests/stmts.sysl"
+                                start: {
+                                  line: 23
+                                  col: 24
+                                }
+                                end: {
+                                  line: 23
+                                  col: 25
+                                }
+                              }
+                            }
+                          }
+                          type: {
+                            no_type: {}
+                          }
+                          source_context: {
+                            file: "tests/stmts.sysl"
+                            start: {
+                              line: 23
+                              col: 20
+                            }
+                            end: {
+                              line: 23
+                              col: 25
+                            }
+                          }
+                        }
+                        if_false: {
+                          ifelse: {
+                            cond: {
+                              binexpr: {
+                                op: EQ
+                                lhs: {
+                                  get_attr: {
+                                    arg: {
+                                      name: "."
+                                      source_context: {
+                                        file: "tests/stmts.sysl"
+                                        start: {
+                                          line: 22
+                                          col: 16
+                                        }
+                                        end: {
+                                          line: 22
+                                          col: 17
+                                        }
+                                      }
+                                    }
+                                    attr: "a1"
+                                  }
+                                  source_context: {
+                                    file: "tests/stmts.sysl"
+                                    start: {
+                                      line: 22
+                                      col: 16
+                                    }
+                                    end: {
+                                      line: 22
+                                      col: 17
+                                    }
+                                  }
+                                }
+                                rhs: {
+                                  literal: {
+                                    i: 4
+                                  }
+                                  source_context: {
+                                    file: "tests/stmts.sysl"
+                                    start: {
+                                      line: 24
+                                      col: 8
+                                    }
+                                    end: {
+                                      line: 24
+                                      col: 8
+                                    }
+                                  }
+                                }
+                              }
+                              source_context: {
+                                file: "tests/stmts.sysl"
+                                start: {
+                                  line: 24
+                                  col: 8
+                                }
+                                end: {
+                                  line: 24
+                                  col: 8
+                                }
+                              }
+                            }
+                            if_true: {
+                              ifelse: {
+                                cond: {
+                                  call: {
+                                    func: "bool"
+                                    arg: {
+                                      binexpr: {
+                                        op: EQ
+                                        lhs: {
+                                          get_attr: {
+                                            arg: {
+                                              name: "."
+                                              source_context: {
+                                                file: "tests/stmts.sysl"
+                                                start: {
+                                                  line: 25
+                                                  col: 10
+                                                }
+                                                end: {
+                                                  line: 25
+                                                  col: 11
+                                                }
+                                              }
+                                            }
+                                            attr: "aa"
+                                          }
+                                          source_context: {
+                                            file: "tests/stmts.sysl"
+                                            start: {
+                                              line: 25
+                                              col: 10
+                                            }
+                                            end: {
+                                              line: 25
+                                              col: 11
+                                            }
+                                          }
+                                        }
+                                        rhs: {
+                                          literal: {
+                                            s: "b"
+                                          }
+                                          source_context: {
+                                            file: "tests/stmts.sysl"
+                                            start: {
+                                              line: 25
+                                              col: 17
+                                            }
+                                            end: {
+                                              line: 25
+                                              col: 17
+                                            }
+                                          }
+                                        }
+                                      }
+                                      source_context: {
+                                        file: "tests/stmts.sysl"
+                                        start: {
+                                          line: 25
+                                          col: 10
+                                        }
+                                        end: {
+                                          line: 25
+                                          col: 17
+                                        }
+                                      }
+                                    }
+                                  }
+                                  source_context: {
+                                    file: "tests/stmts.sysl"
+                                    start: {
+                                      line: 24
+                                      col: 15
+                                    }
+                                    end: {
+                                      line: 27
+                                      col: 8
+                                    }
+                                  }
+                                }
+                                if_true: {
+                                  get_attr: {
+                                    arg: {
+                                      name: "."
+                                      source_context: {
+                                        file: "tests/stmts.sysl"
+                                        start: {
+                                          line: 25
+                                          col: 24
+                                        }
+                                        end: {
+                                          line: 25
+                                          col: 25
+                                        }
+                                      }
+                                    }
+                                    attr: "bb"
+                                  }
+                                  source_context: {
+                                    file: "tests/stmts.sysl"
+                                    start: {
+                                      line: 25
+                                      col: 24
+                                    }
+                                    end: {
+                                      line: 25
+                                      col: 25
+                                    }
+                                  }
+                                }
+                                if_false: {
+                                  literal: {
+                                    null: {}
+                                  }
+                                  type: {
+                                    primitive: EMPTY
+                                  }
+                                  source_context: {
+                                    file: "tests/stmts.sysl"
+                                    start: {
+                                      line: 26
+                                      col: 15
+                                    }
+                                    end: {
+                                      line: 26
+                                      col: 15
+                                    }
+                                  }
+                                }
+                              }
+                              type: {
+                                primitive: EMPTY
+                              }
+                            }
+                            if_false: {
+                              literal: {
+                                null: {}
+                              }
+                              type: {
+                                primitive: EMPTY
+                              }
+                              source_context: {
+                                file: "tests/stmts.sysl"
+                                start: {
+                                  line: 27
+                                  col: 13
+                                }
+                                end: {
+                                  line: 27
+                                  col: 13
+                                }
+                              }
+                            }
+                          }
+                          type: {
                             primitive: EMPTY
                           }
                         }
                       }
-                    }
-                    if_true {
-                      literal {
-                        null {
-                        }
-                      }
-                      type {
+                      type: {
                         primitive: EMPTY
                       }
                     }
-                    if_false {
-                      call {
-                        func: "transform"
-                        arg {
-                          get_attr {
-                            arg {
-                              name: "bar"
-                            }
-                            attr: "id"
-                          }
-                        }
-                      }
+                  }
+                  type: {
+                    primitive: EMPTY
+                  }
+                  source_context: {
+                    file: "tests/stmts.sysl"
+                    start: {
+                      line: 22
+                      col: 6
                     }
+                    end: {
+                      line: 28
+                      col: 6
+                    }
+                    text: "foo7 = if .a1 ==:\n        2, 3 => .aa + 3 .pqr\n        4 => if:\n          .aa == \"b\" => .bb\n          else null\n        else null\n      foo8 = if .a1 ==:\n        2, 3 => .aa + 3 .pqr\n        else if .a1 ==:\n          2, 3 => .aa + 3 .pqr\n          else null\n      funccall(\"arg\").*\n    )\n"
                   }
                 }
               }
             }
-            stmt {
-              assign {
-                name: "foo4"
-                expr {
-                  ifelse {
-                    cond {
-                      call {
-                        func: "bool"
-                        arg {
-                          binexpr {
-                            op: EQ
-                            lhs {
-                              get_attr {
-                                arg {
-                                  name: "."
-                                }
-                                attr: "a1"
-                              }
-                            }
-                            rhs {
-                              literal {
-                                b: true
-                              }
-                              type {
-                                primitive: BOOL
-                              }
-                            }
-                          }
-                        }
-                      }
-                    }
-                    if_true {
-                      binexpr {
-                        op: ADD
-                        lhs {
-                          get_attr {
-                            arg {
-                              name: "."
-                            }
-                            attr: "aa"
-                          }
-                        }
-                        rhs {
-                          get_attr {
-                            arg {
-                              literal {
-                                i: 3
-                              }
-                            }
-                            attr: "pqr"
-                          }
-                        }
-                      }
-                    }
-                    if_false {
-                      ifelse {
-                        cond {
-                          call {
-                            func: "bool"
-                            arg {
-                              get_attr {
-                                arg {
-                                  name: "."
-                                }
-                                attr: "a2"
-                              }
-                            }
-                          }
-                        }
-                        if_true {
-                          ifelse {
-                            cond {
-                              call {
-                                func: "bool"
-                                arg {
-                                  get_attr {
-                                    arg {
-                                      name: "."
-                                    }
-                                    attr: "bar"
-                                  }
-                                }
-                              }
-                            }
-                            if_true {
-                              binexpr {
-                                op: ADD
-                                lhs {
-                                  get_attr {
-                                    arg {
-                                      name: "."
-                                    }
-                                    attr: "a3"
-                                  }
-                                }
-                                rhs {
-                                  literal {
-                                    i: 4
-                                  }
-                                }
-                              }
-                            }
-                          }
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            }
-            stmt {
-              assign {
-                name: "foo5"
-                expr {
-                  ifelse {
-                    cond {
-                      call {
-                        func: "bool"
-                        arg {
-                          binexpr {
-                            op: EQ
-                            lhs {
-                              get_attr {
-                                arg {
-                                  name: "."
-                                }
-                                attr: "a1"
-                              }
-                            }
-                            rhs {
-                              literal {
-                                i: 2
-                              }
-                            }
-                          }
-                        }
-                      }
-                    }
-                    if_true {
-                      binexpr {
-                        op: ADD
-                        lhs {
-                          get_attr {
-                            arg {
-                              name: "."
-                            }
-                            attr: "aa"
-                          }
-                        }
-                        rhs {
-                          get_attr {
-                            arg {
-                              literal {
-                                i: 2
-                              }
-                            }
-                            attr: "pqr"
-                          }
-                        }
-                      }
-                    }
-                    if_false {
-                      ifelse {
-                        cond {
-                          call {
-                            func: "bool"
-                            arg {
-                              binexpr {
-                                op: EQ
-                                lhs {
-                                  get_attr {
-                                    arg {
-                                      name: "."
-                                    }
-                                    attr: "a1"
-                                  }
-                                }
-                                rhs {
-                                  literal {
-                                    i: 3
-                                  }
-                                }
-                              }
-                            }
-                          }
-                        }
-                        if_true {
-                          binexpr {
-                            op: ADD
-                            lhs {
-                              get_attr {
-                                arg {
-                                  name: "."
-                                }
-                                attr: "aa"
-                              }
-                            }
-                            rhs {
-                              get_attr {
-                                arg {
-                                  literal {
-                                    i: 3
-                                  }
-                                }
-                                attr: "pqr"
-                              }
-                            }
-                          }
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            }
-            stmt {
-              assign {
-                name: "foo6"
-                expr {
-                  ifelse {
-                    cond {
-                      binexpr {
+            stmt: {
+              assign: {
+                name: "foo8"
+                expr: {
+                  ifelse: {
+                    cond: {
+                      binexpr: {
                         op: EQ
-                        lhs {
-                          get_attr {
-                            arg {
+                        lhs: {
+                          get_attr: {
+                            arg: {
                               name: "."
+                              source_context: {
+                                file: "tests/stmts.sysl"
+                                start: {
+                                  line: 28
+                                  col: 16
+                                }
+                                end: {
+                                  line: 28
+                                  col: 17
+                                }
+                              }
                             }
                             attr: "a1"
                           }
+                          source_context: {
+                            file: "tests/stmts.sysl"
+                            start: {
+                              line: 28
+                              col: 16
+                            }
+                            end: {
+                              line: 28
+                              col: 17
+                            }
+                          }
                         }
-                        rhs {
-                          literal {
+                        rhs: {
+                          literal: {
                             i: 2
+                          }
+                          source_context: {
+                            file: "tests/stmts.sysl"
+                            start: {
+                              line: 29
+                              col: 8
+                            }
+                            end: {
+                              line: 29
+                              col: 8
+                            }
                           }
                         }
                       }
+                      source_context: {
+                        file: "tests/stmts.sysl"
+                        start: {
+                          line: 28
+                          col: 16
+                        }
+                        end: {
+                          line: 28
+                          col: 20
+                        }
+                      }
                     }
-                    if_true {
-                      binexpr {
+                    if_true: {
+                      binexpr: {
                         op: ADD
-                        lhs {
-                          get_attr {
-                            arg {
+                        lhs: {
+                          get_attr: {
+                            arg: {
                               name: "."
+                              source_context: {
+                                file: "tests/stmts.sysl"
+                                start: {
+                                  line: 29
+                                  col: 16
+                                }
+                                end: {
+                                  line: 29
+                                  col: 17
+                                }
+                              }
                             }
                             attr: "aa"
                           }
+                          source_context: {
+                            file: "tests/stmts.sysl"
+                            start: {
+                              line: 29
+                              col: 16
+                            }
+                            end: {
+                              line: 29
+                              col: 17
+                            }
+                          }
                         }
-                        rhs {
-                          get_attr {
-                            arg {
-                              literal {
-                                i: 2
+                        rhs: {
+                          get_attr: {
+                            arg: {
+                              literal: {
+                                i: 3
+                              }
+                              source_context: {
+                                file: "tests/stmts.sysl"
+                                start: {
+                                  line: 29
+                                  col: 22
+                                }
+                                end: {
+                                  line: 29
+                                  col: 22
+                                }
                               }
                             }
                             attr: "pqr"
                           }
+                          source_context: {
+                            file: "tests/stmts.sysl"
+                            start: {
+                              line: 29
+                              col: 24
+                            }
+                            end: {
+                              line: 29
+                              col: 25
+                            }
+                          }
+                        }
+                      }
+                      type: {
+                        no_type: {}
+                      }
+                      source_context: {
+                        file: "tests/stmts.sysl"
+                        start: {
+                          line: 29
+                          col: 20
+                        }
+                        end: {
+                          line: 29
+                          col: 25
                         }
                       }
                     }
-                    if_false {
-                      ifelse {
-                        cond {
-                          binexpr {
+                    if_false: {
+                      ifelse: {
+                        cond: {
+                          binexpr: {
                             op: EQ
-                            lhs {
-                              get_attr {
-                                arg {
+                            lhs: {
+                              get_attr: {
+                                arg: {
                                   name: "."
-                                }
-                                attr: "a1"
-                              }
-                            }
-                            rhs {
-                              literal {
-                                i: 3
-                              }
-                            }
-                          }
-                        }
-                        if_true {
-                          binexpr {
-                            op: ADD
-                            lhs {
-                              get_attr {
-                                arg {
-                                  name: "."
-                                }
-                                attr: "aa"
-                              }
-                            }
-                            rhs {
-                              get_attr {
-                                arg {
-                                  literal {
-                                    i: 3
-                                  }
-                                }
-                                attr: "pqr"
-                              }
-                            }
-                          }
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            }
-            stmt {
-              assign {
-                name: "foo7"
-                expr {
-                  ifelse {
-                    cond {
-                      binexpr {
-                        op: EQ
-                        lhs {
-                          get_attr {
-                            arg {
-                              name: "."
-                            }
-                            attr: "a1"
-                          }
-                        }
-                        rhs {
-                          literal {
-                            i: 2
-                          }
-                        }
-                      }
-                    }
-                    if_true {
-                      binexpr {
-                        op: ADD
-                        lhs {
-                          get_attr {
-                            arg {
-                              name: "."
-                            }
-                            attr: "aa"
-                          }
-                        }
-                        rhs {
-                          get_attr {
-                            arg {
-                              literal {
-                                i: 3
-                              }
-                            }
-                            attr: "pqr"
-                          }
-                        }
-                      }
-                    }
-                    if_false {
-                      ifelse {
-                        cond {
-                          binexpr {
-                            op: EQ
-                            lhs {
-                              get_attr {
-                                arg {
-                                  name: "."
-                                }
-                                attr: "a1"
-                              }
-                            }
-                            rhs {
-                              literal {
-                                i: 3
-                              }
-                            }
-                          }
-                        }
-                        if_true {
-                          binexpr {
-                            op: ADD
-                            lhs {
-                              get_attr {
-                                arg {
-                                  name: "."
-                                }
-                                attr: "aa"
-                              }
-                            }
-                            rhs {
-                              get_attr {
-                                arg {
-                                  literal {
-                                    i: 3
-                                  }
-                                }
-                                attr: "pqr"
-                              }
-                            }
-                          }
-                        }
-                        if_false {
-                          ifelse {
-                            cond {
-                              binexpr {
-                                op: EQ
-                                lhs {
-                                  get_attr {
-                                    arg {
-                                      name: "."
+                                  source_context: {
+                                    file: "tests/stmts.sysl"
+                                    start: {
+                                      line: 28
+                                      col: 16
                                     }
-                                    attr: "a1"
+                                    end: {
+                                      line: 28
+                                      col: 17
+                                    }
                                   }
                                 }
-                                rhs {
-                                  literal {
-                                    i: 4
-                                  }
+                                attr: "a1"
+                              }
+                              source_context: {
+                                file: "tests/stmts.sysl"
+                                start: {
+                                  line: 28
+                                  col: 16
+                                }
+                                end: {
+                                  line: 28
+                                  col: 17
                                 }
                               }
                             }
-                            if_true {
-                              ifelse {
-                                cond {
-                                  call {
-                                    func: "bool"
-                                    arg {
-                                      binexpr {
-                                        op: EQ
-                                        lhs {
-                                          get_attr {
-                                            arg {
-                                              name: "."
-                                            }
-                                            attr: "aa"
-                                          }
+                            rhs: {
+                              literal: {
+                                i: 3
+                              }
+                              source_context: {
+                                file: "tests/stmts.sysl"
+                                start: {
+                                  line: 29
+                                  col: 11
+                                }
+                                end: {
+                                  line: 29
+                                  col: 11
+                                }
+                              }
+                            }
+                          }
+                          source_context: {
+                            file: "tests/stmts.sysl"
+                            start: {
+                              line: 29
+                              col: 11
+                            }
+                            end: {
+                              line: 29
+                              col: 11
+                            }
+                          }
+                        }
+                        if_true: {
+                          binexpr: {
+                            op: ADD
+                            lhs: {
+                              get_attr: {
+                                arg: {
+                                  name: "."
+                                  source_context: {
+                                    file: "tests/stmts.sysl"
+                                    start: {
+                                      line: 29
+                                      col: 16
+                                    }
+                                    end: {
+                                      line: 29
+                                      col: 17
+                                    }
+                                  }
+                                }
+                                attr: "aa"
+                              }
+                              source_context: {
+                                file: "tests/stmts.sysl"
+                                start: {
+                                  line: 29
+                                  col: 16
+                                }
+                                end: {
+                                  line: 29
+                                  col: 17
+                                }
+                              }
+                            }
+                            rhs: {
+                              get_attr: {
+                                arg: {
+                                  literal: {
+                                    i: 3
+                                  }
+                                  source_context: {
+                                    file: "tests/stmts.sysl"
+                                    start: {
+                                      line: 29
+                                      col: 22
+                                    }
+                                    end: {
+                                      line: 29
+                                      col: 22
+                                    }
+                                  }
+                                }
+                                attr: "pqr"
+                              }
+                              source_context: {
+                                file: "tests/stmts.sysl"
+                                start: {
+                                  line: 29
+                                  col: 24
+                                }
+                                end: {
+                                  line: 29
+                                  col: 25
+                                }
+                              }
+                            }
+                          }
+                          type: {
+                            no_type: {}
+                          }
+                          source_context: {
+                            file: "tests/stmts.sysl"
+                            start: {
+                              line: 29
+                              col: 20
+                            }
+                            end: {
+                              line: 29
+                              col: 25
+                            }
+                          }
+                        }
+                        if_false: {
+                          ifelse: {
+                            cond: {
+                              binexpr: {
+                                op: EQ
+                                lhs: {
+                                  get_attr: {
+                                    arg: {
+                                      name: "."
+                                      source_context: {
+                                        file: "tests/stmts.sysl"
+                                        start: {
+                                          line: 30
+                                          col: 16
                                         }
-                                        rhs {
-                                          literal {
-                                            s: "b"
-                                          }
+                                        end: {
+                                          line: 30
+                                          col: 17
                                         }
                                       }
                                     }
-                                  }
-                                }
-                                if_true {
-                                  get_attr {
-                                    arg {
-                                      name: "."
-                                    }
-                                    attr: "bb"
-                                  }
-                                }
-                                if_false {
-                                  literal {
-                                    null {
-                                    }
-                                  }
-                                  type {
-                                    primitive: EMPTY
-                                  }
-                                }
-                              }
-                            }
-                            if_false {
-                              literal {
-                                null {
-                                }
-                              }
-                              type {
-                                primitive: EMPTY
-                              }
-                            }
-                          }
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            }
-            stmt {
-              assign {
-                name: "foo8"
-                expr {
-                  ifelse {
-                    cond {
-                      binexpr {
-                        op: EQ
-                        lhs {
-                          get_attr {
-                            arg {
-                              name: "."
-                            }
-                            attr: "a1"
-                          }
-                        }
-                        rhs {
-                          literal {
-                            i: 2
-                          }
-                        }
-                      }
-                    }
-                    if_true {
-                      binexpr {
-                        op: ADD
-                        lhs {
-                          get_attr {
-                            arg {
-                              name: "."
-                            }
-                            attr: "aa"
-                          }
-                        }
-                        rhs {
-                          get_attr {
-                            arg {
-                              literal {
-                                i: 3
-                              }
-                            }
-                            attr: "pqr"
-                          }
-                        }
-                      }
-                    }
-                    if_false {
-                      ifelse {
-                        cond {
-                          binexpr {
-                            op: EQ
-                            lhs {
-                              get_attr {
-                                arg {
-                                  name: "."
-                                }
-                                attr: "a1"
-                              }
-                            }
-                            rhs {
-                              literal {
-                                i: 3
-                              }
-                            }
-                          }
-                        }
-                        if_true {
-                          binexpr {
-                            op: ADD
-                            lhs {
-                              get_attr {
-                                arg {
-                                  name: "."
-                                }
-                                attr: "aa"
-                              }
-                            }
-                            rhs {
-                              get_attr {
-                                arg {
-                                  literal {
-                                    i: 3
-                                  }
-                                }
-                                attr: "pqr"
-                              }
-                            }
-                          }
-                        }
-                        if_false {
-                          ifelse {
-                            cond {
-                              binexpr {
-                                op: EQ
-                                lhs {
-                                  get_attr {
-                                    arg {
-                                      name: "."
-                                    }
                                     attr: "a1"
                                   }
+                                  source_context: {
+                                    file: "tests/stmts.sysl"
+                                    start: {
+                                      line: 30
+                                      col: 16
+                                    }
+                                    end: {
+                                      line: 30
+                                      col: 17
+                                    }
+                                  }
                                 }
-                                rhs {
-                                  literal {
+                                rhs: {
+                                  literal: {
                                     i: 2
+                                  }
+                                  source_context: {
+                                    file: "tests/stmts.sysl"
+                                    start: {
+                                      line: 31
+                                      col: 10
+                                    }
+                                    end: {
+                                      line: 31
+                                      col: 10
+                                    }
                                   }
                                 }
                               }
+                              source_context: {
+                                file: "tests/stmts.sysl"
+                                start: {
+                                  line: 30
+                                  col: 16
+                                }
+                                end: {
+                                  line: 30
+                                  col: 20
+                                }
+                              }
                             }
-                            if_true {
-                              binexpr {
+                            if_true: {
+                              binexpr: {
                                 op: ADD
-                                lhs {
-                                  get_attr {
-                                    arg {
+                                lhs: {
+                                  get_attr: {
+                                    arg: {
                                       name: "."
+                                      source_context: {
+                                        file: "tests/stmts.sysl"
+                                        start: {
+                                          line: 31
+                                          col: 18
+                                        }
+                                        end: {
+                                          line: 31
+                                          col: 19
+                                        }
+                                      }
                                     }
                                     attr: "aa"
                                   }
+                                  source_context: {
+                                    file: "tests/stmts.sysl"
+                                    start: {
+                                      line: 31
+                                      col: 18
+                                    }
+                                    end: {
+                                      line: 31
+                                      col: 19
+                                    }
+                                  }
                                 }
-                                rhs {
-                                  get_attr {
-                                    arg {
-                                      literal {
+                                rhs: {
+                                  get_attr: {
+                                    arg: {
+                                      literal: {
                                         i: 3
+                                      }
+                                      source_context: {
+                                        file: "tests/stmts.sysl"
+                                        start: {
+                                          line: 31
+                                          col: 24
+                                        }
+                                        end: {
+                                          line: 31
+                                          col: 24
+                                        }
                                       }
                                     }
                                     attr: "pqr"
                                   }
-                                }
-                              }
-                            }
-                            if_false {
-                              ifelse {
-                                cond {
-                                  binexpr {
-                                    op: EQ
-                                    lhs {
-                                      get_attr {
-                                        arg {
-                                          name: "."
-                                        }
-                                        attr: "a1"
-                                      }
+                                  source_context: {
+                                    file: "tests/stmts.sysl"
+                                    start: {
+                                      line: 31
+                                      col: 26
                                     }
-                                    rhs {
-                                      literal {
-                                        i: 3
-                                      }
+                                    end: {
+                                      line: 31
+                                      col: 27
                                     }
                                   }
                                 }
-                                if_true {
-                                  binexpr {
-                                    op: ADD
-                                    lhs {
-                                      get_attr {
-                                        arg {
+                              }
+                              type: {
+                                no_type: {}
+                              }
+                              source_context: {
+                                file: "tests/stmts.sysl"
+                                start: {
+                                  line: 31
+                                  col: 22
+                                }
+                                end: {
+                                  line: 31
+                                  col: 27
+                                }
+                              }
+                            }
+                            if_false: {
+                              ifelse: {
+                                cond: {
+                                  binexpr: {
+                                    op: EQ
+                                    lhs: {
+                                      get_attr: {
+                                        arg: {
                                           name: "."
+                                          source_context: {
+                                            file: "tests/stmts.sysl"
+                                            start: {
+                                              line: 30
+                                              col: 16
+                                            }
+                                            end: {
+                                              line: 30
+                                              col: 17
+                                            }
+                                          }
+                                        }
+                                        attr: "a1"
+                                      }
+                                      source_context: {
+                                        file: "tests/stmts.sysl"
+                                        start: {
+                                          line: 30
+                                          col: 16
+                                        }
+                                        end: {
+                                          line: 30
+                                          col: 17
+                                        }
+                                      }
+                                    }
+                                    rhs: {
+                                      literal: {
+                                        i: 3
+                                      }
+                                      source_context: {
+                                        file: "tests/stmts.sysl"
+                                        start: {
+                                          line: 31
+                                          col: 13
+                                        }
+                                        end: {
+                                          line: 31
+                                          col: 13
+                                        }
+                                      }
+                                    }
+                                  }
+                                  source_context: {
+                                    file: "tests/stmts.sysl"
+                                    start: {
+                                      line: 31
+                                      col: 13
+                                    }
+                                    end: {
+                                      line: 31
+                                      col: 13
+                                    }
+                                  }
+                                }
+                                if_true: {
+                                  binexpr: {
+                                    op: ADD
+                                    lhs: {
+                                      get_attr: {
+                                        arg: {
+                                          name: "."
+                                          source_context: {
+                                            file: "tests/stmts.sysl"
+                                            start: {
+                                              line: 31
+                                              col: 18
+                                            }
+                                            end: {
+                                              line: 31
+                                              col: 19
+                                            }
+                                          }
                                         }
                                         attr: "aa"
                                       }
+                                      source_context: {
+                                        file: "tests/stmts.sysl"
+                                        start: {
+                                          line: 31
+                                          col: 18
+                                        }
+                                        end: {
+                                          line: 31
+                                          col: 19
+                                        }
+                                      }
                                     }
-                                    rhs {
-                                      get_attr {
-                                        arg {
-                                          literal {
+                                    rhs: {
+                                      get_attr: {
+                                        arg: {
+                                          literal: {
                                             i: 3
+                                          }
+                                          source_context: {
+                                            file: "tests/stmts.sysl"
+                                            start: {
+                                              line: 31
+                                              col: 24
+                                            }
+                                            end: {
+                                              line: 31
+                                              col: 24
+                                            }
                                           }
                                         }
                                         attr: "pqr"
                                       }
+                                      source_context: {
+                                        file: "tests/stmts.sysl"
+                                        start: {
+                                          line: 31
+                                          col: 26
+                                        }
+                                        end: {
+                                          line: 31
+                                          col: 27
+                                        }
+                                      }
+                                    }
+                                  }
+                                  type: {
+                                    no_type: {}
+                                  }
+                                  source_context: {
+                                    file: "tests/stmts.sysl"
+                                    start: {
+                                      line: 31
+                                      col: 22
+                                    }
+                                    end: {
+                                      line: 31
+                                      col: 27
                                     }
                                   }
                                 }
-                                if_false {
-                                  literal {
-                                    null {
-                                    }
+                                if_false: {
+                                  literal: {
+                                    null: {}
                                   }
-                                  type {
+                                  type: {
                                     primitive: EMPTY
+                                  }
+                                  source_context: {
+                                    file: "tests/stmts.sysl"
+                                    start: {
+                                      line: 32
+                                      col: 15
+                                    }
+                                    end: {
+                                      line: 32
+                                      col: 15
+                                    }
                                   }
                                 }
                               }
+                              type: {
+                                primitive: EMPTY
+                              }
                             }
                           }
+                          type: {
+                            primitive: EMPTY
+                          }
                         }
+                      }
+                      type: {
+                        primitive: EMPTY
+                      }
+                    }
+                  }
+                  type: {
+                    primitive: EMPTY
+                  }
+                  source_context: {
+                    file: "tests/stmts.sysl"
+                    start: {
+                      line: 28
+                      col: 6
+                    }
+                    end: {
+                      line: 33
+                      col: 6
+                    }
+                    text: "foo8 = if .a1 ==:\n        2, 3 => .aa + 3 .pqr\n        else if .a1 ==:\n          2, 3 => .aa + 3 .pqr\n          else null\n      funccall(\"arg\").*\n    )\n"
+                  }
+                }
+              }
+            }
+            stmt: {
+              inject: {
+                call: {
+                  func: "funccall"
+                  arg: {
+                    literal: {
+                      s: "arg"
+                    }
+                    source_context: {
+                      file: "tests/stmts.sysl"
+                      start: {
+                        line: 33
+                        col: 15
+                      }
+                      end: {
+                        line: 33
+                        col: 15
+                      }
+                    }
+                  }
+                  arg: {
+                    name: "out"
+                    source_context: {
+                      file: "tests/stmts.sysl"
+                      start: {
+                        line: 33
+                        col: 6
+                      }
+                      end: {
+                        line: 33
+                        col: 23
                       }
                     }
                   }
                 }
-              }
-            }
-            stmt {
-              inject {
-                call {
-                  func: "funccall"
-                  arg {
-                    literal {
-                      s: "arg"
-                    }
+                source_context: {
+                  file: "tests/stmts.sysl"
+                  start: {
+                    line: 33
+                    col: 6
                   }
-                  arg {
-                    name: "out"
+                  end: {
+                    line: 33
+                    col: 20
                   }
+                  text: "funccall(\"arg\")"
                 }
               }
             }
           }
+          source_context: {
+            file: "tests/stmts.sysl"
+            start: {
+              line: 3
+              col: 4
+            }
+            end: {
+              line: 34
+              col: 5
+            }
+          }
         }
+        source_context: {
+          file: "tests/stmts.sysl"
+          start: {
+            line: 2
+            col: 2
+          }
+          end: {
+            line: 35
+          }
+          text: "!view TestStatements(number <: int) -> int:"
+        }
+      }
+    }
+    source_context: {
+      file: "tests/stmts.sysl"
+      start: {
+        line: 1
+        col: 1
+      }
+      end: {
+        line: 1
+        col: 47
       }
     }
   }

--- a/pkg/parse/tests/strings_expr.sysl.golden.textpb
+++ b/pkg/parse/tests/strings_expr.sysl.golden.textpb
@@ -1,243 +1,261 @@
-apps: <
+apps: {
   key: "TransformApp"
-  value: <
-    name: <
+  value: {
+    name: {
       part: "TransformApp"
-    >
+    }
     long_name: "The \"App\""
-    attrs: <
+    attrs: {
       key: "package"
-      value: <
+      value: {
         s: "io.sysl.demo.petshop.views"
-      >
-    >
-    views: <
+      }
+    }
+    views: {
       key: "NoArgTransform"
-      value: <
-        param: <
+      value: {
+        param: {
           name: "number1"
-          type: <
+          type: {
             primitive: INT
-          >
-        >
-        param: <
+          }
+        }
+        param: {
           name: "foo"
-          type: <
-            type_ref: <
-              ref: <
-                appname: <
+          type: {
+            type_ref: {
+              ref: {
+                appname: {
                   part: "Some"
-                >
+                }
                 path: "Type"
-              >
-            >
-          >
-        >
-        ret_type: <
-          type_ref: <
-            ref: <
-              appname: <
+              }
+            }
+          }
+        }
+        ret_type: {
+          type_ref: {
+            ref: {
+              appname: {
                 part: "Model"
-              >
+              }
               path: "Type"
-            >
-          >
-        >
-        expr: <
-          transform: <
-            arg: <
+            }
+          }
+        }
+        expr: {
+          transform: {
+            arg: {
               name: "."
-              source_context: <
+              source_context: {
                 file: "tests/strings_expr.sysl"
-                start: <
+                start: {
                   line: 3
                   col: 4
-                >
-                end: <
+                }
+                end: {
                   line: 13
                   col: 5
-                >
-              >
-            >
+                }
+              }
+            }
             scopevar: "scopeVar"
-            stmt: <
-              assign: <
+            stmt: {
+              assign: {
                 name: "out"
-                expr: <
-                  literal: <
+                expr: {
+                  literal: {
                     s: "abc"
-                  >
-                  source_context: <
+                  }
+                  type: {
+                    primitive: STRING
+                  }
+                  source_context: {
                     file: "tests/strings_expr.sysl"
-                    start: <
+                    start: {
                       line: 4
                       col: 6
-                    >
-                    end: <
+                    }
+                    end: {
                       line: 4
                       col: 12
-                    >
+                    }
                     text: "out = \"abc\""
-                  >
-                >
-              >
-            >
-            stmt: <
-              assign: <
+                  }
+                }
+              }
+            }
+            stmt: {
+              assign: {
                 name: "out1"
-                expr: <
-                  literal: <
+                expr: {
+                  literal: {
                     s: "'abc'"
-                  >
-                  source_context: <
+                  }
+                  type: {
+                    primitive: STRING
+                  }
+                  source_context: {
                     file: "tests/strings_expr.sysl"
-                    start: <
+                    start: {
                       line: 5
                       col: 6
-                    >
-                    end: <
+                    }
+                    end: {
                       line: 5
                       col: 13
-                    >
+                    }
                     text: "out1 = \"'abc'\""
-                  >
-                >
-              >
-            >
-            stmt: <
-              assign: <
+                  }
+                }
+              }
+            }
+            stmt: {
+              assign: {
                 name: "out2"
-                expr: <
-                  literal: <
+                expr: {
+                  literal: {
                     s: "\"On\nMultiple\nLines\""
-                  >
-                  source_context: <
+                  }
+                  type: {
+                    primitive: STRING
+                  }
+                  source_context: {
                     file: "tests/strings_expr.sysl"
-                    start: <
+                    start: {
                       line: 6
                       col: 6
-                    >
-                    end: <
+                    }
+                    end: {
                       line: 6
                       col: 13
-                    >
+                    }
                     text: "out2 = \"\\\"On\\nMultiple\\nLines\\\"\""
-                  >
-                >
-              >
-            >
-            stmt: <
-              assign: <
+                  }
+                }
+              }
+            }
+            stmt: {
+              assign: {
                 name: "out3"
-                expr: <
-                  literal: <
+                expr: {
+                  literal: {
                     s: "\"abc\""
-                  >
-                  source_context: <
+                  }
+                  type: {
+                    primitive: STRING
+                  }
+                  source_context: {
                     file: "tests/strings_expr.sysl"
-                    start: <
+                    start: {
                       line: 8
                       col: 6
-                    >
-                    end: <
+                    }
+                    end: {
                       line: 8
                       col: 13
-                    >
+                    }
                     text: "out3 = '\"abc\"'"
-                  >
-                >
-              >
-            >
-            stmt: <
-              assign: <
+                  }
+                }
+              }
+            }
+            stmt: {
+              assign: {
                 name: "out4"
-                expr: <
-                  literal: <
+                expr: {
+                  literal: {
                     s: "abc"
-                  >
-                  source_context: <
+                  }
+                  type: {
+                    primitive: STRING
+                  }
+                  source_context: {
                     file: "tests/strings_expr.sysl"
-                    start: <
+                    start: {
                       line: 9
                       col: 6
-                    >
-                    end: <
+                    }
+                    end: {
                       line: 9
                       col: 13
-                    >
+                    }
                     text: "out4 = 'abc'"
-                  >
-                >
-              >
-            >
-            stmt: <
-              assign: <
+                  }
+                }
+              }
+            }
+            stmt: {
+              assign: {
                 name: "out5"
-                expr: <
-                  literal: <
+                expr: {
+                  literal: {
                     s: "\"abc\\ndef\""
-                  >
-                  source_context: <
+                  }
+                  type: {
+                    primitive: STRING
+                  }
+                  source_context: {
                     file: "tests/strings_expr.sysl"
-                    start: <
+                    start: {
                       line: 12
                       col: 6
-                    >
-                    end: <
+                    }
+                    end: {
                       line: 12
                       col: 13
-                    >
+                    }
                     text: "out5 = '\"abc\\ndef\"'"
-                  >
-                >
-              >
-            >
-          >
-          source_context: <
+                  }
+                }
+              }
+            }
+          }
+          source_context: {
             file: "tests/strings_expr.sysl"
-            start: <
+            start: {
               line: 3
               col: 4
-            >
-            end: <
+            }
+            end: {
               line: 13
               col: 5
-            >
-          >
-        >
-        attrs: <
+            }
+          }
+        }
+        attrs: {
           key: "patterns"
-          value: <
-            a: <
-              elt: <
+          value: {
+            a: {
+              elt: {
                 s: "partial"
-              >
-            >
-          >
-        >
-        source_context: <
+              }
+            }
+          }
+        }
+        source_context: {
           file: "tests/strings_expr.sysl"
-          start: <
+          start: {
             line: 2
             col: 2
-          >
-          end: <
+          }
+          end: {
             line: 14
-          >
+          }
           text: "!view NoArgTransform(number1 <: int, foo <: Some.Type ) -> Model.Type [~partial]:"
-        >
-      >
-    >
-    source_context: <
+        }
+      }
+    }
+    source_context: {
       file: "tests/strings_expr.sysl"
-      start: <
+      start: {
         line: 1
         col: 1
-      >
-      end: <
+      }
+      end: {
         line: 1
         col: 64
-      >
-    >
-  >
->
+      }
+    }
+  }
+}

--- a/pkg/parse/tests/tableof.sysl.golden.textpb
+++ b/pkg/parse/tests/tableof.sysl.golden.textpb
@@ -1,168 +1,450 @@
-apps {
+apps: {
   key: "TransformationTest"
-  value {
-    name {
+  value: {
+    name: {
       part: "TransformationTest"
     }
-    attrs {
+    attrs: {
       key: "package"
-      value {
+      value: {
         s: "io.sysl.test.views"
       }
     }
-    views {
+    views: {
       key: "TestTableOf"
-      value {
-        param {
+      value: {
+        param: {
           name: "number"
-          type {
+          type: {
             primitive: INT
           }
         }
-        ret_type {
+        ret_type: {
           primitive: INT
         }
-        expr {
-          transform {
-            arg {
+        expr: {
+          transform: {
+            arg: {
               name: "number"
+              source_context: {
+                file: "tests/tableof.sysl"
+                start: {
+                  line: 3
+                  col: 4
+                }
+                end: {
+                  line: 3
+                  col: 4
+                }
+              }
             }
             scopevar: "."
-            stmt {
-              let {
+            stmt: {
+              let: {
                 name: "out1"
-                expr {
-                  get_attr {
-                    arg {
+                expr: {
+                  get_attr: {
+                    arg: {
                       name: "."
+                      source_context: {
+                        file: "tests/tableof.sysl"
+                        start: {
+                          line: 5
+                          col: 17
+                        }
+                        end: {
+                          line: 5
+                          col: 27
+                        }
+                      }
                     }
                     attr: "abc"
                     setof: true
                   }
+                  source_context: {
+                    file: "tests/tableof.sysl"
+                    start: {
+                      line: 5
+                      col: 6
+                    }
+                    end: {
+                      line: 5
+                      col: 27
+                    }
+                    text: "let out1 = .table of abc"
+                  }
                 }
               }
             }
-            stmt {
-              let {
+            stmt: {
+              let: {
                 name: "out2"
-                expr {
-                  get_attr {
-                    arg {
-                      get_attr {
-                        arg {
+                expr: {
+                  get_attr: {
+                    arg: {
+                      get_attr: {
+                        arg: {
                           name: "."
+                          source_context: {
+                            file: "tests/tableof.sysl"
+                            start: {
+                              line: 6
+                              col: 17
+                            }
+                            end: {
+                              line: 6
+                              col: 27
+                            }
+                          }
                         }
                         attr: "abc"
                         setof: true
                       }
+                      source_context: {
+                        file: "tests/tableof.sysl"
+                        start: {
+                          line: 6
+                          col: 17
+                        }
+                        end: {
+                          line: 6
+                          col: 27
+                        }
+                      }
                     }
                     attr: "def"
+                  }
+                  source_context: {
+                    file: "tests/tableof.sysl"
+                    start: {
+                      line: 6
+                      col: 6
+                    }
+                    end: {
+                      line: 6
+                      col: 31
+                    }
+                    text: "let out2 = .table of abc.def"
                   }
                 }
               }
             }
-            stmt {
-              let {
+            stmt: {
+              let: {
                 name: "out3"
-                expr {
-                  get_attr {
-                    arg {
+                expr: {
+                  get_attr: {
+                    arg: {
                       name: "input"
+                      source_context: {
+                        file: "tests/tableof.sysl"
+                        start: {
+                          line: 8
+                          col: 17
+                        }
+                        end: {
+                          line: 8
+                          col: 17
+                        }
+                      }
                     }
                     attr: "abc"
                     setof: true
                   }
+                  source_context: {
+                    file: "tests/tableof.sysl"
+                    start: {
+                      line: 8
+                      col: 6
+                    }
+                    end: {
+                      line: 8
+                      col: 33
+                    }
+                    text: "let out3 = input .table of abc"
+                  }
                 }
               }
             }
-            stmt {
-              let {
+            stmt: {
+              let: {
                 name: "out4"
-                expr {
-                  get_attr {
-                    arg {
-                      get_attr {
-                        arg {
+                expr: {
+                  get_attr: {
+                    arg: {
+                      get_attr: {
+                        arg: {
                           name: "input"
+                          source_context: {
+                            file: "tests/tableof.sysl"
+                            start: {
+                              line: 9
+                              col: 17
+                            }
+                            end: {
+                              line: 9
+                              col: 17
+                            }
+                          }
                         }
                         attr: "abc"
                         setof: true
                       }
+                      source_context: {
+                        file: "tests/tableof.sysl"
+                        start: {
+                          line: 9
+                          col: 23
+                        }
+                        end: {
+                          line: 9
+                          col: 33
+                        }
+                      }
                     }
                     attr: "def"
+                  }
+                  source_context: {
+                    file: "tests/tableof.sysl"
+                    start: {
+                      line: 9
+                      col: 6
+                    }
+                    end: {
+                      line: 9
+                      col: 37
+                    }
+                    text: "let out4 = input .table of abc.def"
                   }
                 }
               }
             }
-            stmt {
-              let {
+            stmt: {
+              let: {
                 name: "out4a"
-                expr {
-                  get_attr {
-                    arg {
-                      get_attr {
-                        arg {
+                expr: {
+                  get_attr: {
+                    arg: {
+                      get_attr: {
+                        arg: {
                           name: "input"
+                          source_context: {
+                            file: "tests/tableof.sysl"
+                            start: {
+                              line: 10
+                              col: 18
+                            }
+                            end: {
+                              line: 10
+                              col: 18
+                            }
+                          }
                         }
                         attr: "abc"
                         setof: true
                       }
+                      source_context: {
+                        file: "tests/tableof.sysl"
+                        start: {
+                          line: 10
+                          col: 23
+                        }
+                        end: {
+                          line: 10
+                          col: 33
+                        }
+                      }
                     }
                     attr: "def"
+                  }
+                  source_context: {
+                    file: "tests/tableof.sysl"
+                    start: {
+                      line: 10
+                      col: 6
+                    }
+                    end: {
+                      line: 10
+                      col: 37
+                    }
+                    text: "let out4a = input.table of abc.def"
                   }
                 }
               }
             }
-            stmt {
-              let {
+            stmt: {
+              let: {
                 name: "out5"
-                expr {
-                  get_attr {
-                    arg {
-                      get_attr {
-                        arg {
-                          get_attr {
-                            arg {
+                expr: {
+                  get_attr: {
+                    arg: {
+                      get_attr: {
+                        arg: {
+                          get_attr: {
+                            arg: {
                               name: "input"
+                              source_context: {
+                                file: "tests/tableof.sysl"
+                                start: {
+                                  line: 11
+                                  col: 17
+                                }
+                                end: {
+                                  line: 11
+                                  col: 17
+                                }
+                              }
                             }
                             attr: "foo"
+                          }
+                          source_context: {
+                            file: "tests/tableof.sysl"
+                            start: {
+                              line: 11
+                              col: 22
+                            }
+                            end: {
+                              line: 11
+                              col: 23
+                            }
                           }
                         }
                         attr: "abc"
                         setof: true
+                      }
+                      source_context: {
+                        file: "tests/tableof.sysl"
+                        start: {
+                          line: 11
+                          col: 27
+                        }
+                        end: {
+                          line: 11
+                          col: 37
+                        }
                       }
                     }
                     attr: "def"
                   }
+                  source_context: {
+                    file: "tests/tableof.sysl"
+                    start: {
+                      line: 11
+                      col: 6
+                    }
+                    end: {
+                      line: 11
+                      col: 41
+                    }
+                    text: "let out5 = input.foo .table of abc.def"
+                  }
                 }
               }
             }
-            stmt {
-              let {
+            stmt: {
+              let: {
                 name: "out6"
-                expr {
-                  get_attr {
-                    arg {
-                      get_attr {
-                        arg {
-                          get_attr {
-                            arg {
+                expr: {
+                  get_attr: {
+                    arg: {
+                      get_attr: {
+                        arg: {
+                          get_attr: {
+                            arg: {
                               name: "."
+                              source_context: {
+                                file: "tests/tableof.sysl"
+                                start: {
+                                  line: 12
+                                  col: 17
+                                }
+                                end: {
+                                  line: 12
+                                  col: 18
+                                }
+                              }
                             }
                             attr: "foo"
+                          }
+                          source_context: {
+                            file: "tests/tableof.sysl"
+                            start: {
+                              line: 12
+                              col: 17
+                            }
+                            end: {
+                              line: 12
+                              col: 18
+                            }
                           }
                         }
                         attr: "abc"
                         setof: true
                       }
+                      source_context: {
+                        file: "tests/tableof.sysl"
+                        start: {
+                          line: 12
+                          col: 22
+                        }
+                        end: {
+                          line: 12
+                          col: 32
+                        }
+                      }
                     }
                     attr: "def"
+                  }
+                  source_context: {
+                    file: "tests/tableof.sysl"
+                    start: {
+                      line: 12
+                      col: 6
+                    }
+                    end: {
+                      line: 12
+                      col: 36
+                    }
+                    text: "let out6 = .foo .table of abc.def"
                   }
                 }
               }
             }
           }
+          source_context: {
+            file: "tests/tableof.sysl"
+            start: {
+              line: 3
+              col: 4
+            }
+            end: {
+              line: 13
+              col: 5
+            }
+          }
         }
+        source_context: {
+          file: "tests/tableof.sysl"
+          start: {
+            line: 2
+            col: 2
+          }
+          end: {
+            line: 14
+          }
+          text: "!view TestTableOf(number <: int) -> int:"
+        }
+      }
+    }
+    source_context: {
+      file: "tests/tableof.sysl"
+      start: {
+        line: 1
+        col: 1
+      }
+      end: {
+        line: 1
+        col: 47
       }
     }
   }

--- a/pkg/parse/tests/test1.sysl.golden.textpb
+++ b/pkg/parse/tests/test1.sysl.golden.textpb
@@ -1,642 +1,911 @@
-apps: <
+apps: {
   key: "A_B"
-  value: <
-    name: <
+  value: {
+    name: {
       part: "A_B"
-    >
-    endpoints: <
+    }
+    endpoints: {
       key: "C_D"
-      value: <
+      value: {
         name: "C_D"
-        stmt: <
-          call: <
-            target: <
+        stmt: {
+          call: {
+            target: {
               part: "anz_com"
-            >
+            }
             endpoint: "homepage"
-          >
-        >
-        stmt: <
-          call: <
-            target: <
+          }
+        }
+        stmt: {
+          call: {
+            target: {
               part: "Test - App"
-            >
+            }
             endpoint: "Test - Endpoint"
-          >
-        >
-      >
-    >
-    endpoints: <
+          }
+        }
+        source_context: {
+          file: "tests/test1.sysl"
+          start: {
+            line: 67
+            col: 4
+          }
+          end: {
+            line: 70
+            col: 4
+          }
+        }
+      }
+    }
+    endpoints: {
       key: "DDD"
-      value: <
+      value: {
         name: "DDD"
-        stmt: <
-          cond: <
+        stmt: {
+          cond: {
             test: "some condition is true"
-            stmt: <
-              action: <
+            stmt: {
+              action: {
                 action: "Test - App -> eventName"
-              >
-            >
-            stmt: <
-              call: <
-                target: <
+              }
+            }
+            stmt: {
+              call: {
+                target: {
                   part: "Test - App"
-                >
+                }
                 endpoint: "Endpoint2"
-              >
-            >
-            stmt: <
-              cond: <
+              }
+            }
+            stmt: {
+              cond: {
                 test: "result not ok"
-                stmt: <
-                  ret: <
+                stmt: {
+                  ret: {
                     payload: "not ok1"
-                  >
-                >
-              >
-            >
-            stmt: <
-              group: <
+                  }
+                }
+              }
+            }
+            stmt: {
+              group: {
                 title: "else"
-                stmt: <
-                  ret: <
+                stmt: {
+                  ret: {
                     payload: "ok"
-                  >
-                >
-              >
-            >
-          >
-        >
-        stmt: <
-          group: <
+                  }
+                }
+              }
+            }
+          }
+        }
+        stmt: {
+          group: {
             title: "else some other condition"
-            stmt: <
-              action: <
+            stmt: {
+              action: {
                 action: "top level else_statment"
-              >
-            >
-            stmt: <
-              cond: <
+              }
+            }
+            stmt: {
+              cond: {
                 test: "\"some constraint\""
-                stmt: <
-                  ret: <
+                stmt: {
+                  ret: {
                     payload: "ok"
-                  >
-                >
-              >
-            >
-            stmt: <
-              group: <
+                  }
+                }
+              }
+            }
+            stmt: {
+              group: {
                 title: "Else"
-                stmt: <
-                  ret: <
+                stmt: {
+                  ret: {
                     payload: "not ok"
-                  >
-                >
-              >
-            >
-          >
-        >
-        stmt: <
-          action: <
+                  }
+                }
+              }
+            }
+          }
+        }
+        stmt: {
+          action: {
             action: "do some more stuff"
-          >
-        >
-      >
-    >
-    endpoints: <
+          }
+        }
+        source_context: {
+          file: "tests/test1.sysl"
+          start: {
+            line: 70
+            col: 4
+          }
+          end: {
+            line: 87
+            col: 4
+          }
+        }
+      }
+    }
+    endpoints: {
       key: "EEE"
-      value: <
+      value: {
         name: "EEE"
-        stmt: <
-          action: <
+        stmt: {
+          action: {
             action: "..."
-          >
-        >
-      >
-    >
-    endpoints: <
+          }
+        }
+        source_context: {
+          file: "tests/test1.sysl"
+          start: {
+            line: 87
+            col: 4
+          }
+          end: {
+            line: 90
+            col: 4
+          }
+        }
+      }
+    }
+    endpoints: {
       key: "Send document to customer"
-      value: <
+      value: {
         name: "Send document to customer"
-      >
-    >
-  >
->
-apps: <
+        source_context: {
+          file: "tests/test1.sysl"
+          start: {
+            line: 90
+            col: 4
+          }
+          end: {
+            line: 90
+            col: 31
+          }
+        }
+      }
+    }
+    source_context: {
+      file: "tests/test1.sysl"
+      start: {
+        line: 66
+        col: 1
+      }
+      end: {
+        line: 66
+      }
+    }
+  }
+}
+apps: {
   key: "External :: App"
-  value: <
-    name: <
+  value: {
+    name: {
       part: "External"
       part: "App"
-    >
-    endpoints: <
+    }
+    endpoints: {
       key: "Endpoint"
-      value: <
+      value: {
         name: "Endpoint"
-        stmt: <
-          action: <
+        stmt: {
+          action: {
             action: "..."
-          >
-        >
-      >
-    >
-    types: <
+          }
+        }
+        source_context: {
+          file: "tests/test1.sysl"
+          start: {
+            line: 48
+            col: 4
+          }
+          end: {
+            line: 51
+            col: 4
+          }
+        }
+      }
+    }
+    types: {
       key: "Request"
-      value: <
-        tuple: <
-          attr_defs: <
+      value: {
+        tuple: {
+          attr_defs: {
             key: "id"
-            value: <
+            value: {
               primitive: INT
-              source_context: <
+              source_context: {
                 file: "tests/test1.sysl"
-                start: <
+                start: {
                   line: 52
                   col: 14
-                >
-                end: <
+                }
+                end: {
                   line: 52
                   col: 14
-                >
-              >
-            >
-          >
-          attr_defs: <
+                }
+              }
+            }
+          }
+          attr_defs: {
             key: "val"
-            value: <
+            value: {
               primitive: STRING
-              source_context: <
+              source_context: {
                 file: "tests/test1.sysl"
-                start: <
+                start: {
                   line: 53
                   col: 15
-                >
-                end: <
+                }
+                end: {
                   line: 53
                   col: 15
-                >
-              >
-            >
-          >
-        >
-      >
-    >
-    types: <
+                }
+              }
+            }
+          }
+        }
+        source_context: {
+          file: "tests/test1.sysl"
+          start: {
+            line: 51
+            col: 4
+          }
+          end: {
+            line: 54
+            col: 4
+          }
+        }
+      }
+    }
+    types: {
       key: "Response"
-      value: <
-        tuple: <
-          attr_defs: <
+      value: {
+        tuple: {
+          attr_defs: {
             key: "val"
-            value: <
+            value: {
               primitive: STRING
-              source_context: <
+              source_context: {
                 file: "tests/test1.sysl"
-                start: <
+                start: {
                   line: 55
                   col: 15
-                >
-                end: <
+                }
+                end: {
                   line: 55
                   col: 15
-                >
-              >
-            >
-          >
-        >
-      >
-    >
-  >
->
-apps: <
+                }
+              }
+            }
+          }
+        }
+        source_context: {
+          file: "tests/test1.sysl"
+          start: {
+            line: 54
+            col: 4
+          }
+          end: {
+            line: 57
+            col: 11
+          }
+        }
+      }
+    }
+    source_context: {
+      file: "tests/test1.sysl"
+      start: {
+        line: 47
+        col: 1
+      }
+      end: {
+        line: 47
+        col: 12
+      }
+    }
+  }
+}
+apps: {
   key: "My Todo App"
-  value: <
-    name: <
+  value: {
+    name: {
       part: "My Todo App"
-    >
-    attrs: <
+    }
+    attrs: {
       key: "patterns"
-      value: <
-        a: <
-          elt: <
+      value: {
+        a: {
+          elt: {
             s: "webapp"
-          >
-        >
-      >
-    >
-    endpoints: <
+          }
+        }
+      }
+    }
+    endpoints: {
       key: "Add Note"
-      value: <
+      value: {
         name: "Add Note"
-        attrs: <
+        attrs: {
           key: "patterns"
-          value: <
-            a: <
-              elt: <
+          value: {
+            a: {
+              elt: {
                 s: "somepattern"
-              >
-            >
-          >
-        >
-      >
-    >
-  >
->
-apps: <
+              }
+            }
+          }
+        }
+        source_context: {
+          file: "tests/test1.sysl"
+          start: {
+            line: 58
+            col: 4
+          }
+          end: {
+            line: 58
+            col: 29
+          }
+        }
+      }
+    }
+    source_context: {
+      file: "tests/test1.sysl"
+      start: {
+        line: 57
+        col: 1
+      }
+      end: {
+        line: 57
+        col: 20
+      }
+    }
+  }
+}
+apps: {
   key: "Rest Service"
-  value: <
-    name: <
+  value: {
+    name: {
       part: "Rest Service"
-    >
-    endpoints: <
+    }
+    endpoints: {
       key: "GET /foo"
-      value: <
+      value: {
         name: "GET /foo"
-        attrs: <
+        attrs: {
           key: "patterns"
-          value: <
-            a: <
-              elt: <
+          value: {
+            a: {
+              elt: {
                 s: "rest"
-              >
-            >
-          >
-        >
-        stmt: <
-          action: <
+              }
+            }
+          }
+        }
+        stmt: {
+          action: {
             action: "..."
-          >
-        >
-        rest_params: <
+          }
+        }
+        rest_params: {
           method: GET
           path: "/foo"
-        >
-      >
-    >
-  >
->
-apps: <
+        }
+        source_context: {
+          file: "tests/test1.sysl"
+          start: {
+            line: 94
+            col: 8
+          }
+          end: {
+            line: 96
+          }
+        }
+      }
+    }
+    source_context: {
+      file: "tests/test1.sysl"
+      start: {
+        line: 92
+        col: 1
+      }
+      end: {
+        line: 92
+      }
+    }
+  }
+}
+apps: {
   key: "SomeApp"
-  value: <
-    name: <
+  value: {
+    name: {
       part: "SomeApp"
-    >
-    attrs: <
+    }
+    attrs: {
       key: "app_desc"
-      value: <
+      value: {
         s: "this comment belongs to the app defined 'above'"
-      >
-    >
-    attrs: <
+      }
+    }
+    attrs: {
       key: "array"
-      value: <
-        a: <
-          elt: <
+      value: {
+        a: {
+          elt: {
             s: "one"
-          >
-          elt: <
+          }
+          elt: {
             s: "two"
-          >
-        >
-      >
-    >
-    attrs: <
+          }
+        }
+      }
+    }
+    attrs: {
       key: "array_of_arrays"
-      value: <
-        a: <
-          elt: <
-            a: <
-              elt: <
+      value: {
+        a: {
+          elt: {
+            a: {
+              elt: {
                 s: "one"
-              >
-              elt: <
+              }
+              elt: {
                 s: "two"
-              >
-            >
-          >
-        >
-      >
-    >
-    attrs: <
+              }
+            }
+          }
+        }
+      }
+    }
+    attrs: {
       key: "comment"
-      value: <
+      value: {
         s: ""
-      >
-    >
-    attrs: <
+      }
+    }
+    attrs: {
       key: "comment.second"
-      value: <
+      value: {
         s: ""
-      >
-    >
-    attrs: <
+      }
+    }
+    attrs: {
       key: "package"
-      value: <
+      value: {
         s: ""
-      >
-    >
-    attrs: <
+      }
+    }
+    attrs: {
       key: "version"
-      value: <
+      value: {
         s: "1.1.1"
-      >
-    >
-    endpoints: <
+      }
+    }
+    endpoints: {
       key: "Endpoint"
-      value: <
+      value: {
         name: "Endpoint"
-        stmt: <
-          action: <
+        stmt: {
+          action: {
             action: "..."
-          >
-        >
-      >
-    >
-    endpoints: <
+          }
+        }
+        source_context: {
+          file: "tests/test1.sysl"
+          start: {
+            line: 9
+            col: 4
+          }
+          end: {
+            line: 12
+            col: 4
+          }
+        }
+      }
+    }
+    endpoints: {
       key: "Event"
-      value: <
+      value: {
         name: "Event"
         is_pubsub: true
-        param: <
+        param: {
           name: "App.member"
-          type: <
-            no_type: <
-            >
-          >
-        >
-        param: <
+          type: {
+            no_type: {}
+          }
+        }
+        param: {
           name: "request"
-          type: <
-            type_ref: <
-              ref: <
-                appname: <
+          type: {
+            type_ref: {
+              ref: {
+                appname: {
                   part: "SomeApp"
-                >
+                }
                 path: "SomeType"
-              >
-            >
-          >
-        >
-        stmt: <
-          ret: <
+              }
+            }
+          }
+        }
+        stmt: {
+          ret: {
             payload: "\"customer details\""
-          >
-        >
-      >
-    >
-    endpoints: <
+          }
+        }
+        source_context: {
+          file: "tests/test1.sysl"
+          start: {
+            line: 6
+            col: 4
+          }
+          end: {
+            line: 9
+            col: 4
+          }
+        }
+      }
+    }
+    endpoints: {
       key: "FooEndpoint"
-      value: <
+      value: {
         name: "FooEndpoint"
-        stmt: <
-          call: <
-            target: <
+        stmt: {
+          call: {
+            target: {
               part: "Test - App"
-            >
+            }
             endpoint: "Test - Endpoint"
-          >
-        >
-      >
-    >
-    endpoints: <
+          }
+        }
+        source_context: {
+          file: "tests/test1.sysl"
+          start: {
+            line: 12
+            col: 4
+          }
+          end: {
+            line: 16
+            col: 4
+          }
+        }
+      }
+    }
+    endpoints: {
       key: "Test - App -> eventName"
-      value: <
+      value: {
         name: "Test - App -> eventName"
-        attrs: <
+        attrs: {
           key: "patterns"
-          value: <
-            a: <
-              elt: <
+          value: {
+            a: {
+              elt: {
                 s: "mq"
-              >
-            >
-          >
-        >
-        source: <
+              }
+            }
+          }
+        }
+        source: {
           part: "Test - App"
-        >
-        stmt: <
-          action: <
+        }
+        stmt: {
+          action: {
             action: "\"\""
-          >
-        >
-        stmt: <
-          action: <
+          }
+        }
+        stmt: {
+          action: {
             action: "''"
-          >
-        >
-        stmt: <
-          action: <
+          }
+        }
+        stmt: {
+          action: {
             action: "'asdf'"
-          >
-        >
-        stmt: <
-          action: <
+          }
+        }
+        stmt: {
+          action: {
             action: "\"quoted statement: use special chars here like ?? :: etc\""
-          >
-        >
-        stmt: <
-          action: <
+          }
+        }
+        stmt: {
+          action: {
             action: "\"test: single quotes 'above'\""
-          >
-        >
-        stmt: <
-          action: <
+          }
+        }
+        stmt: {
+          action: {
             action: "do something"
-          >
-        >
-        stmt: <
-          action: <
+          }
+        }
+        stmt: {
+          action: {
             action: "| Some multiline comments that you can use for documentation. This is last line."
-          >
-        >
-        stmt: <
-          action: <
+          }
+        }
+        stmt: {
+          action: {
             action: "handle event eventName"
-          >
-        >
-      >
-    >
-  >
->
-apps: <
+          }
+        }
+        source_context: {
+          file: "tests/test1.sysl"
+          start: {
+            line: 16
+            col: 4
+          }
+          end: {
+            line: 28
+            col: 10
+          }
+        }
+      }
+    }
+    source_context: {
+      file: "tests/test1.sysl"
+      start: {
+        line: 1
+        col: 1
+      }
+      end: {
+        line: 1
+        col: 92
+      }
+    }
+  }
+}
+apps: {
   key: "Test - App"
-  value: <
-    name: <
+  value: {
+    name: {
       part: "Test - App"
-    >
-    endpoints: <
+    }
+    endpoints: {
       key: "Endpoint2"
-      value: <
+      value: {
         name: "Endpoint2"
-        attrs: <
+        attrs: {
           key: "ep_desc"
-          value: <
+          value: {
             s: "this comment belongs to the Endpoint2 defined above"
-          >
-        >
-        param: <
+          }
+        }
+        param: {
           name: "request"
-          type: <
-            set: <
-              type_ref: <
-                ref: <
-                  appname: <
+          type: {
+            set: {
+              type_ref: {
+                ref: {
+                  appname: {
                     part: "SomeApp"
-                  >
+                  }
                   path: "SomeType"
-                >
-              >
-            >
-          >
-        >
-        stmt: <
-          action: <
+                }
+              }
+            }
+          }
+        }
+        stmt: {
+          action: {
             action: "| Single line statement"
-          >
-        >
-        stmt: <
-          call: <
-            target: <
+          }
+        }
+        stmt: {
+          call: {
+            target: {
               part: "Test - App"
-            >
+            }
             endpoint: "eventName"
-          >
-        >
-      >
-    >
-    endpoints: <
+          }
+        }
+        source_context: {
+          file: "tests/test1.sysl"
+          start: {
+            line: 39
+            col: 4
+          }
+          end: {
+            line: 44
+            col: 4
+          }
+        }
+      }
+    }
+    endpoints: {
       key: "Test - Endpoint"
-      value: <
+      value: {
         name: "Test - Endpoint"
-        param: <
+        param: {
           name: "request"
-          type: <
-            type_ref: <
-              ref: <
-                appname: <
+          type: {
+            type_ref: {
+              ref: {
+                appname: {
                   part: "SomeApp"
-                >
+                }
                 path: "SomeType"
-              >
-            >
-          >
-        >
-        stmt: <
-          call: <
-            target: <
+              }
+            }
+          }
+        }
+        stmt: {
+          call: {
+            target: {
               part: "External"
               part: "App"
-            >
+            }
             endpoint: "Endpoint"
-          >
-        >
-        stmt: <
-          call: <
-            target: <
+          }
+        }
+        stmt: {
+          call: {
+            target: {
               part: "Rest Service"
-            >
+            }
             endpoint: "GET /foo"
-          >
-        >
-        stmt: <
-          cond: <
+          }
+        }
+        stmt: {
+          cond: {
             test: "value == one"
-            stmt: <
-              action: <
+            stmt: {
+              action: {
                 action: "do something"
-              >
-            >
-          >
-        >
-        stmt: <
-          group: <
+              }
+            }
+          }
+        }
+        stmt: {
+          group: {
             title: "else if value == two"
-            stmt: <
-              action: <
+            stmt: {
+              action: {
                 action: "do something else"
-              >
-            >
-          >
-        >
-        stmt: <
-          group: <
+              }
+            }
+          }
+        }
+        stmt: {
+          group: {
             title: "else"
-            stmt: <
-              ret: <
+            stmt: {
+              ret: {
                 payload: "ok"
-              >
-            >
-          >
-        >
-      >
-    >
-    endpoints: <
+              }
+            }
+          }
+        }
+        source_context: {
+          file: "tests/test1.sysl"
+          start: {
+            line: 29
+            col: 4
+          }
+          end: {
+            line: 39
+            col: 4
+          }
+        }
+      }
+    }
+    endpoints: {
       key: "another event"
-      value: <
+      value: {
         name: "another event"
         is_pubsub: true
-      >
-    >
-    endpoints: <
+        source_context: {
+          file: "tests/test1.sysl"
+          start: {
+            line: 45
+            col: 4
+          }
+          end: {
+            line: 45
+            col: 23
+          }
+        }
+      }
+    }
+    endpoints: {
       key: "eventName"
-      value: <
+      value: {
         name: "eventName"
         is_pubsub: true
-        param: <
+        param: {
           name: "in"
-          type: <
+          type: {
             primitive: STRING
-          >
-        >
-        stmt: <
-          call: <
-            target: <
+          }
+        }
+        stmt: {
+          call: {
+            target: {
               part: "SomeApp"
-            >
+            }
             endpoint: "Test - App -> eventName"
-          >
-        >
-      >
-    >
-  >
->
-apps: <
+          }
+        }
+      }
+    }
+    source_context: {
+      file: "tests/test1.sysl"
+      start: {
+        line: 28
+        col: 1
+      }
+      end: {
+        line: 28
+      }
+    }
+  }
+}
+apps: {
   key: "anz_com"
-  value: <
-    name: <
+  value: {
+    name: {
       part: "anz_com"
-    >
-    endpoints: <
+    }
+    endpoints: {
       key: "homepage"
-      value: <
+      value: {
         name: "homepage"
-      >
-    >
-    types: <
+        source_context: {
+          file: "tests/test1.sysl"
+          start: {
+            line: 61
+            col: 4
+          }
+          end: {
+            line: 61
+            col: 14
+          }
+        }
+      }
+    }
+    types: {
       key: "Response"
-      value: <
-        tuple: <
-          attr_defs: <
+      value: {
+        tuple: {
+          attr_defs: {
             key: "val"
-            value: <
+            value: {
               primitive: STRING
-              source_context: <
+              source_context: {
                 file: "tests/test1.sysl"
-                start: <
+                start: {
                   line: 64
                   col: 15
-                >
-                end: <
+                }
+                end: {
                   line: 64
                   col: 15
-                >
-              >
-            >
-          >
-        >
-      >
-    >
-  >
->
+                }
+              }
+            }
+          }
+        }
+        source_context: {
+          file: "tests/test1.sysl"
+          start: {
+            line: 63
+            col: 4
+          }
+          end: {
+            line: 66
+            col: 3
+          }
+        }
+      }
+    }
+    source_context: {
+      file: "tests/test1.sysl"
+      start: {
+        line: 60
+        col: 1
+      }
+      end: {
+        line: 60
+      }
+    }
+  }
+}

--- a/pkg/parse/tests/test2.sysl.golden.textpb
+++ b/pkg/parse/tests/test2.sysl.golden.textpb
@@ -1,315 +1,399 @@
-apps: <
+apps: {
   key: "Request"
-  value: <
-    name: <
+  value: {
+    name: {
       part: "Request"
-    >
-    types: <
+    }
+    types: {
       key: "Input"
-      value: <
-        tuple: <
-          attr_defs: <
+      value: {
+        tuple: {
+          attr_defs: {
             key: "field1"
-            value: <
+            value: {
               primitive: INT
-              source_context: <
+              source_context: {
                 file: "tests/test2.sysl"
-                start: <
+                start: {
                   line: 22
                   col: 18
-                >
-                end: <
+                }
+                end: {
                   line: 22
                   col: 18
-                >
-              >
-            >
-          >
-        >
-      >
-    >
-  >
->
-apps: <
+                }
+              }
+            }
+          }
+        }
+        source_context: {
+          file: "tests/test2.sysl"
+          start: {
+            line: 21
+            col: 4
+          }
+          end: {
+            line: 24
+            col: 8
+          }
+        }
+      }
+    }
+    source_context: {
+      file: "tests/test2.sysl"
+      start: {
+        line: 20
+        col: 1
+      }
+      end: {
+        line: 20
+      }
+    }
+  }
+}
+apps: {
   key: "Response"
-  value: <
-    name: <
+  value: {
+    name: {
       part: "Response"
-    >
-    types: <
+    }
+    types: {
       key: "Output"
-      value: <
-        tuple: <
-          attr_defs: <
+      value: {
+        tuple: {
+          attr_defs: {
             key: "field1"
-            value: <
-              type_ref: <
-                context: <
-                  appname: <
+            value: {
+              type_ref: {
+                context: {
+                  appname: {
                     part: "Response"
-                  >
+                  }
                   path: "Output"
-                >
-                ref: <
+                }
+                ref: {
                   path: "Request"
-                >
-              >
-              source_context: <
+                }
+              }
+              source_context: {
                 file: "tests/test2.sysl"
-                start: <
+                start: {
                   line: 26
                   col: 18
-                >
-                end: <
+                }
+                end: {
                   line: 26
                   col: 18
-                >
-              >
-            >
-          >
-        >
-      >
-    >
-  >
->
-apps: <
+                }
+              }
+            }
+          }
+        }
+        source_context: {
+          file: "tests/test2.sysl"
+          start: {
+            line: 25
+            col: 4
+          }
+          end: {
+            line: 27
+          }
+        }
+      }
+    }
+    source_context: {
+      file: "tests/test2.sysl"
+      start: {
+        line: 24
+        col: 1
+      }
+      end: {
+        line: 24
+      }
+    }
+  }
+}
+apps: {
   key: "Tuple Model"
-  value: <
-    name: <
+  value: {
+    name: {
       part: "Tuple Model"
-    >
-    types: <
+    }
+    types: {
       key: "Foo"
-      value: <
-        tuple: <
-          attr_defs: <
+      value: {
+        tuple: {
+          attr_defs: {
             key: "id"
-            value: <
+            value: {
               primitive: INT
-              attrs: <
+              attrs: {
                 key: "description"
-                value: <
+                value: {
                   s: "some description"
-                >
-              >
-              source_context: <
+                }
+              }
+              source_context: {
                 file: "tests/test2.sysl"
-                start: <
+                start: {
                   line: 4
                   col: 14
-                >
-                end: <
+                }
+                end: {
                   line: 4
                   col: 14
-                >
-              >
-            >
-          >
-        >
-        attrs: <
+                }
+              }
+            }
+          }
+        }
+        attrs: {
           key: "description"
-          value: <
+          value: {
             s: "some description"
-          >
-        >
-      >
-    >
-    types: <
+          }
+        }
+        source_context: {
+          file: "tests/test2.sysl"
+          start: {
+            line: 3
+            col: 4
+          }
+          end: {
+            line: 6
+            col: 4
+          }
+        }
+      }
+    }
+    types: {
       key: "PersonName"
-      value: <
-        tuple: <
-          attr_defs: <
+      value: {
+        tuple: {
+          attr_defs: {
             key: "first_name"
-            value: <
+            value: {
               primitive: STRING
-              source_context: <
+              source_context: {
                 file: "tests/test2.sysl"
-                start: <
+                start: {
                   line: 16
                   col: 22
-                >
-                end: <
+                }
+                end: {
                   line: 16
                   col: 22
-                >
-              >
-            >
-          >
-          attr_defs: <
+                }
+              }
+            }
+          }
+          attr_defs: {
             key: "last_name"
-            value: <
+            value: {
               primitive: STRING
-              source_context: <
+              source_context: {
                 file: "tests/test2.sysl"
-                start: <
+                start: {
                   line: 18
                   col: 21
-                >
-                end: <
+                }
+                end: {
                   line: 18
                   col: 21
-                >
-              >
-            >
-          >
-          attr_defs: <
+                }
+              }
+            }
+          }
+          attr_defs: {
             key: "middle_name"
-            value: <
-              list: <
-                type: <
+            value: {
+              list: {
+                type: {
                   primitive: STRING
-                  source_context: <
+                  source_context: {
                     file: "tests/test2.sysl"
-                    start: <
+                    start: {
                       line: 17
                       col: 29
-                    >
-                    end: <
+                    }
+                    end: {
                       line: 17
                       col: 29
-                    >
-                  >
-                >
-              >
-            >
-          >
-          attr_defs: <
+                    }
+                  }
+                }
+              }
+            }
+          }
+          attr_defs: {
             key: "title"
-            value: <
+            value: {
               primitive: STRING
-              source_context: <
+              source_context: {
                 file: "tests/test2.sysl"
-                start: <
+                start: {
                   line: 15
                   col: 17
-                >
-                end: <
+                }
+                end: {
                   line: 15
                   col: 17
-                >
-              >
-            >
-          >
-        >
-      >
-    >
-    types: <
+                }
+              }
+            }
+          }
+        }
+        source_context: {
+          file: "tests/test2.sysl"
+          start: {
+            line: 14
+            col: 4
+          }
+          end: {
+            line: 20
+            col: 7
+          }
+        }
+      }
+    }
+    types: {
       key: "TableName"
-      value: <
-        tuple: <
-          attr_defs: <
+      value: {
+        tuple: {
+          attr_defs: {
             key: "fieldname"
-            value: <
+            value: {
               primitive: STRING
-              attrs: <
+              attrs: {
                 key: "description"
-                value: <
-                  s: "Multi-line annotation statement"
-                >
-              >
-              source_context: <
+                value: {
+                  s: "Multi-line annotation\n statement\n"
+                }
+              }
+              source_context: {
                 file: "tests/test2.sysl"
-                start: <
+                start: {
                   line: 10
                   col: 21
-                >
-                end: <
+                }
+                end: {
                   line: 10
                   col: 21
-                >
-              >
-            >
-          >
-          attr_defs: <
+                }
+              }
+            }
+          }
+          attr_defs: {
             key: "fieldname2"
-            value: <
-              set: <
+            value: {
+              set: {
                 primitive: STRING
-                source_context: <
+                source_context: {
                   file: "tests/test2.sysl"
-                  start: <
+                  start: {
                     line: 11
                     col: 22
-                  >
-                  end: <
+                  }
+                  end: {
                     line: 11
                     col: 29
-                  >
-                >
-              >
-              attrs: <
+                  }
+                }
+              }
+              attrs: {
                 key: "description"
-                value: <
-                  s: "Multi-line annotation statement"
-                >
-              >
-              source_context: <
+                value: {
+                  s: "Multi-line annotation\n statement\n"
+                }
+              }
+              source_context: {
                 file: "tests/test2.sysl"
-                start: <
+                start: {
                   line: 11
                   col: 22
-                >
-                end: <
+                }
+                end: {
                   line: 11
                   col: 29
-                >
-              >
-            >
-          >
-          attr_defs: <
+                }
+              }
+            }
+          }
+          attr_defs: {
             key: "ids"
-            value: <
-              set: <
-                type_ref: <
-                  context: <
-                    appname: <
+            value: {
+              set: {
+                type_ref: {
+                  context: {
+                    appname: {
                       part: "Tuple Model"
-                    >
+                    }
                     path: "TableName"
-                  >
-                  ref: <
+                  }
+                  ref: {
                     path: "Foo"
-                  >
-                >
-                source_context: <
+                  }
+                }
+                source_context: {
                   file: "tests/test2.sysl"
-                  start: <
+                  start: {
                     line: 12
                     col: 15
-                  >
-                  end: <
+                  }
+                  end: {
                     line: 12
                     col: 22
-                  >
-                >
-              >
-              attrs: <
+                  }
+                }
+              }
+              attrs: {
                 key: "description"
-                value: <
-                  s: "Multi-line annotation statement"
-                >
-              >
-              source_context: <
+                value: {
+                  s: "Multi-line annotation\n statement\n"
+                }
+              }
+              source_context: {
                 file: "tests/test2.sysl"
-                start: <
+                start: {
                   line: 12
                   col: 15
-                >
-                end: <
+                }
+                end: {
                   line: 12
                   col: 22
-                >
-              >
-            >
-          >
-        >
-        attrs: <
+                }
+              }
+            }
+          }
+        }
+        attrs: {
           key: "description"
-          value: <
-            s: "Multi-line annotation statement"
-          >
-        >
-      >
-    >
-  >
->
+          value: {
+            s: "Multi-line annotation\n statement\n"
+          }
+        }
+        source_context: {
+          file: "tests/test2.sysl"
+          start: {
+            line: 7
+            col: 4
+          }
+          end: {
+            line: 14
+            col: 4
+          }
+        }
+      }
+    }
+    source_context: {
+      file: "tests/test2.sysl"
+      start: {
+        line: 1
+        col: 1
+      }
+      end: {
+        line: 1
+      }
+    }
+  }
+}

--- a/pkg/parse/tests/test4.sysl.golden.textpb
+++ b/pkg/parse/tests/test4.sysl.golden.textpb
@@ -1,334 +1,464 @@
-apps: <
+apps: {
   key: "Browser App"
-  value: <
-    name: <
+  value: {
+    name: {
       part: "Browser App"
-    >
-    endpoints: <
+    }
+    endpoints: {
       key: "EP"
-      value: <
+      value: {
         name: "EP"
-        param: <
+        param: {
           name: "p1"
-          type: <
-            type_ref: <
-              ref: <
-                appname: <
+          type: {
+            type_ref: {
+              ref: {
+                appname: {
                   part: "GO"
                   part: "Sample"
                   part: "My Todo App"
-                >
+                }
                 path: "id"
-              >
-            >
-          >
-        >
-      >
-    >
-    endpoints: <
+              }
+            }
+          }
+        }
+        source_context: {
+          file: "tests/test4.sysl"
+          start: {
+            line: 22
+            col: 4
+          }
+          end: {
+            line: 22
+            col: 47
+          }
+        }
+      }
+    }
+    endpoints: {
       key: "EP1"
-      value: <
+      value: {
         name: "EP1"
-        param: <
+        param: {
           name: "p2"
-          type: <
-            type_ref: <
-              ref: <
-                appname: <
+          type: {
+            type_ref: {
+              ref: {
+                appname: {
                   part: "Sample"
                   part: "My Todo App"
-                >
+                }
                 path: "id"
-              >
-            >
-          >
-        >
-      >
-    >
-    endpoints: <
+              }
+            }
+          }
+        }
+        source_context: {
+          file: "tests/test4.sysl"
+          start: {
+            line: 23
+            col: 4
+          }
+          end: {
+            line: 23
+            col: 42
+          }
+        }
+      }
+    }
+    endpoints: {
       key: "EP2"
-      value: <
+      value: {
         name: "EP2"
-        param: <
+        param: {
           name: "p3"
-          type: <
-            type_ref: <
-              ref: <
-                appname: <
+          type: {
+            type_ref: {
+              ref: {
+                appname: {
                   part: "My Todo App"
-                >
+                }
                 path: "id"
-              >
-            >
-          >
-        >
-      >
-    >
-    endpoints: <
+              }
+            }
+          }
+        }
+        source_context: {
+          file: "tests/test4.sysl"
+          start: {
+            line: 24
+            col: 4
+          }
+          end: {
+            line: 24
+            col: 33
+          }
+        }
+      }
+    }
+    endpoints: {
       key: "EP3"
-      value: <
+      value: {
         name: "EP3"
-        param: <
+        param: {
           name: "p4"
-          type: <
-            type_ref: <
-              ref: <
-                appname: <
+          type: {
+            type_ref: {
+              ref: {
+                appname: {
                   part: "id"
-                >
-              >
-            >
-          >
-        >
-      >
-    >
-    types: <
+                }
+              }
+            }
+          }
+        }
+        source_context: {
+          file: "tests/test4.sysl"
+          start: {
+            line: 25
+            col: 4
+          }
+          end: {
+            line: 25
+            col: 21
+          }
+        }
+      }
+    }
+    types: {
       key: "Data"
-      value: <
-        tuple: <
-          attr_defs: <
+      value: {
+        tuple: {
+          attr_defs: {
             key: "id"
-            value: <
-              type_ref: <
-                context: <
-                  appname: <
+            value: {
+              type_ref: {
+                context: {
+                  appname: {
                     part: "Browser App"
-                  >
+                  }
                   path: "Data"
-                >
-                ref: <
-                  appname: <
+                }
+                ref: {
+                  appname: {
                     part: "GO"
                     part: "Sample"
-                  >
+                  }
                   path: "My Todo App"
                   path: "id"
-                >
-              >
-              source_context: <
+                }
+              }
+              source_context: {
                 file: "tests/test4.sysl"
-                start: <
+                start: {
                   line: 18
                   col: 14
-                >
-                end: <
+                }
+                end: {
                   line: 18
                   col: 42
-                >
-              >
-            >
-          >
-          attr_defs: <
+                }
+              }
+            }
+          }
+          attr_defs: {
             key: "id2"
-            value: <
-              type_ref: <
-                context: <
-                  appname: <
+            value: {
+              type_ref: {
+                context: {
+                  appname: {
                     part: "Browser App"
-                  >
+                  }
                   path: "Data"
-                >
-                ref: <
-                  appname: <
+                }
+                ref: {
+                  appname: {
                     part: "Sample"
-                  >
+                  }
                   path: "My Todo App"
                   path: "id"
-                >
-              >
-              source_context: <
+                }
+              }
+              source_context: {
                 file: "tests/test4.sysl"
-                start: <
+                start: {
                   line: 19
                   col: 15
-                >
-                end: <
+                }
+                end: {
                   line: 19
                   col: 37
-                >
-              >
-            >
-          >
-          attr_defs: <
+                }
+              }
+            }
+          }
+          attr_defs: {
             key: "id3"
-            value: <
-              type_ref: <
-                context: <
-                  appname: <
+            value: {
+              type_ref: {
+                context: {
+                  appname: {
                     part: "Browser App"
-                  >
+                  }
                   path: "Data"
-                >
-                ref: <
+                }
+                ref: {
                   path: "My Todo App"
                   path: "id"
-                >
-              >
-              source_context: <
+                }
+              }
+              source_context: {
                 file: "tests/test4.sysl"
-                start: <
+                start: {
                   line: 20
                   col: 15
-                >
-                end: <
+                }
+                end: {
                   line: 20
                   col: 27
-                >
-              >
-            >
-          >
-        >
-      >
-    >
-  >
->
-apps: <
+                }
+              }
+            }
+          }
+        }
+        source_context: {
+          file: "tests/test4.sysl"
+          start: {
+            line: 17
+            col: 4
+          }
+          end: {
+            line: 22
+            col: 4
+          }
+        }
+      }
+    }
+    source_context: {
+      file: "tests/test4.sysl"
+      start: {
+        line: 16
+        col: 1
+      }
+      end: {
+        line: 16
+      }
+    }
+  }
+}
+apps: {
   key: "GO ::Sample:: My Todo App"
-  value: <
-    name: <
+  value: {
+    name: {
       part: "GO"
       part: "Sample"
       part: "My Todo App"
-    >
-    types: <
+    }
+    types: {
       key: "Todo"
-      value: <
-        tuple: <
-          attr_defs: <
+      value: {
+        tuple: {
+          attr_defs: {
             key: "id"
-            value: <
+            value: {
               primitive: INT
-              source_context: <
+              source_context: {
                 file: "tests/test4.sysl"
-                start: <
+                start: {
                   line: 3
                   col: 14
-                >
-                end: <
+                }
+                end: {
                   line: 3
                   col: 14
-                >
-              >
-            >
-          >
-          attr_defs: <
+                }
+              }
+            }
+          }
+          attr_defs: {
             key: "note"
-            value: <
+            value: {
               primitive: STRING
-              source_context: <
+              source_context: {
                 file: "tests/test4.sysl"
-                start: <
+                start: {
                   line: 4
                   col: 16
-                >
-                end: <
+                }
+                end: {
                   line: 4
                   col: 16
-                >
-              >
-            >
-          >
-        >
-      >
-    >
-  >
->
-apps: <
+                }
+              }
+            }
+          }
+        }
+        source_context: {
+          file: "tests/test4.sysl"
+          start: {
+            line: 2
+            col: 4
+          }
+          end: {
+            line: 6
+            col: 6
+          }
+        }
+      }
+    }
+    source_context: {
+      file: "tests/test4.sysl"
+      start: {
+        line: 1
+        col: 1
+      }
+      end: {
+        line: 1
+        col: 14
+      }
+    }
+  }
+}
+apps: {
   key: "My Todo App"
-  value: <
-    name: <
+  value: {
+    name: {
       part: "My Todo App"
-    >
-    types: <
+    }
+    types: {
       key: "Todo"
-      value: <
-        tuple: <
-          attr_defs: <
+      value: {
+        tuple: {
+          attr_defs: {
             key: "id"
-            value: <
+            value: {
               primitive: INT
-              source_context: <
+              source_context: {
                 file: "tests/test4.sysl"
-                start: <
+                start: {
                   line: 13
                   col: 14
-                >
-                end: <
+                }
+                end: {
                   line: 13
                   col: 14
-                >
-              >
-            >
-          >
-          attr_defs: <
+                }
+              }
+            }
+          }
+          attr_defs: {
             key: "note"
-            value: <
+            value: {
               primitive: STRING
-              source_context: <
+              source_context: {
                 file: "tests/test4.sysl"
-                start: <
+                start: {
                   line: 14
                   col: 16
-                >
-                end: <
+                }
+                end: {
                   line: 14
                   col: 16
-                >
-              >
-            >
-          >
-        >
-      >
-    >
-  >
->
-apps: <
+                }
+              }
+            }
+          }
+        }
+        source_context: {
+          file: "tests/test4.sysl"
+          start: {
+            line: 12
+            col: 4
+          }
+          end: {
+            line: 16
+            col: 11
+          }
+        }
+      }
+    }
+    source_context: {
+      file: "tests/test4.sysl"
+      start: {
+        line: 11
+        col: 1
+      }
+      end: {
+        line: 11
+      }
+    }
+  }
+}
+apps: {
   key: "Sample::My Todo App"
-  value: <
-    name: <
+  value: {
+    name: {
       part: "Sample"
       part: "My Todo App"
-    >
-    types: <
+    }
+    types: {
       key: "Todo"
-      value: <
-        tuple: <
-          attr_defs: <
+      value: {
+        tuple: {
+          attr_defs: {
             key: "id"
-            value: <
+            value: {
               primitive: INT
-              source_context: <
+              source_context: {
                 file: "tests/test4.sysl"
-                start: <
+                start: {
                   line: 8
                   col: 14
-                >
-                end: <
+                }
+                end: {
                   line: 8
                   col: 14
-                >
-              >
-            >
-          >
-          attr_defs: <
+                }
+              }
+            }
+          }
+          attr_defs: {
             key: "note"
-            value: <
+            value: {
               primitive: STRING
-              source_context: <
+              source_context: {
                 file: "tests/test4.sysl"
-                start: <
+                start: {
                   line: 9
                   col: 16
-                >
-                end: <
+                }
+                end: {
                   line: 9
                   col: 16
-                >
-              >
-            >
-          >
-        >
-      >
-    >
-  >
->
+                }
+              }
+            }
+          }
+        }
+        source_context: {
+          file: "tests/test4.sysl"
+          start: {
+            line: 7
+            col: 4
+          }
+          end: {
+            line: 11
+            col: 11
+          }
+        }
+      }
+    }
+    source_context: {
+      file: "tests/test4.sysl"
+      start: {
+        line: 6
+        col: 1
+      }
+      end: {
+        line: 6
+        col: 8
+      }
+    }
+  }
+}

--- a/pkg/parse/tests/test_rest_api.sysl.golden.textpb
+++ b/pkg/parse/tests/test_rest_api.sysl.golden.textpb
@@ -1,989 +1,988 @@
-apps: <
+apps: {
   key: "BrowserApp"
-  value: <
-    name: <
+  value: {
+    name: {
       part: "BrowserApp"
-    >
-    attrs: <
+    }
+    attrs: {
       key: "patterns"
-      value: <
-        a: <
-          elt: <
+      value: {
+        a: {
+          elt: {
             s: "ajax"
-          >
-        >
-      >
-    >
-    endpoints: <
+          }
+        }
+      }
+    }
+    endpoints: {
       key: "HomePage"
-      value: <
+      value: {
         name: "HomePage"
-        stmt: <
-          call: <
-            target: <
+        stmt: {
+          call: {
+            target: {
               part: "My"
               part: "Server"
-            >
+            }
             endpoint: "GET /"
-          >
-        >
-        source_context: <
+          }
+        }
+        source_context: {
           file: "tests/test_rest_api.sysl"
-          start: <
+          start: {
             line: 48
             col: 4
-          >
-          end: <
+          }
+          end: {
             line: 51
             col: 4
-          >
-        >
-      >
-    >
-    endpoints: <
+          }
+        }
+      }
+    }
+    endpoints: {
       key: "On Click"
-      value: <
+      value: {
         name: "On Click"
-        stmt: <
-          action: <
+        stmt: {
+          action: {
             action: "| Comment On click, initiate a server call"
-          >
-        >
-        stmt: <
-          call: <
-            target: <
+          }
+        }
+        stmt: {
+          call: {
+            target: {
               part: "My"
               part: "Server"
-            >
+            }
             endpoint: "GET /first/{id}"
-          >
-          attrs: <
+          }
+          attrs: {
             key: "patterns"
-            value: <
-              a: <
-                elt: <
+            value: {
+              a: {
+                elt: {
                   s: "pattern+foo"
-                >
-              >
-            >
-          >
-        >
-        stmt: <
-          call: <
-            target: <
+                }
+              }
+            }
+          }
+        }
+        stmt: {
+          call: {
+            target: {
               part: "BrowserApp"
-            >
+            }
             endpoint: "Show Success"
-          >
-        >
-        source_context: <
+          }
+        }
+        source_context: {
           file: "tests/test_rest_api.sysl"
-          start: <
+          start: {
             line: 59
             col: 4
-          >
-          end: <
+          }
+          end: {
             line: 63
-          >
-        >
-      >
-    >
-    endpoints: <
+          }
+        }
+      }
+    }
+    endpoints: {
       key: "Show Foo"
-      value: <
+      value: {
         name: "Show Foo"
-        stmt: <
-          call: <
-            target: <
+        stmt: {
+          call: {
+            target: {
               part: "My"
               part: "Server"
-            >
+            }
             endpoint: "GET /foo"
-          >
-        >
-        stmt: <
-          call: <
-            target: <
+          }
+        }
+        stmt: {
+          call: {
+            target: {
               part: "My"
               part: "Server"
-            >
+            }
             endpoint: "GET /foo/"
-          >
-        >
-        source_context: <
+          }
+        }
+        source_context: {
           file: "tests/test_rest_api.sysl"
-          start: <
+          start: {
             line: 51
             col: 4
-          >
-          end: <
+          }
+          end: {
             line: 55
             col: 4
-          >
-        >
-      >
-    >
-    endpoints: <
+          }
+        }
+      }
+    }
+    endpoints: {
       key: "Show Success"
-      value: <
+      value: {
         name: "Show Success"
-        stmt: <
-          call: <
-            target: <
+        stmt: {
+          call: {
+            target: {
               part: "My"
               part: "Server"
-            >
+            }
             endpoint: "GET /first-level/{id}/second/third"
-          >
-        >
-        stmt: <
-          ret: <
+          }
+        }
+        stmt: {
+          ret: {
             payload: "200 ok"
-          >
-        >
-        source_context: <
+          }
+        }
+        source_context: {
           file: "tests/test_rest_api.sysl"
-          start: <
+          start: {
             line: 55
             col: 4
-          >
-          end: <
+          }
+          end: {
             line: 59
             col: 4
-          >
-        >
-      >
-    >
-    types: <
+          }
+        }
+      }
+    }
+    types: {
       key: "Request"
-      value: <
-        tuple: <
-          attr_defs: <
+      value: {
+        tuple: {
+          attr_defs: {
             key: "val"
-            value: <
+            value: {
               primitive: STRING
-              attrs: <
+              attrs: {
                 key: "description"
-                value: <
-                  s: "Multi line comment 1 Multi line comment 2"
-                >
-              >
-              source_context: <
+                value: {
+                  s: "Multi line comment 1\n Multi line comment 2\n"
+                }
+              }
+              source_context: {
                 file: "tests/test_rest_api.sysl"
-                start: <
+                start: {
                   line: 46
                   col: 15
-                >
-                end: <
+                }
+                end: {
                   line: 46
                   col: 15
-                >
-              >
-            >
-          >
-        >
-        attrs: <
+                }
+              }
+            }
+          }
+        }
+        attrs: {
           key: "description"
-          value: <
-            s: "Multi line comment 1 Multi line comment 2"
-          >
-        >
-        source_context: <
+          value: {
+            s: "Multi line comment 1\n Multi line comment 2\n"
+          }
+        }
+        source_context: {
           file: "tests/test_rest_api.sysl"
-          start: <
+          start: {
             line: 43
             col: 4
-          >
-          end: <
+          }
+          end: {
             line: 48
             col: 4
-          >
-        >
-      >
-    >
-    source_context: <
+          }
+        }
+      }
+    }
+    source_context: {
       file: "tests/test_rest_api.sysl"
-      start: <
+      start: {
         line: 41
         col: 1
-      >
-      end: <
+      }
+      end: {
         line: 41
         col: 17
-      >
-    >
-  >
->
-apps: <
+      }
+    }
+  }
+}
+apps: {
   key: "My :: Server"
-  value: <
-    name: <
+  value: {
+    name: {
       part: "My"
       part: "Server"
-    >
-    attrs: <
+    }
+    attrs: {
       key: "patterns"
-      value: <
-        a: <
-          elt: <
+      value: {
+        a: {
+          elt: {
             s: "rest"
-          >
-        >
-      >
-    >
-    endpoints: <
+          }
+        }
+      }
+    }
+    endpoints: {
       key: "GET /"
-      value: <
+      value: {
         name: "GET /"
-        attrs: <
+        attrs: {
           key: "patterns"
-          value: <
-            a: <
-              elt: <
+          value: {
+            a: {
+              elt: {
                 s: "rest"
-              >
-            >
-          >
-        >
-        stmt: <
-          action: <
+              }
+            }
+          }
+        }
+        stmt: {
+          action: {
             action: "..."
-          >
-        >
-        rest_params: <
+          }
+        }
+        rest_params: {
           method: GET
           path: "/"
-        >
-        source_context: <
+        }
+        source_context: {
           file: "tests/test_rest_api.sysl"
-          start: <
+          start: {
             line: 3
             col: 8
-          >
-          end: <
+          }
+          end: {
             line: 5
             col: 4
-          >
-        >
-      >
-    >
-    endpoints: <
+          }
+        }
+      }
+    }
+    endpoints: {
       key: "GET /first"
-      value: <
+      value: {
         name: "GET /first"
-        attrs: <
+        attrs: {
           key: "patterns"
-          value: <
-            a: <
-              elt: <
+          value: {
+            a: {
+              elt: {
                 s: "rest"
-              >
-              elt: <
+              }
+              elt: {
                 s: "deprecated"
-              >
-              elt: <
+              }
+              elt: {
                 s: "rest"
-              >
-              elt: <
+              }
+              elt: {
                 s: "https"
-              >
-            >
-          >
-        >
-        param: <
-        >
-        stmt: <
-          action: <
+              }
+            }
+          }
+        }
+        param: {}
+        stmt: {
+          action: {
             action: "..."
-          >
-        >
-        rest_params: <
+          }
+        }
+        rest_params: {
           method: GET
           path: "/first"
-        >
-        source_context: <
+        }
+        source_context: {
           file: "tests/test_rest_api.sysl"
-          start: <
+          start: {
             line: 20
             col: 8
-          >
-          end: <
+          }
+          end: {
             line: 22
             col: 8
-          >
-        >
-      >
-    >
-    endpoints: <
+          }
+        }
+      }
+    }
+    endpoints: {
       key: "GET /first-level/{id}/second/third"
-      value: <
+      value: {
         name: "GET /first-level/{id}/second/third"
         docstring: " Multi line statement - 1 Multi line statement - 2 Multi line statement - 3"
-        attrs: <
+        attrs: {
           key: "id"
-          value: <
+          value: {
             s: "id01"
-          >
-        >
-        attrs: <
+          }
+        }
+        attrs: {
           key: "patterns"
-          value: <
-            a: <
-              elt: <
+          value: {
+            a: {
+              elt: {
                 s: "rest"
-              >
-            >
-          >
-        >
-        stmt: <
-          ret: <
+              }
+            }
+          }
+        }
+        stmt: {
+          ret: {
             payload: "200 ok"
-          >
-        >
-        rest_params: <
+          }
+        }
+        rest_params: {
           method: GET
           path: "/first-level/{id}/second/third"
-          query_param: <
+          query_param: {
             name: "q"
-            type: <
-              type_ref: <
-                context: <
-                  appname: <
+            type: {
+              type_ref: {
+                context: {
+                  appname: {
                     part: "My"
                     part: "Server"
-                  >
-                >
-                ref: <
+                  }
+                }
+                ref: {
                   path: "queryTerms"
-                >
-              >
-              source_context: <
+                }
+              }
+              source_context: {
                 file: "tests/test_rest_api.sysl"
-                start: <
+                start: {
                   line: 35
                   col: 13
-                >
-                end: <
+                }
+                end: {
                   line: 35
                   col: 26
-                >
-              >
-            >
-          >
-          query_param: <
+                }
+              }
+            }
+          }
+          query_param: {
             name: "limit"
-            type: <
-              type_ref: <
-                context: <
-                  appname: <
+            type: {
+              type_ref: {
+                context: {
+                  appname: {
                     part: "My"
                     part: "Server"
-                  >
-                >
-                ref: <
+                  }
+                }
+                ref: {
                   path: "pageSize"
-                >
-              >
-              source_context: <
+                }
+              }
+              source_context: {
                 file: "tests/test_rest_api.sysl"
-                start: <
+                start: {
                   line: 35
                   col: 28
-                >
-                end: <
+                }
+                end: {
                   line: 35
                   col: 43
-                >
-              >
-            >
-          >
-          query_param: <
+                }
+              }
+            }
+          }
+          query_param: {
             name: "offset"
-            type: <
-              type_ref: <
-                context: <
-                  appname: <
+            type: {
+              type_ref: {
+                context: {
+                  appname: {
                     part: "My"
                     part: "Server"
-                  >
-                >
-                ref: <
+                  }
+                }
+                ref: {
                   path: "startingRecord"
-                >
-              >
-              source_context: <
+                }
+              }
+              source_context: {
                 file: "tests/test_rest_api.sysl"
-                start: <
+                start: {
                   line: 35
                   col: 45
-                >
-                end: <
+                }
+                end: {
                   line: 35
                   col: 67
-                >
-              >
-            >
-          >
-          url_param: <
+                }
+              }
+            }
+          }
+          url_param: {
             name: "id"
-            type: <
+            type: {
               primitive: INT
-              source_context: <
+              source_context: {
                 file: "tests/test_rest_api.sysl"
-                start: <
+                start: {
                   line: 34
                   col: 17
-                >
-                end: <
+                }
+                end: {
                   line: 34
                   col: 25
-                >
-              >
-            >
-          >
-        >
-        source_context: <
+                }
+              }
+            }
+          }
+        }
+        source_context: {
           file: "tests/test_rest_api.sysl"
-          start: <
+          start: {
             line: 35
             col: 8
-          >
-          end: <
+          }
+          end: {
             line: 41
             col: 10
-          >
-        >
-      >
-    >
-    endpoints: <
+          }
+        }
+      }
+    }
+    endpoints: {
       key: "GET /first/{id}"
-      value: <
+      value: {
         name: "GET /first/{id}"
-        attrs: <
+        attrs: {
           key: "patterns"
-          value: <
-            a: <
-              elt: <
+          value: {
+            a: {
+              elt: {
                 s: "rest"
-              >
-              elt: <
+              }
+              elt: {
                 s: "deprecated"
-              >
-            >
-          >
-        >
-        attrs: <
+              }
+            }
+          }
+        }
+        attrs: {
           key: "system_id"
-          value: <
+          value: {
             s: "001"
-          >
-        >
-        attrs: <
+          }
+        }
+        attrs: {
           key: "uber"
-          value: <
+          value: {
             s: "value"
-          >
-        >
-        stmt: <
-          action: <
+          }
+        }
+        stmt: {
+          action: {
             action: "..."
-          >
-        >
-        rest_params: <
+          }
+        }
+        rest_params: {
           method: GET
           path: "/first/{id}"
-          query_param: <
+          query_param: {
             name: "depth"
-            type: <
+            type: {
               primitive: INT
-              source_context: <
+              source_context: {
                 file: "tests/test_rest_api.sysl"
-                start: <
+                start: {
                   line: 23
                   col: 17
-                >
-                end: <
+                }
+                end: {
                   line: 23
                   col: 23
-                >
-              >
-            >
-          >
-          query_param: <
+                }
+              }
+            }
+          }
+          query_param: {
             name: "limit"
-            type: <
+            type: {
               primitive: INT
               opt: true
-              source_context: <
+              source_context: {
                 file: "tests/test_rest_api.sysl"
-                start: <
+                start: {
                   line: 23
                   col: 27
-                >
-                end: <
+                }
+                end: {
                   line: 23
                   col: 36
-                >
-              >
-            >
-          >
-          query_param: <
+                }
+              }
+            }
+          }
+          query_param: {
             name: "offset"
-            type: <
+            type: {
               primitive: INT
               opt: true
-              source_context: <
+              source_context: {
                 file: "tests/test_rest_api.sysl"
-                start: <
+                start: {
                   line: 23
                   col: 38
-                >
-                end: <
+                }
+                end: {
                   line: 23
                   col: 48
-                >
-              >
-            >
-          >
-          url_param: <
+                }
+              }
+            }
+          }
+          url_param: {
             name: "id"
-            type: <
+            type: {
               primitive: INT
-              source_context: <
+              source_context: {
                 file: "tests/test_rest_api.sysl"
-                start: <
+                start: {
                   line: 22
                   col: 9
-                >
-                end: <
+                }
+                end: {
                   line: 22
                   col: 17
-                >
-              >
-            >
-          >
-        >
-        source_context: <
+                }
+              }
+            }
+          }
+        }
+        source_context: {
           file: "tests/test_rest_api.sysl"
-          start: <
+          start: {
             line: 23
             col: 12
-          >
-          end: <
+          }
+          end: {
             line: 25
             col: 12
-          >
-        >
-      >
-    >
-    endpoints: <
+          }
+        }
+      }
+    }
+    endpoints: {
       key: "GET /foo"
-      value: <
+      value: {
         name: "GET /foo"
-        attrs: <
+        attrs: {
           key: "patterns"
-          value: <
-            a: <
-              elt: <
+          value: {
+            a: {
+              elt: {
                 s: "rest"
-              >
-            >
-          >
-        >
-        attrs: <
+              }
+            }
+          }
+        }
+        attrs: {
           key: "zero"
-          value: <
+          value: {
             s: "0"
-          >
-        >
-        stmt: <
-          action: <
+          }
+        }
+        stmt: {
+          action: {
             action: "..."
-          >
-        >
-        rest_params: <
+          }
+        }
+        rest_params: {
           method: GET
           path: "/foo"
-        >
-        source_context: <
+        }
+        source_context: {
           file: "tests/test_rest_api.sysl"
-          start: <
+          start: {
             line: 6
             col: 8
-          >
-          end: <
+          }
+          end: {
             line: 8
             col: 8
-          >
-        >
-      >
-    >
-    endpoints: <
+          }
+        }
+      }
+    }
+    endpoints: {
       key: "GET /foo/"
-      value: <
+      value: {
         name: "GET /foo/"
-        attrs: <
+        attrs: {
           key: "patterns"
-          value: <
-            a: <
-              elt: <
+          value: {
+            a: {
+              elt: {
                 s: "rest"
-              >
-            >
-          >
-        >
-        attrs: <
+              }
+            }
+          }
+        }
+        attrs: {
           key: "zero"
-          value: <
+          value: {
             s: "0"
-          >
-        >
-        stmt: <
-          action: <
+          }
+        }
+        stmt: {
+          action: {
             action: "..."
-          >
-        >
-        rest_params: <
+          }
+        }
+        rest_params: {
           method: GET
           path: "/foo/"
-        >
-        source_context: <
+        }
+        source_context: {
           file: "tests/test_rest_api.sysl"
-          start: <
+          start: {
             line: 9
             col: 12
-          >
-          end: <
+          }
+          end: {
             line: 11
             col: 8
-          >
-        >
-      >
-    >
-    endpoints: <
+          }
+        }
+      }
+    }
+    endpoints: {
       key: "GET /foo/blah"
-      value: <
+      value: {
         name: "GET /foo/blah"
-        attrs: <
+        attrs: {
           key: "four"
-          value: <
+          value: {
             s: "4"
-          >
-        >
-        attrs: <
+          }
+        }
+        attrs: {
           key: "patterns"
-          value: <
-            a: <
-              elt: <
+          value: {
+            a: {
+              elt: {
                 s: "rest"
-              >
-            >
-          >
-        >
-        attrs: <
+              }
+            }
+          }
+        }
+        attrs: {
           key: "zero"
-          value: <
+          value: {
             s: "0"
-          >
-        >
-        param: <
+          }
+        }
+        param: {
           name: "str"
-          type: <
+          type: {
             primitive: STRING
-          >
-        >
-        stmt: <
-          action: <
+          }
+        }
+        stmt: {
+          action: {
             action: "..."
-          >
-        >
-        rest_params: <
+          }
+        }
+        rest_params: {
           method: GET
           path: "/foo/blah"
-        >
-        source_context: <
+        }
+        source_context: {
           file: "tests/test_rest_api.sysl"
-          start: <
+          start: {
             line: 17
             col: 12
-          >
-          end: <
+          }
+          end: {
             line: 19
             col: 4
-          >
-        >
-      >
-    >
-    endpoints: <
+          }
+        }
+      }
+    }
+    endpoints: {
       key: "POST /first/{id}/another-second"
-      value: <
+      value: {
         name: "POST /first/{id}/another-second"
-        attrs: <
+        attrs: {
           key: "patterns"
-          value: <
-            a: <
-              elt: <
+          value: {
+            a: {
+              elt: {
                 s: "rest"
-              >
-              elt: <
+              }
+              elt: {
                 s: "deprecated"
-              >
-            >
-          >
-        >
-        attrs: <
+              }
+            }
+          }
+        }
+        attrs: {
           key: "uber"
-          value: <
+          value: {
             s: "value"
-          >
-        >
-        stmt: <
-          action: <
+          }
+        }
+        stmt: {
+          action: {
             action: "..."
-          >
-        >
-        rest_params: <
+          }
+        }
+        rest_params: {
           method: POST
           path: "/first/{id}/another-second"
-          url_param: <
+          url_param: {
             name: "id"
-            type: <
+            type: {
               primitive: INT
-              source_context: <
+              source_context: {
                 file: "tests/test_rest_api.sysl"
-                start: <
+                start: {
                   line: 22
                   col: 9
-                >
-                end: <
+                }
+                end: {
                   line: 22
                   col: 17
-                >
-              >
-            >
-          >
-        >
-        source_context: <
+                }
+              }
+            }
+          }
+        }
+        source_context: {
           file: "tests/test_rest_api.sysl"
-          start: <
+          start: {
             line: 32
             col: 16
-          >
-          end: <
+          }
+          end: {
             line: 34
             col: 4
-          >
-        >
-      >
-    >
-    endpoints: <
+          }
+        }
+      }
+    }
+    endpoints: {
       key: "POST /first/{id}/second/third"
-      value: <
+      value: {
         name: "POST /first/{id}/second/third"
-        attrs: <
+        attrs: {
           key: "patterns"
-          value: <
-            a: <
-              elt: <
+          value: {
+            a: {
+              elt: {
                 s: "rest"
-              >
-              elt: <
+              }
+              elt: {
                 s: "deprecated"
-              >
-            >
-          >
-        >
-        attrs: <
+              }
+            }
+          }
+        }
+        attrs: {
           key: "uber"
-          value: <
+          value: {
             s: "value"
-          >
-        >
-        param: <
+          }
+        }
+        param: {
           name: "value"
-          type: <
-            type_ref: <
-              ref: <
-                appname: <
+          type: {
+            type_ref: {
+              ref: {
+                appname: {
                   part: "Request"
-                >
+                }
                 path: "val"
-              >
-            >
-          >
-        >
-        stmt: <
-          action: <
+              }
+            }
+          }
+        }
+        stmt: {
+          action: {
             action: "..."
-          >
-        >
-        rest_params: <
+          }
+        }
+        rest_params: {
           method: POST
           path: "/first/{id}/second/third"
-          url_param: <
+          url_param: {
             name: "id"
-            type: <
+            type: {
               primitive: INT
-              source_context: <
+              source_context: {
                 file: "tests/test_rest_api.sysl"
-                start: <
+                start: {
                   line: 22
                   col: 9
-                >
-                end: <
+                }
+                end: {
                   line: 22
                   col: 17
-                >
-              >
-            >
-          >
-        >
-        source_context: <
+                }
+              }
+            }
+          }
+        }
+        source_context: {
           file: "tests/test_rest_api.sysl"
-          start: <
+          start: {
             line: 29
             col: 20
-          >
-          end: <
+          }
+          end: {
             line: 31
             col: 12
-          >
-        >
-      >
-    >
-    endpoints: <
+          }
+        }
+      }
+    }
+    endpoints: {
       key: "POST /foo/bar/baz"
-      value: <
+      value: {
         name: "POST /foo/bar/baz"
         docstring: "\"Create\" an item"
-        attrs: <
+        attrs: {
           key: "one"
-          value: <
+          value: {
             s: "1"
-          >
-        >
-        attrs: <
+          }
+        }
+        attrs: {
           key: "patterns"
-          value: <
-            a: <
-              elt: <
+          value: {
+            a: {
+              elt: {
                 s: "rest"
-              >
-            >
-          >
-        >
-        attrs: <
+              }
+            }
+          }
+        }
+        attrs: {
           key: "three"
-          value: <
+          value: {
             s: "3"
-          >
-        >
-        attrs: <
+          }
+        }
+        attrs: {
           key: "two"
-          value: <
+          value: {
             s: "2"
-          >
-        >
-        attrs: <
+          }
+        }
+        attrs: {
           key: "zero"
-          value: <
+          value: {
             s: "0"
-          >
-        >
-        stmt: <
-          action: <
+          }
+        }
+        stmt: {
+          action: {
             action: "..."
-          >
-        >
-        rest_params: <
+          }
+        }
+        rest_params: {
           method: POST
           path: "/foo/bar/baz"
-        >
-        source_context: <
+        }
+        source_context: {
           file: "tests/test_rest_api.sysl"
-          start: <
+          start: {
             line: 13
             col: 16
-          >
-          end: <
+          }
+          end: {
             line: 16
             col: 8
-          >
-        >
-      >
-    >
-    endpoints: <
+          }
+        }
+      }
+    }
+    endpoints: {
       key: "PUT /first/{id}/second"
-      value: <
+      value: {
         name: "PUT /first/{id}/second"
-        attrs: <
+        attrs: {
           key: "patterns"
-          value: <
-            a: <
-              elt: <
+          value: {
+            a: {
+              elt: {
                 s: "rest"
-              >
-              elt: <
+              }
+              elt: {
                 s: "deprecated"
-              >
-            >
-          >
-        >
-        attrs: <
+              }
+            }
+          }
+        }
+        attrs: {
           key: "uber"
-          value: <
+          value: {
             s: "value"
-          >
-        >
-        stmt: <
-          ret: <
+          }
+        }
+        stmt: {
+          ret: {
             payload: "200 ok"
-          >
-        >
-        rest_params: <
+          }
+        }
+        rest_params: {
           method: PUT
           path: "/first/{id}/second"
-          url_param: <
+          url_param: {
             name: "id"
-            type: <
+            type: {
               primitive: INT
-              source_context: <
+              source_context: {
                 file: "tests/test_rest_api.sysl"
-                start: <
+                start: {
                   line: 22
                   col: 9
-                >
-                end: <
+                }
+                end: {
                   line: 22
                   col: 17
-                >
-              >
-            >
-          >
-        >
-        source_context: <
+                }
+              }
+            }
+          }
+        }
+        source_context: {
           file: "tests/test_rest_api.sysl"
-          start: <
+          start: {
             line: 26
             col: 16
-          >
-          end: <
+          }
+          end: {
             line: 28
             col: 16
-          >
-        >
-      >
-    >
-    source_context: <
+          }
+        }
+      }
+    }
+    source_context: {
       file: "tests/test_rest_api.sysl"
-      start: <
+      start: {
         line: 1
         col: 1
-      >
-      end: <
+      }
+      end: {
         line: 1
         col: 19
-      >
-    >
-  >
->
+      }
+    }
+  }
+}

--- a/pkg/parse/tests/transform.sysl.golden.textpb
+++ b/pkg/parse/tests/transform.sysl.golden.textpb
@@ -1,781 +1,1672 @@
-apps: <
+apps: {
   key: "TransformApp"
-  value: <
-    name: <
+  value: {
+    name: {
       part: "TransformApp"
-    >
-    attrs: <
+    }
+    attrs: {
       key: "package"
-      value: <
+      value: {
         s: "io.sysl.demo.petshop.views"
-      >
-    >
-    types: <
+      }
+    }
+    types: {
       key: "AnonType_0__"
-      value: <
-        tuple: <
-          attr_defs: <
+      value: {
+        tuple: {
+          attr_defs: {
             key: "breed"
-            value: <
-              type_ref: <
-                context: <
-                  appname: <
+            value: {
+              type_ref: {
+                context: {
+                  appname: {
                     part: "TransformApp"
-                  >
+                  }
                   path: "AnonType_0__"
-                >
-                ref: <
-                  appname: <
+                }
+                ref: {
+                  appname: {
                     part: "PetShopModel"
-                  >
+                  }
                   path: "Breed"
-                >
-              >
-            >
-          >
-        >
-      >
-    >
-    types: <
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+    types: {
       key: "FooType"
-      value: <
-        tuple: <
-          attr_defs: <
+      value: {
+        tuple: {
+          attr_defs: {
             key: "amount"
-            value: <
+            value: {
               primitive: DECIMAL
-              constraint: <
-                length: <
+              constraint: {
+                length: {
                   max: 14
-                >
-              >
-              source_context: <
+                }
+              }
+              source_context: {
                 file: "tests/transform.sysl"
-                start: <
+                start: {
                   line: 59
                   col: 16
-                >
-                end: <
+                }
+                end: {
                   line: 59
                   col: 26
-                >
-              >
-            >
-          >
-          attr_defs: <
+                }
+              }
+            }
+          }
+          attr_defs: {
             key: "id"
-            value: <
+            value: {
               primitive: INT
-              source_context: <
+              source_context: {
                 file: "tests/transform.sysl"
-                start: <
+                start: {
                   line: 58
                   col: 12
-                >
-                end: <
+                }
+                end: {
                   line: 58
                   col: 12
-                >
-              >
-            >
-          >
-        >
-      >
-    >
-    views: <
+                }
+              }
+            }
+          }
+        }
+        source_context: {
+          file: "tests/transform.sysl"
+          start: {
+            line: 57
+            col: 2
+          }
+          end: {
+            line: 60
+          }
+        }
+      }
+    }
+    views: {
       key: "NoArgTransform"
-      value: <
-        param: <
+      value: {
+        param: {
           name: "number1"
-          type: <
+          type: {
             primitive: INT
-          >
-        >
-        param: <
+          }
+        }
+        param: {
           name: "foo"
-          type: <
-            type_ref: <
-              ref: <
-                appname: <
+          type: {
+            type_ref: {
+              ref: {
+                appname: {
                   part: "Some"
-                >
+                }
                 path: "Type"
-              >
-            >
-          >
-        >
-        ret_type: <
-          type_ref: <
-            ref: <
-              appname: <
+              }
+            }
+          }
+        }
+        ret_type: {
+          type_ref: {
+            ref: {
+              appname: {
                 part: "Model"
-              >
+              }
               path: "Type"
-            >
-          >
-        >
-        expr: <
-          transform: <
-            arg: <
+            }
+          }
+        }
+        expr: {
+          transform: {
+            arg: {
               name: "."
-            >
+              source_context: {
+                file: "tests/transform.sysl"
+                start: {
+                  line: 3
+                  col: 4
+                }
+                end: {
+                  line: 5
+                  col: 5
+                }
+              }
+            }
             scopevar: "scopeVar"
-            stmt: <
-              assign: <
+            stmt: {
+              assign: {
                 name: "out"
-                expr: <
-                  binexpr: <
+                expr: {
+                  binexpr: {
                     op: SUB
-                    lhs: <
-                      binexpr: <
+                    lhs: {
+                      binexpr: {
                         op: ADD
-                        lhs: <
+                        lhs: {
                           name: "number"
-                        >
-                        rhs: <
-                          literal: <
+                          source_context: {
+                            file: "tests/transform.sysl"
+                            start: {
+                              line: 4
+                              col: 12
+                            }
+                            end: {
+                              line: 4
+                              col: 12
+                            }
+                          }
+                        }
+                        rhs: {
+                          literal: {
                             i: 1
-                          >
-                        >
-                      >
-                    >
-                    rhs: <
+                          }
+                          type: {
+                            primitive: INT
+                          }
+                          source_context: {
+                            file: "tests/transform.sysl"
+                            start: {
+                              line: 4
+                              col: 21
+                            }
+                            end: {
+                              line: 4
+                              col: 21
+                            }
+                          }
+                        }
+                      }
+                      type: {
+                        primitive: INT
+                      }
+                      source_context: {
+                        file: "tests/transform.sysl"
+                        start: {
+                          line: 4
+                          col: 19
+                        }
+                        end: {
+                          line: 4
+                          col: 21
+                        }
+                      }
+                    }
+                    rhs: {
                       name: "scopeVar"
-                    >
-                  >
-                >
-              >
-            >
-          >
-        >
-        attrs: <
+                      source_context: {
+                        file: "tests/transform.sysl"
+                        start: {
+                          line: 4
+                          col: 25
+                        }
+                        end: {
+                          line: 4
+                          col: 25
+                        }
+                      }
+                    }
+                  }
+                  type: {
+                    no_type: {}
+                  }
+                  source_context: {
+                    file: "tests/transform.sysl"
+                    start: {
+                      line: 4
+                      col: 6
+                    }
+                    end: {
+                      line: 4
+                      col: 25
+                    }
+                    text: "out = number + 1 - scopeVar"
+                  }
+                }
+              }
+            }
+          }
+          source_context: {
+            file: "tests/transform.sysl"
+            start: {
+              line: 3
+              col: 4
+            }
+            end: {
+              line: 5
+              col: 5
+            }
+          }
+        }
+        attrs: {
           key: "patterns"
-          value: <
-            a: <
-              elt: <
+          value: {
+            a: {
+              elt: {
                 s: "partial"
-              >
-            >
-          >
-        >
-      >
-    >
-    views: <
+              }
+            }
+          }
+        }
+        source_context: {
+          file: "tests/transform.sysl"
+          start: {
+            line: 2
+            col: 2
+          }
+          end: {
+            line: 7
+            col: 2
+          }
+          text: "!view NoArgTransform(number1 <: int, foo <: Some.Type ) -> Model.Type [~partial]:"
+        }
+      }
+    }
+    views: {
       key: "WithArgTransform"
-      value: <
-        param: <
+      value: {
+        param: {
           name: "number"
-          type: <
+          type: {
             primitive: INT
-          >
-        >
-        ret_type: <
+          }
+        }
+        ret_type: {
           primitive: INT
-        >
-        expr: <
-          transform: <
-            arg: <
+        }
+        expr: {
+          transform: {
+            arg: {
               name: "argName"
-            >
+              source_context: {
+                file: "tests/transform.sysl"
+                start: {
+                  line: 8
+                  col: 4
+                }
+                end: {
+                  line: 8
+                  col: 4
+                }
+              }
+            }
             scopevar: "scopeVar"
-            stmt: <
-              assign: <
+            stmt: {
+              assign: {
                 name: "out"
-                expr: <
-                  binexpr: <
+                expr: {
+                  binexpr: {
                     op: SUB
-                    lhs: <
+                    lhs: {
                       name: "number"
-                    >
-                    rhs: <
-                      literal: <
+                      source_context: {
+                        file: "tests/transform.sysl"
+                        start: {
+                          line: 9
+                          col: 12
+                        }
+                        end: {
+                          line: 9
+                          col: 12
+                        }
+                      }
+                    }
+                    rhs: {
+                      literal: {
                         i: 1
-                      >
-                    >
-                  >
-                >
-              >
-            >
-          >
-        >
-        attrs: <
+                      }
+                      type: {
+                        primitive: INT
+                      }
+                      source_context: {
+                        file: "tests/transform.sysl"
+                        start: {
+                          line: 9
+                          col: 21
+                        }
+                        end: {
+                          line: 9
+                          col: 21
+                        }
+                      }
+                    }
+                  }
+                  type: {
+                    primitive: INT
+                  }
+                  source_context: {
+                    file: "tests/transform.sysl"
+                    start: {
+                      line: 9
+                      col: 6
+                    }
+                    end: {
+                      line: 9
+                      col: 21
+                    }
+                    text: "out = number - 1"
+                  }
+                }
+              }
+            }
+          }
+          source_context: {
+            file: "tests/transform.sysl"
+            start: {
+              line: 8
+              col: 4
+            }
+            end: {
+              line: 10
+              col: 5
+            }
+          }
+        }
+        attrs: {
           key: "abc"
-          value: <
+          value: {
             s: "foo"
-          >
-        >
-      >
-    >
-    views: <
+          }
+        }
+        source_context: {
+          file: "tests/transform.sysl"
+          start: {
+            line: 7
+            col: 2
+          }
+          end: {
+            line: 12
+            col: 2
+          }
+          text: "!view WithArgTransform(number <: int ) -> int [abc=\"foo\"]:"
+        }
+      }
+    }
+    views: {
       key: "nestedTransformWithAnonymousType"
-      value: <
-        param: <
+      value: {
+        param: {
           name: "number"
-          type: <
+          type: {
             primitive: INT
-          >
-        >
-        ret_type: <
-          type_ref: <
-            ref: <
-              appname: <
+          }
+        }
+        ret_type: {
+          type_ref: {
+            ref: {
+              appname: {
                 part: "Some1"
-              >
+              }
               path: "Type"
-            >
-          >
-        >
-        expr: <
-          transform: <
-            arg: <
+            }
+          }
+        }
+        expr: {
+          transform: {
+            arg: {
               name: "argName"
-            >
+              source_context: {
+                file: "tests/transform.sysl"
+                start: {
+                  line: 48
+                  col: 4
+                }
+                end: {
+                  line: 48
+                  col: 4
+                }
+              }
+            }
             scopevar: "."
-            stmt: <
-              let: <
+            stmt: {
+              let: {
                 name: "_breedsAndPets"
-                expr: <
-                  transform: <
-                    arg: <
-                      get_attr: <
-                        arg: <
+                expr: {
+                  transform: {
+                    arg: {
+                      get_attr: {
+                        arg: {
                           name: "."
-                        >
+                          source_context: {
+                            file: "tests/transform.sysl"
+                            start: {
+                              line: 49
+                              col: 27
+                            }
+                            end: {
+                              line: 49
+                              col: 28
+                            }
+                          }
+                        }
                         attr: "breeds"
-                      >
-                    >
+                      }
+                      source_context: {
+                        file: "tests/transform.sysl"
+                        start: {
+                          line: 49
+                          col: 27
+                        }
+                        end: {
+                          line: 49
+                          col: 28
+                        }
+                      }
+                    }
                     scopevar: "."
-                    stmt: <
-                      let: <
+                    stmt: {
+                      let: {
                         name: "breedId"
-                        expr: <
-                          call: <
+                        expr: {
+                          call: {
                             func: "autoinc"
-                          >
-                        >
-                      >
-                    >
-                    stmt: <
-                      assign: <
+                          }
+                          source_context: {
+                            file: "tests/transform.sysl"
+                            start: {
+                              line: 50
+                              col: 8
+                            }
+                            end: {
+                              line: 50
+                              col: 30
+                            }
+                            text: "let breedId = autoinc()"
+                          }
+                        }
+                      }
+                    }
+                    stmt: {
+                      assign: {
                         name: "breed"
-                        expr: <
-                          transform: <
-                            arg: <
+                        expr: {
+                          transform: {
+                            arg: {
                               name: "."
-                            >
+                              source_context: {
+                                file: "tests/transform.sysl"
+                                start: {
+                                  line: 51
+                                  col: 16
+                                }
+                                end: {
+                                  line: 53
+                                  col: 9
+                                }
+                              }
+                            }
                             scopevar: "."
-                            stmt: <
-                              assign: <
+                            stmt: {
+                              assign: {
                                 name: "breedName"
-                                expr: <
-                                  get_attr: <
-                                    arg: <
+                                expr: {
+                                  get_attr: {
+                                    arg: {
                                       name: "."
-                                    >
+                                      source_context: {
+                                        file: "tests/transform.sysl"
+                                        start: {
+                                          line: 52
+                                          col: 24
+                                        }
+                                        end: {
+                                          line: 52
+                                          col: 25
+                                        }
+                                      }
+                                    }
                                     attr: "name"
-                                  >
-                                >
-                              >
-                            >
-                          >
-                          type: <
-                            type_ref: <
-                              context: <
-                                appname: <
+                                  }
+                                  source_context: {
+                                    file: "tests/transform.sysl"
+                                    start: {
+                                      line: 52
+                                      col: 12
+                                    }
+                                    end: {
+                                      line: 52
+                                      col: 25
+                                    }
+                                    text: "breedName = .name"
+                                  }
+                                }
+                              }
+                            }
+                          }
+                          type: {
+                            type_ref: {
+                              context: {
+                                appname: {
                                   part: "TransformApp"
-                                >
-                              >
-                              ref: <
-                                appname: <
+                                }
+                              }
+                              ref: {
+                                appname: {
                                   part: "PetShopModel"
-                                >
+                                }
                                 path: "Breed"
-                              >
-                            >
-                          >
-                        >
-                      >
-                    >
-                  >
-                  type: <
-                    set: <
-                      type_ref: <
-                        context: <
-                          appname: <
+                              }
+                            }
+                          }
+                          source_context: {
+                            file: "tests/transform.sysl"
+                            start: {
+                              line: 51
+                              col: 8
+                            }
+                            end: {
+                              line: 53
+                              col: 9
+                            }
+                            text: "breed = -> <PetShopModel.Breed>(:\n            breedName = .name\n        )\n"
+                          }
+                        }
+                      }
+                    }
+                  }
+                  type: {
+                    set: {
+                      type_ref: {
+                        context: {
+                          appname: {
                             part: "TransformApp"
-                          >
-                        >
-                        ref: <
-                          appname: <
+                          }
+                        }
+                        ref: {
+                          appname: {
                             part: "TransformApp"
-                          >
+                          }
                           path: "AnonType_0__"
-                        >
-                      >
-                    >
-                  >
-                >
-              >
-            >
-          >
-          type: <
-            type_ref: <
-              context: <
-                appname: <
+                        }
+                      }
+                    }
+                  }
+                  source_context: {
+                    file: "tests/transform.sysl"
+                    start: {
+                      line: 49
+                      col: 6
+                    }
+                    end: {
+                      line: 54
+                      col: 7
+                    }
+                    text: "let _breedsAndPets = .breeds -> <set of>(:\n        let breedId = autoinc()\n        breed = -> <PetShopModel.Breed>(:\n            breedName = .name\n        )\n      )\n"
+                  }
+                }
+              }
+            }
+          }
+          type: {
+            type_ref: {
+              context: {
+                appname: {
                   part: "TransformApp"
-                >
-              >
-              ref: <
-                appname: <
+                }
+              }
+              ref: {
+                appname: {
                   part: "Some"
-                >
+                }
                 path: "Type"
-              >
-            >
-          >
-        >
-      >
-    >
-    views: <
+              }
+            }
+          }
+          source_context: {
+            file: "tests/transform.sysl"
+            start: {
+              line: 48
+              col: 4
+            }
+            end: {
+              line: 55
+              col: 5
+            }
+          }
+        }
+        source_context: {
+          file: "tests/transform.sysl"
+          start: {
+            line: 47
+            col: 2
+          }
+          end: {
+            line: 57
+            col: 2
+          }
+          text: "!view nestedTransformWithAnonymousType(number <: int ) -> Some1.Type:"
+        }
+      }
+    }
+    views: {
       key: "noReturnType"
-      value: <
-        param: <
+      value: {
+        param: {
           name: "number"
-          type: <
+          type: {
             primitive: INT
-          >
-        >
-        ret_type: <
-          type_ref: <
-            context: <
-              appname: <
+          }
+        }
+        ret_type: {
+          type_ref: {
+            context: {
+              appname: {
                 part: "TransformApp"
-              >
-            >
-            ref: <
-              appname: <
+              }
+            }
+            ref: {
+              appname: {
                 part: "Some"
-              >
+              }
               path: "Type"
-            >
-          >
-        >
-        expr: <
-          transform: <
-            arg: <
+            }
+          }
+        }
+        expr: {
+          transform: {
+            arg: {
               name: "argName"
-            >
+              source_context: {
+                file: "tests/transform.sysl"
+                start: {
+                  line: 43
+                  col: 4
+                }
+                end: {
+                  line: 43
+                  col: 4
+                }
+              }
+            }
             scopevar: "."
-            stmt: <
-              assign: <
+            stmt: {
+              assign: {
                 name: "out"
-                expr: <
-                  binexpr: <
+                expr: {
+                  binexpr: {
                     op: ADD
-                    lhs: <
+                    lhs: {
                       name: "number"
-                    >
-                    rhs: <
-                      literal: <
+                      source_context: {
+                        file: "tests/transform.sysl"
+                        start: {
+                          line: 44
+                          col: 12
+                        }
+                        end: {
+                          line: 44
+                          col: 12
+                        }
+                      }
+                    }
+                    rhs: {
+                      literal: {
                         s: "foo"
-                      >
-                    >
-                  >
-                >
-              >
-            >
-          >
-          type: <
-            type_ref: <
-              context: <
-                appname: <
+                      }
+                      type: {
+                        primitive: STRING
+                      }
+                      source_context: {
+                        file: "tests/transform.sysl"
+                        start: {
+                          line: 44
+                          col: 21
+                        }
+                        end: {
+                          line: 44
+                          col: 21
+                        }
+                      }
+                    }
+                  }
+                  type: {
+                    primitive: STRING
+                  }
+                  source_context: {
+                    file: "tests/transform.sysl"
+                    start: {
+                      line: 44
+                      col: 6
+                    }
+                    end: {
+                      line: 44
+                      col: 21
+                    }
+                    text: "out = number + \"foo\""
+                  }
+                }
+              }
+            }
+          }
+          type: {
+            type_ref: {
+              context: {
+                appname: {
                   part: "TransformApp"
-                >
-              >
-              ref: <
-                appname: <
+                }
+              }
+              ref: {
+                appname: {
                   part: "Some"
-                >
+                }
                 path: "Type"
-              >
-            >
-          >
-        >
-      >
-    >
-    views: <
+              }
+            }
+          }
+          source_context: {
+            file: "tests/transform.sysl"
+            start: {
+              line: 43
+              col: 4
+            }
+            end: {
+              line: 45
+              col: 5
+            }
+          }
+        }
+        source_context: {
+          file: "tests/transform.sysl"
+          start: {
+            line: 42
+            col: 2
+          }
+          end: {
+            line: 47
+            col: 2
+          }
+          text: "!view noReturnType(number <: int ):"
+        }
+      }
+    }
+    views: {
       key: "noScopeVar"
-      value: <
-        param: <
+      value: {
+        param: {
           name: "number"
-          type: <
+          type: {
             primitive: INT
-          >
-        >
-        ret_type: <
+          }
+        }
+        ret_type: {
           primitive: INT
-        >
-        expr: <
-          transform: <
-            arg: <
+        }
+        expr: {
+          transform: {
+            arg: {
               name: "argName"
-            >
+              source_context: {
+                file: "tests/transform.sysl"
+                start: {
+                  line: 13
+                  col: 4
+                }
+                end: {
+                  line: 13
+                  col: 4
+                }
+              }
+            }
             scopevar: "."
-            stmt: <
-              assign: <
+            stmt: {
+              assign: {
                 name: "out"
-                expr: <
-                  binexpr: <
+                expr: {
+                  binexpr: {
                     op: ADD
-                    lhs: <
-                      binexpr: <
+                    lhs: {
+                      binexpr: {
                         op: MUL
-                        lhs: <
+                        lhs: {
                           name: "number"
-                        >
-                        rhs: <
-                          literal: <
+                          source_context: {
+                            file: "tests/transform.sysl"
+                            start: {
+                              line: 14
+                              col: 12
+                            }
+                            end: {
+                              line: 14
+                              col: 12
+                            }
+                          }
+                        }
+                        rhs: {
+                          literal: {
                             decimal: "1.5"
-                          >
-                        >
-                      >
-                    >
-                    rhs: <
-                      literal: <
+                          }
+                          type: {
+                            primitive: DECIMAL
+                          }
+                          source_context: {
+                            file: "tests/transform.sysl"
+                            start: {
+                              line: 14
+                              col: 21
+                            }
+                            end: {
+                              line: 14
+                              col: 21
+                            }
+                          }
+                        }
+                      }
+                      type: {
+                        primitive: DECIMAL
+                      }
+                      source_context: {
+                        file: "tests/transform.sysl"
+                        start: {
+                          line: 14
+                          col: 19
+                        }
+                        end: {
+                          line: 14
+                          col: 21
+                        }
+                      }
+                    }
+                    rhs: {
+                      literal: {
                         i: 2
-                      >
-                    >
-                  >
-                >
-              >
-            >
-          >
-        >
-      >
-    >
-    views: <
+                      }
+                      type: {
+                        primitive: INT
+                      }
+                      source_context: {
+                        file: "tests/transform.sysl"
+                        start: {
+                          line: 14
+                          col: 27
+                        }
+                        end: {
+                          line: 14
+                          col: 27
+                        }
+                      }
+                    }
+                  }
+                  type: {
+                    primitive: INT
+                  }
+                  source_context: {
+                    file: "tests/transform.sysl"
+                    start: {
+                      line: 14
+                      col: 6
+                    }
+                    end: {
+                      line: 14
+                      col: 27
+                    }
+                    text: "out = number * 1.5 + 2"
+                  }
+                }
+              }
+            }
+          }
+          source_context: {
+            file: "tests/transform.sysl"
+            start: {
+              line: 13
+              col: 4
+            }
+            end: {
+              line: 15
+              col: 5
+            }
+          }
+        }
+        source_context: {
+          file: "tests/transform.sysl"
+          start: {
+            line: 12
+            col: 2
+          }
+          end: {
+            line: 17
+            col: 2
+          }
+          text: "!view noScopeVar(number <: int ) -> int:"
+        }
+      }
+    }
+    views: {
       key: "withAnonymousSetOfReturnType"
-      value: <
-        param: <
+      value: {
+        param: {
           name: "number"
-          type: <
+          type: {
             primitive: INT
-          >
-        >
-        ret_type: <
+          }
+        }
+        ret_type: {
           primitive: INT
-        >
-        expr: <
-          transform: <
-            arg: <
+        }
+        expr: {
+          transform: {
+            arg: {
               name: "argName"
-            >
+              source_context: {
+                file: "tests/transform.sysl"
+                start: {
+                  line: 18
+                  col: 3
+                }
+                end: {
+                  line: 18
+                  col: 3
+                }
+              }
+            }
             scopevar: "."
-            stmt: <
-              assign: <
+            stmt: {
+              assign: {
                 name: "out"
-                expr: <
-                  binexpr: <
+                expr: {
+                  binexpr: {
                     op: POW
-                    lhs: <
+                    lhs: {
                       name: "number"
-                    >
-                    rhs: <
-                      binexpr: <
+                      source_context: {
+                        file: "tests/transform.sysl"
+                        start: {
+                          line: 19
+                          col: 11
+                        }
+                        end: {
+                          line: 19
+                          col: 11
+                        }
+                      }
+                    }
+                    rhs: {
+                      binexpr: {
                         op: POW
-                        lhs: <
-                          literal: <
+                        lhs: {
+                          literal: {
                             i: 2
-                          >
-                        >
-                        rhs: <
-                          literal: <
+                          }
+                          type: {
+                            primitive: INT
+                          }
+                          source_context: {
+                            file: "tests/transform.sysl"
+                            start: {
+                              line: 19
+                              col: 21
+                            }
+                            end: {
+                              line: 19
+                              col: 21
+                            }
+                          }
+                        }
+                        rhs: {
+                          literal: {
                             i: 3
-                          >
-                        >
-                      >
-                    >
-                  >
-                >
-              >
-            >
-          >
-        >
-      >
-    >
-    views: <
+                          }
+                          type: {
+                            primitive: INT
+                          }
+                          source_context: {
+                            file: "tests/transform.sysl"
+                            start: {
+                              line: 19
+                              col: 26
+                            }
+                            end: {
+                              line: 19
+                              col: 26
+                            }
+                          }
+                        }
+                      }
+                      type: {
+                        primitive: INT
+                      }
+                      source_context: {
+                        file: "tests/transform.sysl"
+                        start: {
+                          line: 19
+                          col: 21
+                        }
+                        end: {
+                          line: 19
+                          col: 26
+                        }
+                      }
+                    }
+                  }
+                  type: {
+                    primitive: INT
+                  }
+                  source_context: {
+                    file: "tests/transform.sysl"
+                    start: {
+                      line: 19
+                      col: 5
+                    }
+                    end: {
+                      line: 19
+                      col: 26
+                    }
+                    text: "out = number ** 2 ** 3"
+                  }
+                }
+              }
+            }
+          }
+          source_context: {
+            file: "tests/transform.sysl"
+            start: {
+              line: 18
+              col: 3
+            }
+            end: {
+              line: 20
+              col: 4
+            }
+          }
+        }
+        source_context: {
+          file: "tests/transform.sysl"
+          start: {
+            line: 17
+            col: 2
+          }
+          end: {
+            line: 22
+            col: 2
+          }
+          text: "!view withAnonymousSetOfReturnType(number <: int ) -> int:"
+        }
+      }
+    }
+    views: {
       key: "withSetOfReturnType"
-      value: <
-        param: <
+      value: {
+        param: {
           name: "number"
-          type: <
+          type: {
             primitive: INT
-          >
-        >
-        ret_type: <
-          set: <
-            type_ref: <
-              ref: <
-                appname: <
+          }
+        }
+        ret_type: {
+          set: {
+            type_ref: {
+              ref: {
+                appname: {
                   part: "Some1"
-                >
+                }
                 path: "Type"
-              >
-            >
-          >
-        >
-        expr: <
-          transform: <
-            arg: <
+              }
+            }
+          }
+        }
+        expr: {
+          transform: {
+            arg: {
               name: "argName"
-            >
+              source_context: {
+                file: "tests/transform.sysl"
+                start: {
+                  line: 23
+                  col: 4
+                }
+                end: {
+                  line: 23
+                  col: 4
+                }
+              }
+            }
             scopevar: "."
-            stmt: <
-              assign: <
+            stmt: {
+              assign: {
                 name: "out"
-                expr: <
-                  binexpr: <
+                expr: {
+                  binexpr: {
                     op: DIV
-                    lhs: <
+                    lhs: {
                       name: "number"
-                    >
-                    rhs: <
+                      source_context: {
+                        file: "tests/transform.sysl"
+                        start: {
+                          line: 24
+                          col: 12
+                        }
+                        end: {
+                          line: 24
+                          col: 12
+                        }
+                      }
+                    }
+                    rhs: {
                       name: "number"
-                    >
-                  >
-                >
-              >
-            >
-          >
-          type: <
-            set: <
-              type_ref: <
-                context: <
-                  appname: <
+                      source_context: {
+                        file: "tests/transform.sysl"
+                        start: {
+                          line: 24
+                          col: 21
+                        }
+                        end: {
+                          line: 24
+                          col: 21
+                        }
+                      }
+                    }
+                  }
+                  type: {
+                    no_type: {}
+                  }
+                  source_context: {
+                    file: "tests/transform.sysl"
+                    start: {
+                      line: 24
+                      col: 6
+                    }
+                    end: {
+                      line: 24
+                      col: 21
+                    }
+                    text: "out = number / number"
+                  }
+                }
+              }
+            }
+          }
+          type: {
+            set: {
+              type_ref: {
+                context: {
+                  appname: {
                     part: "TransformApp"
-                  >
-                >
-                ref: <
-                  appname: <
+                  }
+                }
+                ref: {
+                  appname: {
                     part: "Some"
-                  >
+                  }
                   path: "Type"
-                >
-              >
-            >
-          >
-        >
-      >
-    >
-    views: <
+                }
+              }
+            }
+          }
+          source_context: {
+            file: "tests/transform.sysl"
+            start: {
+              line: 23
+              col: 4
+            }
+            end: {
+              line: 25
+              col: 5
+            }
+          }
+        }
+        source_context: {
+          file: "tests/transform.sysl"
+          start: {
+            line: 22
+            col: 2
+          }
+          end: {
+            line: 27
+            col: 2
+          }
+          text: "!view withSetOfReturnType(number <: int ) -> set of Some1.Type:"
+        }
+      }
+    }
+    views: {
       key: "withSomeReturnType"
-      value: <
-        param: <
+      value: {
+        param: {
           name: "number"
-          type: <
+          type: {
             primitive: INT
-          >
-        >
-        ret_type: <
-          type_ref: <
-            ref: <
-              appname: <
+          }
+        }
+        ret_type: {
+          type_ref: {
+            ref: {
+              appname: {
                 part: "Some1"
-              >
+              }
               path: "Type"
-            >
-          >
-        >
-        expr: <
-          transform: <
-            arg: <
+            }
+          }
+        }
+        expr: {
+          transform: {
+            arg: {
               name: "argName"
-            >
+              source_context: {
+                file: "tests/transform.sysl"
+                start: {
+                  line: 28
+                  col: 4
+                }
+                end: {
+                  line: 28
+                  col: 4
+                }
+              }
+            }
             scopevar: "."
-            stmt: <
-              assign: <
+            stmt: {
+              assign: {
                 name: "out"
-                expr: <
-                  binexpr: <
+                expr: {
+                  binexpr: {
                     op: ADD
-                    lhs: <
+                    lhs: {
                       name: "number"
-                    >
-                    rhs: <
-                      literal: <
+                      source_context: {
+                        file: "tests/transform.sysl"
+                        start: {
+                          line: 29
+                          col: 12
+                        }
+                        end: {
+                          line: 29
+                          col: 12
+                        }
+                      }
+                    }
+                    rhs: {
+                      literal: {
                         s: "foo"
-                      >
-                    >
-                  >
-                >
-              >
-            >
-          >
-          type: <
-            type_ref: <
-              context: <
-                appname: <
+                      }
+                      type: {
+                        primitive: STRING
+                      }
+                      source_context: {
+                        file: "tests/transform.sysl"
+                        start: {
+                          line: 29
+                          col: 21
+                        }
+                        end: {
+                          line: 29
+                          col: 21
+                        }
+                      }
+                    }
+                  }
+                  type: {
+                    primitive: STRING
+                  }
+                  source_context: {
+                    file: "tests/transform.sysl"
+                    start: {
+                      line: 29
+                      col: 6
+                    }
+                    end: {
+                      line: 29
+                      col: 21
+                    }
+                    text: "out = number + \"foo\""
+                  }
+                }
+              }
+            }
+          }
+          type: {
+            type_ref: {
+              context: {
+                appname: {
                   part: "TransformApp"
-                >
-              >
-              ref: <
-                appname: <
+                }
+              }
+              ref: {
+                appname: {
                   part: "Some"
-                >
+                }
                 path: "Type"
-              >
-            >
-          >
-        >
-      >
-    >
-    views: <
+              }
+            }
+          }
+          source_context: {
+            file: "tests/transform.sysl"
+            start: {
+              line: 28
+              col: 4
+            }
+            end: {
+              line: 30
+              col: 5
+            }
+          }
+        }
+        source_context: {
+          file: "tests/transform.sysl"
+          start: {
+            line: 27
+            col: 2
+          }
+          end: {
+            line: 32
+            col: 2
+          }
+          text: "!view withSomeReturnType(number <: int ) -> Some1.Type:"
+        }
+      }
+    }
+    views: {
       key: "withSomeReturnType2"
-      value: <
-        param: <
+      value: {
+        param: {
           name: "number"
-          type: <
-            type_ref: <
-              ref: <
-                appname: <
+          type: {
+            type_ref: {
+              ref: {
+                appname: {
                   part: "Sometype"
-                >
-              >
-            >
-          >
-        >
-        ret_type: <
-          set: <
-            type_ref: <
-              ref: <
-                appname: <
+                }
+              }
+            }
+          }
+        }
+        ret_type: {
+          set: {
+            type_ref: {
+              ref: {
+                appname: {
                   part: "Sometype"
-                >
-              >
-            >
-          >
-        >
-        expr: <
-          transform: <
-            arg: <
+                }
+              }
+            }
+          }
+        }
+        expr: {
+          transform: {
+            arg: {
               name: "argName"
-            >
+              source_context: {
+                file: "tests/transform.sysl"
+                start: {
+                  line: 33
+                  col: 4
+                }
+                end: {
+                  line: 33
+                  col: 4
+                }
+              }
+            }
             scopevar: "."
-            stmt: <
-              assign: <
+            stmt: {
+              assign: {
                 name: "out"
-                expr: <
-                  binexpr: <
+                expr: {
+                  binexpr: {
                     op: ADD
-                    lhs: <
+                    lhs: {
                       name: "number"
-                    >
-                    rhs: <
-                      literal: <
+                      source_context: {
+                        file: "tests/transform.sysl"
+                        start: {
+                          line: 34
+                          col: 12
+                        }
+                        end: {
+                          line: 34
+                          col: 12
+                        }
+                      }
+                    }
+                    rhs: {
+                      literal: {
                         s: "foo"
-                      >
-                    >
-                  >
-                >
-              >
-            >
-          >
-          type: <
-            type_ref: <
-              context: <
-                appname: <
+                      }
+                      type: {
+                        primitive: STRING
+                      }
+                      source_context: {
+                        file: "tests/transform.sysl"
+                        start: {
+                          line: 34
+                          col: 21
+                        }
+                        end: {
+                          line: 34
+                          col: 21
+                        }
+                      }
+                    }
+                  }
+                  type: {
+                    primitive: STRING
+                  }
+                  source_context: {
+                    file: "tests/transform.sysl"
+                    start: {
+                      line: 34
+                      col: 6
+                    }
+                    end: {
+                      line: 34
+                      col: 21
+                    }
+                    text: "out = number + \"foo\""
+                  }
+                }
+              }
+            }
+          }
+          type: {
+            type_ref: {
+              context: {
+                appname: {
                   part: "TransformApp"
-                >
-              >
-              ref: <
-                appname: <
+                }
+              }
+              ref: {
+                appname: {
                   part: "Sometype"
-                >
-              >
-            >
-          >
-        >
-      >
-    >
-    views: <
+                }
+              }
+            }
+          }
+          source_context: {
+            file: "tests/transform.sysl"
+            start: {
+              line: 33
+              col: 4
+            }
+            end: {
+              line: 35
+              col: 5
+            }
+          }
+        }
+        source_context: {
+          file: "tests/transform.sysl"
+          start: {
+            line: 32
+            col: 2
+          }
+          end: {
+            line: 37
+            col: 2
+          }
+          text: "!view withSomeReturnType2(number <: Sometype ) -> set of Sometype:"
+        }
+      }
+    }
+    views: {
       key: "withSomeReturnType3"
-      value: <
-        param: <
+      value: {
+        param: {
           name: "foo"
-          type: <
-            set: <
-              type_ref: <
-                ref: <
-                  appname: <
+          type: {
+            set: {
+              type_ref: {
+                ref: {
+                  appname: {
                     part: "Model"
-                  >
+                  }
                   path: "SomeType"
-                >
-              >
-            >
-          >
-        >
-        ret_type: <
-          set: <
-            type_ref: <
-              context: <
-                appname: <
+                }
+              }
+            }
+          }
+        }
+        ret_type: {
+          set: {
+            type_ref: {
+              context: {
+                appname: {
                   part: "TransformApp"
-                >
-              >
-              ref: <
-                appname: <
+                }
+              }
+              ref: {
+                appname: {
                   part: "Some"
-                >
+                }
                 path: "Type"
-              >
-            >
-          >
-        >
-        expr: <
-          transform: <
-            arg: <
+              }
+            }
+          }
+        }
+        expr: {
+          transform: {
+            arg: {
               name: "argName"
-            >
+              source_context: {
+                file: "tests/transform.sysl"
+                start: {
+                  line: 38
+                  col: 4
+                }
+                end: {
+                  line: 38
+                  col: 4
+                }
+              }
+            }
             scopevar: "."
-            stmt: <
-              assign: <
+            stmt: {
+              assign: {
                 name: "out"
-                expr: <
-                  binexpr: <
+                expr: {
+                  binexpr: {
                     op: ADD
-                    lhs: <
+                    lhs: {
                       name: "number"
-                    >
-                    rhs: <
-                      literal: <
+                      source_context: {
+                        file: "tests/transform.sysl"
+                        start: {
+                          line: 39
+                          col: 12
+                        }
+                        end: {
+                          line: 39
+                          col: 12
+                        }
+                      }
+                    }
+                    rhs: {
+                      literal: {
                         s: "foo"
-                      >
-                    >
-                  >
-                >
-              >
-            >
-          >
-          type: <
-            set: <
-              type_ref: <
-                context: <
-                  appname: <
+                      }
+                      type: {
+                        primitive: STRING
+                      }
+                      source_context: {
+                        file: "tests/transform.sysl"
+                        start: {
+                          line: 39
+                          col: 21
+                        }
+                        end: {
+                          line: 39
+                          col: 21
+                        }
+                      }
+                    }
+                  }
+                  type: {
+                    primitive: STRING
+                  }
+                  source_context: {
+                    file: "tests/transform.sysl"
+                    start: {
+                      line: 39
+                      col: 6
+                    }
+                    end: {
+                      line: 39
+                      col: 21
+                    }
+                    text: "out = number + \"foo\""
+                  }
+                }
+              }
+            }
+          }
+          type: {
+            set: {
+              type_ref: {
+                context: {
+                  appname: {
                     part: "TransformApp"
-                  >
-                >
-                ref: <
-                  appname: <
+                  }
+                }
+                ref: {
+                  appname: {
                     part: "Some"
-                  >
+                  }
                   path: "Type"
-                >
-              >
-            >
-          >
-        >
-      >
-    >
-  >
->
+                }
+              }
+            }
+          }
+          source_context: {
+            file: "tests/transform.sysl"
+            start: {
+              line: 38
+              col: 4
+            }
+            end: {
+              line: 40
+              col: 5
+            }
+          }
+        }
+        source_context: {
+          file: "tests/transform.sysl"
+          start: {
+            line: 37
+            col: 2
+          }
+          end: {
+            line: 42
+            col: 2
+          }
+          text: "!view withSomeReturnType3(foo <: set of Model.SomeType ):"
+        }
+      }
+    }
+    source_context: {
+      file: "tests/transform.sysl"
+      start: {
+        line: 1
+        col: 1
+      }
+      end: {
+        line: 1
+        col: 49
+      }
+    }
+  }
+}

--- a/pkg/parse/tests/union.sysl.golden.textpb
+++ b/pkg/parse/tests/union.sysl.golden.textpb
@@ -1,69 +1,122 @@
-apps: <
+apps: {
   key: "Test"
-  value: <
-    name: <
+  value: {
+    name: {
       part: "Test"
-    >
-    types: <
+    }
+    types: {
       key: "A"
-      value: <
-      >
-    >
-    types: <
+      value: {
+        source_context: {
+          file: "tests/union.sysl"
+          start: {
+            line: 2
+            col: 4
+          }
+          end: {
+            line: 2
+            col: 13
+          }
+        }
+      }
+    }
+    types: {
       key: "B"
-      value: <
-      >
-    >
-    types: <
+      value: {
+        source_context: {
+          file: "tests/union.sysl"
+          start: {
+            line: 3
+            col: 4
+          }
+          end: {
+            line: 3
+            col: 13
+          }
+        }
+      }
+    }
+    types: {
       key: "C"
-      value: <
-      >
-    >
-    types: <
+      value: {
+        source_context: {
+          file: "tests/union.sysl"
+          start: {
+            line: 4
+            col: 4
+          }
+          end: {
+            line: 4
+            col: 13
+          }
+        }
+      }
+    }
+    types: {
       key: "U"
-      value: <
-        one_of: <
-          type: <
-            type_ref: <
-              context: <
-                appname: <
+      value: {
+        one_of: {
+          type: {
+            type_ref: {
+              context: {
+                appname: {
                   part: "Test"
-                >
+                }
                 path: "U"
-              >
-              ref: <
+              }
+              ref: {
                 path: "A"
-              >
-            >
-          >
-          type: <
-            type_ref: <
-              context: <
-                appname: <
+              }
+            }
+          }
+          type: {
+            type_ref: {
+              context: {
+                appname: {
                   part: "Test"
-                >
+                }
                 path: "U"
-              >
-              ref: <
+              }
+              ref: {
                 path: "B"
-              >
-            >
-          >
-          type: <
-            type_ref: <
-              context: <
-                appname: <
+              }
+            }
+          }
+          type: {
+            type_ref: {
+              context: {
+                appname: {
                   part: "Test"
-                >
+                }
                 path: "U"
-              >
-              ref: <
+              }
+              ref: {
                 path: "C"
-              >
-            >
-          >
-        >
-      >
-    >
-  >
->
+              }
+            }
+          }
+        }
+        source_context: {
+          file: "tests/union.sysl"
+          start: {
+            line: 6
+            col: 4
+          }
+          end: {
+            line: 10
+          }
+        }
+      }
+    }
+    source_context: {
+      file: "tests/union.sysl"
+      start: {
+        line: 1
+        col: 1
+      }
+      end: {
+        line: 1
+      }
+    }
+  }
+}

--- a/pkg/parse/tests/until_loop.sysl.golden.textpb
+++ b/pkg/parse/tests/until_loop.sysl.golden.textpb
@@ -1,20 +1,20 @@
-apps {
+apps: {
   key: "Client"
-  value {
-    name {
+  value: {
+    name: {
       part: "Client"
     }
-    endpoints {
+    endpoints: {
       key: "On Click"
-      value {
+      value: {
         name: "On Click"
-        stmt {
-          loop {
+        stmt: {
+          loop: {
             mode: UNTIL
             criterion: "have requests"
-            stmt {
-              call {
-                target {
+            stmt: {
+              call: {
+                target: {
                   part: "Server"
                 }
                 endpoint: "Process Payload"
@@ -22,20 +22,61 @@ apps {
             }
           }
         }
+        source_context: {
+          file: "tests/until_loop.sysl"
+          start: {
+            line: 5
+            col: 4
+          }
+          end: {
+            line: 9
+          }
+        }
+      }
+    }
+    source_context: {
+      file: "tests/until_loop.sysl"
+      start: {
+        line: 4
+        col: 1
+      }
+      end: {
+        line: 4
       }
     }
   }
 }
-apps {
+apps: {
   key: "Server"
-  value {
-    name {
+  value: {
+    name: {
       part: "Server"
     }
-    endpoints {
+    endpoints: {
       key: "Process Payload"
-      value {
+      value: {
         name: "Process Payload"
+        source_context: {
+          file: "tests/until_loop.sysl"
+          start: {
+            line: 2
+            col: 4
+          }
+          end: {
+            line: 2
+            col: 21
+          }
+        }
+      }
+    }
+    source_context: {
+      file: "tests/until_loop.sysl"
+      start: {
+        line: 1
+        col: 1
+      }
+      end: {
+        line: 1
       }
     }
   }

--- a/pkg/parse/tests/with_spaces.sysl.golden.textpb
+++ b/pkg/parse/tests/with_spaces.sysl.golden.textpb
@@ -1,208 +1,272 @@
-apps: <
+apps: {
   key: "AnotherApp"
-  value: <
-    name: <
+  value: {
+    name: {
       part: "AnotherApp"
-    >
-    types: <
+    }
+    types: {
       key: "SecondTable"
-      value: <
-        tuple: <
-          attr_defs: <
+      value: {
+        tuple: {
+          attr_defs: {
             key: "Id"
-            value: <
-              type_ref: <
-                context: <
-                  appname: <
+            value: {
+              type_ref: {
+                context: {
+                  appname: {
                     part: "AnotherApp"
-                  >
+                  }
                   path: "SecondTable"
-                >
-                ref: <
-                  appname: <
+                }
+                ref: {
+                  appname: {
                     part: "App with"
-                  >
+                  }
                   path: "space"
                   path: "Id"
-                >
-              >
-              source_context: <
+                }
+              }
+              source_context: {
                 file: "tests/with_spaces.sysl"
-                start: <
+                start: {
                   line: 11
                   col: 14
-                >
-                end: <
+                }
+                end: {
                   line: 11
                   col: 32
-                >
-              >
-            >
-          >
-          attr_defs: <
+                }
+              }
+            }
+          }
+          attr_defs: {
             key: "Id2"
-            value: <
-              type_ref: <
-                context: <
-                  appname: <
+            value: {
+              type_ref: {
+                context: {
+                  appname: {
                     part: "AnotherApp"
-                  >
+                  }
                   path: "SecondTable"
-                >
-                ref: <
-                  appname: <
+                }
+                ref: {
+                  appname: {
                     part: "App with"
-                  >
+                  }
                   path: "space"
                   path: "Id"
-                >
-              >
-              source_context: <
+                }
+              }
+              source_context: {
                 file: "tests/with_spaces.sysl"
-                start: <
+                start: {
                   line: 12
                   col: 15
-                >
-                end: <
+                }
+                end: {
                   line: 12
                   col: 35
-                >
-              >
-            >
-          >
-          attr_defs: <
+                }
+              }
+            }
+          }
+          attr_defs: {
             key: "Id3"
-            value: <
-              type_ref: <
-                context: <
-                  appname: <
+            value: {
+              type_ref: {
+                context: {
+                  appname: {
                     part: "AnotherApp"
-                  >
+                  }
                   path: "SecondTable"
-                >
-                ref: <
-                  appname: <
+                }
+                ref: {
+                  appname: {
                     part: "My"
                     part: "App with"
-                  >
+                  }
                   path: "space"
                   path: "Id"
-                >
-              >
-              source_context: <
+                }
+              }
+              source_context: {
                 file: "tests/with_spaces.sysl"
-                start: <
+                start: {
                   line: 13
                   col: 15
-                >
-                end: <
+                }
+                end: {
                   line: 13
                   col: 41
-                >
-              >
-            >
-          >
-          attr_defs: <
+                }
+              }
+            }
+          }
+          attr_defs: {
             key: "Id4"
-            value: <
-              type_ref: <
-                context: <
-                  appname: <
+            value: {
+              type_ref: {
+                context: {
+                  appname: {
                     part: "AnotherApp"
-                  >
+                  }
                   path: "SecondTable"
-                >
-                ref: <
-                  appname: <
+                }
+                ref: {
+                  appname: {
                     part: "My"
                     part: "App with"
-                  >
+                  }
                   path: "space"
                   path: "Id"
-                >
-              >
-              source_context: <
+                }
+              }
+              source_context: {
                 file: "tests/with_spaces.sysl"
-                start: <
+                start: {
                   line: 14
                   col: 15
-                >
-                end: <
+                }
+                end: {
                   line: 14
                   col: 44
-                >
-              >
-            >
-          >
-        >
-      >
-    >
-  >
->
-apps: <
+                }
+              }
+            }
+          }
+        }
+        source_context: {
+          file: "tests/with_spaces.sysl"
+          start: {
+            line: 10
+            col: 4
+          }
+          end: {
+            line: 15
+          }
+        }
+      }
+    }
+    source_context: {
+      file: "tests/with_spaces.sysl"
+      start: {
+        line: 9
+        col: 1
+      }
+      end: {
+        line: 9
+      }
+    }
+  }
+}
+apps: {
   key: "App with :: space"
-  value: <
-    name: <
+  value: {
+    name: {
       part: "App with"
       part: "space"
-    >
-    types: <
+    }
+    types: {
       key: "SomeTable"
-      value: <
-        tuple: <
-          attr_defs: <
+      value: {
+        tuple: {
+          attr_defs: {
             key: "Id"
-            value: <
+            value: {
               primitive: INT
-              source_context: <
+              source_context: {
                 file: "tests/with_spaces.sysl"
-                start: <
+                start: {
                   line: 3
                   col: 14
-                >
-                end: <
+                }
+                end: {
                   line: 3
                   col: 14
-                >
-              >
-            >
-          >
-        >
-      >
-    >
-  >
->
-apps: <
+                }
+              }
+            }
+          }
+        }
+        source_context: {
+          file: "tests/with_spaces.sysl"
+          start: {
+            line: 2
+            col: 4
+          }
+          end: {
+            line: 5
+            col: 2
+          }
+        }
+      }
+    }
+    source_context: {
+      file: "tests/with_spaces.sysl"
+      start: {
+        line: 1
+        col: 1
+      }
+      end: {
+        line: 1
+        col: 12
+      }
+    }
+  }
+}
+apps: {
   key: "My ::  App with :: space"
-  value: <
-    name: <
+  value: {
+    name: {
       part: "My"
       part: "App with"
       part: "space"
-    >
-    types: <
+    }
+    types: {
       key: "SomeTable"
-      value: <
-        tuple: <
-          attr_defs: <
+      value: {
+        tuple: {
+          attr_defs: {
             key: "Id"
-            value: <
+            value: {
               primitive: INT
-              source_context: <
+              source_context: {
                 file: "tests/with_spaces.sysl"
-                start: <
+                start: {
                   line: 7
                   col: 14
-                >
-                end: <
+                }
+                end: {
                   line: 7
                   col: 14
-                >
-              >
-            >
-          >
-        >
-      >
-    >
-  >
->
+                }
+              }
+            }
+          }
+        }
+        source_context: {
+          file: "tests/with_spaces.sysl"
+          start: {
+            line: 6
+            col: 4
+          }
+          end: {
+            line: 9
+            col: 10
+          }
+        }
+      }
+    }
+    source_context: {
+      file: "tests/with_spaces.sysl"
+      start: {
+        line: 5
+        col: 1
+      }
+      end: {
+        line: 5
+        col: 19
+      }
+    }
+  }
+}


### PR DESCRIPTION
Previously, the following docstring attribute would be parsed as:

```
    !type LongDescriptionNoExtraLines:
        @description =:
            | # This is a formatted description
            | Something
            | Something else
        field <: string
```

`"# This is a formatted description Something Something else"`

Which breaks the formatting of markdown content, as markdown is newline sensitive.

Fixes # .

Changes proposed in this pull request:
- 
- 

Checklist:
- [ ] Added related tests
- [ ] Made corresponding changes to the documentation
