### PR TITLE
allows alias in plantuml tuple data structure

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.13
 replace github.com/spf13/afero => github.com/anz-bank/afero v1.2.3
 
 require (
-	aqwari.net/xml v0.0.0-20200323224746-73105c9af915
+	aqwari.net/xml v0.0.0-20200619145941-6c62842e69c1
 	github.com/alecthomas/assert v0.0.0-20170929043011-405dbfeb8e38
 	github.com/alecthomas/chroma v0.7.3
 	github.com/alecthomas/colour v0.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-aqwari.net/xml v0.0.0-20200323224746-73105c9af915 h1:XE0WxBil+QakNGN1kP3jzCNGPQ2hKvPIXxwB6wkKN1c=
-aqwari.net/xml v0.0.0-20200323224746-73105c9af915/go.mod h1:NIqcJ5inc6DJNSGCVEYGd3vohE6xF4fhUKHSl5bItVE=
+aqwari.net/xml v0.0.0-20200619145941-6c62842e69c1 h1:MRcR/WbipbMIH7HY4ARtkZn79QV0N2lS5smQeVfGTsI=
+aqwari.net/xml v0.0.0-20200619145941-6c62842e69c1/go.mod h1:NIqcJ5inc6DJNSGCVEYGd3vohE6xF4fhUKHSl5bItVE=
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=

--- a/pkg/datamodeldiagram/datamodelview.go
+++ b/pkg/datamodeldiagram/datamodelview.go
@@ -44,6 +44,7 @@ type EntityViewParam struct {
 	EntityColor  string
 	EntityHeader string
 	EntityName   string
+	EntityAlias  string
 	IgnoredTypes map[string]struct{}
 	Types        map[string]*sysl.Type
 }
@@ -182,9 +183,23 @@ func (v *DataModelView) DrawTuple(
 	entity *sysl.Type_Tuple,
 	relationshipMap map[string]map[string]RelationshipParam,
 ) {
+	var alias, typeName string
+	if viewParam.EntityAlias == "" {
+		alias = viewParam.EntityName
+	} else {
+		alias = viewParam.EntityAlias
+		// add space for better formatting and allow empty space when alias == ""
+		typeName = " "+viewParam.EntityName
+	}
 	encEntity := v.UniqueVarForAppName(strings.Split(viewParam.EntityName, ".")...)
-	v.StringBuilder.WriteString(fmt.Sprintf("%s \"%s\" as %s %s(%s,%s)%s {\n", classString, viewParam.EntityName,
-		encEntity, entityLessThanArrow, viewParam.EntityHeader, viewParam.EntityColor, entityGreaterThanArrow))
+	v.StringBuilder.WriteString(
+		fmt.Sprintf(
+			"%s \"%s\" as %s %s(%s,%s)%s%s {\n",
+			classString, alias,
+			encEntity, entityLessThanArrow, viewParam.EntityHeader,
+			viewParam.EntityColor, typeName, entityGreaterThanArrow,
+		),
+	)
 	var appName string
 	var relation string
 	var collectionString string

--- a/pkg/datamodeldiagram/datamodelview.go
+++ b/pkg/datamodeldiagram/datamodelview.go
@@ -189,9 +189,14 @@ func (v *DataModelView) DrawTuple(
 	} else {
 		alias = viewParam.EntityAlias
 		// add space for better formatting and allow empty space when alias == ""
-		typeName = " "+viewParam.EntityName
+		typeName = " " + viewParam.EntityName
 	}
 	encEntity := v.UniqueVarForAppName(strings.Split(viewParam.EntityName, ".")...)
+
+	// this will create a class header, with alias it will look like the following:
+	// class "AliasName" as _0 << (D,orchid) TypeName >> {
+	// Without the alias:
+	// class "TypeName" as _0 << (D,orchid) >> {
 	v.StringBuilder.WriteString(
 		fmt.Sprintf(
 			"%s \"%s\" as %s %s(%s,%s)%s%s {\n",

--- a/pkg/datamodeldiagram/datamodelview_test.go
+++ b/pkg/datamodeldiagram/datamodelview_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/anz-bank/sysl/pkg/sysl"
+	"github.com/anz-bank/sysl/pkg/syslwrapper"
 	"github.com/stretchr/testify/mock"
 
 	"github.com/stretchr/testify/assert"
@@ -56,6 +57,9 @@ func TestDrawPrimitive(t *testing.T) {
 
 func TestDrawTuple(t *testing.T) {
 	t.Parallel()
+	tuple := syslwrapper.MakeTuple(
+		map[string]*sysl.Type{"attr1": syslwrapper.MakePrimitive("string")},
+	).Type.(*sysl.Type_Tuple_).Tuple
 	assertDraw(t,
 		`class "aliasName" as _0 << (D,orchid) typeName >> {
 + attr1 : string
@@ -70,14 +74,7 @@ func TestDrawTuple(t *testing.T) {
 					EntityName:   "typeName",
 					EntityAlias:  "aliasName",
 				},
-				&sysl.Type_Tuple{
-					AttrDefs: map[string]*sysl.Type{
-						"attr1": {
-							Type: &sysl.Type_Primitive_{Primitive: sysl.Type_STRING},
-						},
-					},
-				},
-				relationshipMap,
+				tuple, relationshipMap,
 			)
 		},
 	)
@@ -96,16 +93,8 @@ func TestDrawTuple(t *testing.T) {
 					EntityName:   "typeName",
 					EntityAlias:  "",
 				},
-				&sysl.Type_Tuple{
-					AttrDefs: map[string]*sysl.Type{
-						"attr1": {
-							Type: &sysl.Type_Primitive_{Primitive: sysl.Type_STRING},
-						},
-					},
-				},
-				relationshipMap,
+				tuple, relationshipMap,
 			)
 		},
 	)
 }
-

--- a/pkg/datamodeldiagram/datamodelview_test.go
+++ b/pkg/datamodeldiagram/datamodelview_test.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/anz-bank/sysl/pkg/sysl"
 	"github.com/stretchr/testify/mock"
 
 	"github.com/stretchr/testify/assert"
@@ -18,22 +19,93 @@ func (mock *ClassLabelerMock) LabelClass(className string) string {
 	return args.String(0)
 }
 
-func TestDrawPrimitive(t *testing.T) {
+func assertDraw(t *testing.T,
+	expected, className string,
+	drawFunc func(*DataModelView, map[string]map[string]RelationshipParam)) {
 	clMock := new(ClassLabelerMock)
-	clMock.On("LabelClass", "uuid").Return("test")
+	clMock.On("LabelClass", className).Return("test")
 
 	var stringBuilder strings.Builder
 	v := MakeDataModelView(clMock, nil, &stringBuilder, "title", "project")
-	viewParam := EntityViewParam{
-		EntityColor:  "orchid",
-		EntityHeader: "D",
-		EntityName:   "uuid",
-	}
 	relationshipMap := map[string]map[string]RelationshipParam{}
-	v.DrawPrimitive(viewParam, "INT", relationshipMap)
+	drawFunc(v, relationshipMap)
 	actual := v.StringBuilder.String()
 
-	expected := "class \"uuid\" as _0 << (D,orchid) int >> {\n" + "}\n"
 	assert.EqualValues(t, expected, actual, nil)
 	clMock.AssertExpectations(t)
 }
+
+func TestDrawPrimitive(t *testing.T) {
+	t.Parallel()
+	assertDraw(t,
+		"class \"uuid\" as _0 << (D,orchid) int >> {\n}\n",
+		"uuid",
+		func(v *DataModelView, relationshipMap map[string]map[string]RelationshipParam) {
+			v.DrawPrimitive(
+				EntityViewParam{
+					EntityColor:  "orchid",
+					EntityHeader: "D",
+					EntityName:   "uuid",
+				},
+				"INT",
+				relationshipMap,
+			)
+		},
+	)
+}
+
+func TestDrawTuple(t *testing.T) {
+	t.Parallel()
+	assertDraw(t,
+		`class "aliasName" as _0 << (D,orchid) typeName >> {
++ attr1 : string
+}
+`,
+		"typeName",
+		func(v *DataModelView, relationshipMap map[string]map[string]RelationshipParam) {
+			v.DrawTuple(
+				EntityViewParam{
+					EntityColor:  "orchid",
+					EntityHeader: "D",
+					EntityName:   "typeName",
+					EntityAlias:  "aliasName",
+				},
+				&sysl.Type_Tuple{
+					AttrDefs: map[string]*sysl.Type{
+						"attr1": {
+							Type: &sysl.Type_Primitive_{Primitive: sysl.Type_STRING},
+						},
+					},
+				},
+				relationshipMap,
+			)
+		},
+	)
+
+	assertDraw(t,
+		`class "typeName" as _0 << (D,orchid) >> {
++ attr1 : string
+}
+`,
+		"typeName",
+		func(v *DataModelView, relationshipMap map[string]map[string]RelationshipParam) {
+			v.DrawTuple(
+				EntityViewParam{
+					EntityColor:  "orchid",
+					EntityHeader: "D",
+					EntityName:   "typeName",
+					EntityAlias:  "",
+				},
+				&sysl.Type_Tuple{
+					AttrDefs: map[string]*sysl.Type{
+						"attr1": {
+							Type: &sysl.Type_Primitive_{Primitive: sysl.Type_STRING},
+						},
+					},
+				},
+				relationshipMap,
+			)
+		},
+	)
+}
+


### PR DESCRIPTION
Fixes # .

Changes proposed in this pull request:
- Allows plantuml alias in tuple data structure

Before:
![image](https://user-images.githubusercontent.com/25704935/86419835-df82a500-bd17-11ea-88a0-f347029e492f.png)

After:
![image](https://user-images.githubusercontent.com/25704935/86419817-d0035c00-bd17-11ea-83ba-cf3ea88817d5.png)

Checklist:
- [x] Added related tests
- [ ] Made corresponding changes to the documentation
