### PR TITLE
fixes attribute scope issues in type

### DIFF
--- a/pkg/parse/Parser_test.go
+++ b/pkg/parse/Parser_test.go
@@ -589,6 +589,12 @@ func TestOpenAPI3(t *testing.T) {
 	testParseAgainstGoldenWithSourceContext(t, "tests/openapi3.sysl")
 }
 
+func TestAttrScope(t *testing.T) {
+	t.Parallel()
+
+	testParseAgainstGoldenWithSourceContext(t, "tests/attr_scope.sysl")
+}
+
 func TestUndefinedRootAbsoluteImport(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/parse/listener_impl.go
+++ b/pkg/parse/listener_impl.go
@@ -765,7 +765,10 @@ func (s *TreeShapeListener) applyAnnotations(
 			if f.Attrs == nil {
 				f.Attrs = map[string]*sysl.Attribute{}
 			}
-			f.Attrs[varname] = attr
+			// if varname is already in lower scope, it shouldn't replace the value
+			if _, exists := f.Attrs[varname]; !exists {
+				f.Attrs[varname] = attr
+			}
 		}
 	}
 }

--- a/pkg/parse/tests/attr_scope.sysl
+++ b/pkg/parse/tests/attr_scope.sysl
@@ -1,0 +1,7 @@
+App:
+    !type scope:
+        @scope1 = "scope1"
+        x <: string:
+            @scope1 = "scope2"
+        y <: string:
+            @scope2 = "scope2"

--- a/pkg/parse/tests/attr_scope.sysl.golden.textpb
+++ b/pkg/parse/tests/attr_scope.sysl.golden.textpb
@@ -1,0 +1,92 @@
+apps: {
+  key: "App"
+  value: {
+    name: {
+      part: "App"
+    }
+    types: {
+      key: "scope"
+      value: {
+        tuple: {
+          attr_defs: {
+            key: "x"
+            value: {
+              primitive: STRING
+              attrs: {
+                key: "scope1"
+                value: {
+                  s: "scope2"
+                }
+              }
+              source_context: {
+                file: "tests/attr_scope.sysl"
+                start: {
+                  line: 5
+                  col: 13
+                }
+                end: {
+                  line: 6
+                  col: 8
+                }
+              }
+            }
+          }
+          attr_defs: {
+            key: "y"
+            value: {
+              primitive: STRING
+              attrs: {
+                key: "scope1"
+                value: {
+                  s: "scope1"
+                }
+              }
+              attrs: {
+                key: "scope2"
+                value: {
+                  s: "scope2"
+                }
+              }
+              source_context: {
+                file: "tests/attr_scope.sysl"
+                start: {
+                  line: 7
+                  col: 13
+                }
+                end: {
+                  line: 8
+                }
+              }
+            }
+          }
+        }
+        attrs: {
+          key: "scope1"
+          value: {
+            s: "scope1"
+          }
+        }
+        source_context: {
+          file: "tests/attr_scope.sysl"
+          start: {
+            line: 3
+            col: 4
+          }
+          end: {
+            line: 8
+          }
+        }
+      }
+    }
+    source_context: {
+      file: "tests/attr_scope.sysl"
+      start: {
+        line: 1
+        col: 1
+      }
+      end: {
+        line: 1
+      }
+    }
+  }
+}


### PR DESCRIPTION
Initially attributes in the higher scope replaces attributes that are in lower scope.
This shouldn't happen.

For example:
```sysl
App:
    !type attr:
        @a = 1
        i <: string:
            @a = 2
```
The resulted sysl module would replace the `a` attribute under the
field `i` with the value 1 which is higher in the scope.

This commit ensures that if attr values in lower scopes can not
be replaced by values in the higher scope.

Checklist:
- [x] Added related tests
- [ ] Made corresponding changes to the documentation
