### PR TITLE
handles tuple diagram gen with sequence of primitives fields

### DIFF
--- a/pkg/datamodeldiagram/datamodelview.go
+++ b/pkg/datamodeldiagram/datamodelview.go
@@ -308,6 +308,8 @@ func (v *DataModelView) DrawTuple(
 						Count:        1,
 					}
 				}
+			} else {
+				v.StringBuilder.WriteString(collectionString)
 			}
 		} else {
 			v.StringBuilder.WriteString(fmt.Sprintf("+ %s : %s\n", attrName, strings.ToLower(attrType.GetPrimitive().String())))

--- a/pkg/datamodeldiagram/datamodelview_test.go
+++ b/pkg/datamodeldiagram/datamodelview_test.go
@@ -97,4 +97,32 @@ func TestDrawTuple(t *testing.T) {
 			)
 		},
 	)
+
+	assertDraw(t,
+		`class "typeName" as _0 << (D,orchid) >> {
++ attr1 : **Sequence <string>**
++ attr2 : **Set <int>**
++ attr3 : **List <bool>**
+}
+`,
+		"typeName",
+		func(v *DataModelView, relationshipMap map[string]map[string]RelationshipParam) {
+			v.DrawTuple(
+				EntityViewParam{
+					EntityColor:  "orchid",
+					EntityHeader: "D",
+					EntityName:   "typeName",
+					EntityAlias:  "",
+				},
+				syslwrapper.MakeTuple(
+					map[string]*sysl.Type{
+						"attr1": syslwrapper.MakeSequence(syslwrapper.MakePrimitive("string")),
+						"attr2": syslwrapper.MakeSet(syslwrapper.MakePrimitive("int")),
+						"attr3": syslwrapper.MakeList(syslwrapper.MakePrimitive("bool")),
+					},
+				).Type.(*sysl.Type_Tuple_).Tuple,
+				relationshipMap,
+			)
+		},
+	)
 }

--- a/pkg/syslwrapper/test_helper.go
+++ b/pkg/syslwrapper/test_helper.go
@@ -209,6 +209,14 @@ func MakeSet(setType *sysl.Type) *sysl.Type {
 	}
 }
 
+func MakeSequence(seqType *sysl.Type) *sysl.Type {
+	return &sysl.Type{
+		Type: &sysl.Type_Sequence{
+			Sequence: seqType,
+		},
+	}
+}
+
 func MakeNoType() *sysl.Type {
 	return &sysl.Type{
 		Type: &sysl.Type_NoType_{


### PR DESCRIPTION
Initially, tuple type whose fields are sequence of primitives generate the wrong plantuml diagram. This PR fixes that.

For example:
```sysl
App:
    !type VeryComplex:
        complex <: sequence of string
```

|Before|After|
|--|--|
|![image](https://user-images.githubusercontent.com/25704935/87104189-7b715b00-c29a-11ea-8c42-be64ade7502d.png)|![image](https://user-images.githubusercontent.com/25704935/87104168-698fb800-c29a-11ea-9e09-1e21157befd4.png)|

Checklist:
- [x] Added related tests
- [ ] Made corresponding changes to the documentation
