### PR TITLE
Escape typeprefix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ lint: ## Run golangci-lint
 	golangci-lint run ./...
 
 golden: ## Updates golden test files in pkg/parse. TODO: Extend to work for all golden files
-	go test ./pkg/parse ./pkg/exporter -update
+	go test ./pkg/parse ./pkg/exporter ./pkg/importer -update
 
 coverage: ## Run tests and verify the test coverage remains high
 	./scripts/test-with-coverage.sh 80

--- a/pkg/importer/importer_test.go
+++ b/pkg/importer/importer_test.go
@@ -1,8 +1,10 @@
 package importer
 
 import (
+	"flag"
 	"fmt"
 	"io/ioutil"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -12,6 +14,15 @@ import (
 
 	"github.com/stretchr/testify/require"
 )
+
+var (
+	update = flag.Bool("update", false, "Update golden test files")
+)
+
+func TestMain(m *testing.M) {
+	flag.Parse()
+	os.Exit(m.Run())
+}
 
 type testConfig struct {
 	name          string
@@ -33,19 +44,26 @@ func runImportEqualityTests(t *testing.T, cfg testConfig) {
 			filename := strings.TrimSuffix(f.Name(), ext)
 			t.Run(fmt.Sprintf("%s-%s", cfg.name, filename), func(t *testing.T) {
 				t.Parallel()
+				syslFile := filepath.Join(cfg.testDir, filename+".sysl")
 				fileToImport := syslutil.MustAbsolute(t, filepath.Join(cfg.testDir, filename+cfg.testExtension))
 				input, err := ioutil.ReadFile(fileToImport)
 				require.NoError(t, err)
-				syslFile := filepath.Join(cfg.testDir, filename+".sysl")
-				expected, err := ioutil.ReadFile(syslFile)
-				require.NoError(t, err)
-				expected = syslutil.HandleCRLF(expected)
 				absFilePath, err := filepath.Abs(filepath.Join(cfg.testDir, filename+cfg.testExtension))
 				require.NoError(t, err)
 				imp, err := Factory(absFilePath, input, logger)
 				require.NoError(t, err)
 				imp.WithAppName("testapp").WithPackage("package_foo")
 				result, err := imp.Load(string(input))
+				require.NoError(t, err)
+				if *update {
+					err = ioutil.WriteFile(syslFile, []byte(result), 0644)
+					if err != nil {
+						t.Error(err)
+					}
+				}
+				expected, err := ioutil.ReadFile(syslFile)
+				require.NoError(t, err)
+				expected = syslutil.HandleCRLF(expected)
 				require.NoError(t, err)
 				require.Equal(t, string(expected), result)
 			})

--- a/pkg/importer/openapi.go
+++ b/pkg/importer/openapi.go
@@ -388,7 +388,7 @@ func (o *openapiv3) buildEndpoint(path string, item *openapi3.PathItem) []Method
 				ep.Params.Add(param)
 			}
 		}
-		typePrefix := convertToSyslSafe(cleanEndpointPath(path)) + "_"
+		typePrefix := getSyslSafeName(convertToSyslSafe(cleanEndpointPath(path))) + "_"
 		for statusCode, resp := range op.Responses {
 			text := "error"
 			if statusCode[0] == '2' {

--- a/pkg/importer/tests-openapi/simple_with_special_char_endpoint.sysl
+++ b/pkg/importer/tests-openapi/simple_with_special_char_endpoint.sysl
@@ -28,8 +28,20 @@ testapp "Simple" [package="package_foo"]:
             | No description.
             return ok <: SimpleObj
 
+    /withHeaders%3AandSpecialChars:
+        GET:
+            | No description.
+            return error <: _withHeaders%3AandSpecialChars_error
+            return ok <: SimpleObj
+
     #---------------------------------------------------------------------------
     # definitions
+
+    !type Error:
+        code <: int?:
+            @json_tag = "code"
+        description <: string?:
+            @json_tag = "description"
 
     !type SimpleObj:
         name <: string?:
@@ -38,3 +50,9 @@ testapp "Simple" [package="package_foo"]:
     !type SimpleObj2:
         name <: SimpleObj?:
             @json_tag = "name"
+
+    !type _withHeaders%3AandSpecialChars_error:
+        Error <: Error [mediatype="application/json"]:
+            @json_tag = "Error"
+        content-type <: string [~header]:
+            @json_tag = "content-type"

--- a/pkg/importer/tests-openapi/simple_with_special_char_endpoint.yaml
+++ b/pkg/importer/tests-openapi/simple_with_special_char_endpoint.yaml
@@ -38,6 +38,24 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/SimpleObj"
+  /withHeaders:andSpecialChars:
+    get:
+      responses:
+        200:
+          description: "200 OK"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SimpleObj"
+        404:
+          description: "Not Found"
+          headers:
+            content-type:
+              type: string
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
 components:
   schemas:
     SimpleObj:
@@ -50,3 +68,10 @@ components:
       properties:
         name:
           type: SimpleObj
+    Error:
+      type: object
+      properties:
+        description:
+          type: string
+        code:
+          type: int


### PR DESCRIPTION
Fixes the escaping of special chars which was previously causing syntax errors.

e.g the following OpenAPI input would produce invalid Sysl due to special characters not being escaped
```
 /withHeaders:andSpecialChars:
    get:
      responses:
        200:
          description: "200 OK"
          content:
            application/json:
              schema:
                $ref: "#/components/schemas/SimpleObj"
        404:
          description: "Not Found"
          headers:
            content-type:
              type: string
          content:
            application/json:
              schema:
                $ref: "#/components/schemas/Error"
```

Changes proposed in this pull request:
- Add escaping of special characters in the OpenAPI3 importer, when responses have a header field defined
- Add updating of importer test files to `make golden` target

Checklist:
- [x] Added related tests
- [x] Made corresponding changes to the documentation
