### PR TITLE
Remove type warning from sysl wrapper

### DIFF
--- a/pkg/syslwrapper/app.go
+++ b/pkg/syslwrapper/app.go
@@ -480,8 +480,6 @@ func (am *AppMapper) MapType(t *sysl.Type) *Type {
 				primaryKey = pk.GetAttrName()[0]
 			}
 		}
-	default:
-		fmt.Printf("Type not defined %s", t.Type)
 	}
 
 	return &Type{


### PR DESCRIPTION
Removes a warning print statement that was causing excessive noise during mermaid diagram generation
