### PR TITLE
Escape spaces when printing app names

### DIFF
--- a/pkg/mermaid/integrationdiagram/integrationdiagram.go
+++ b/pkg/mermaid/integrationdiagram/integrationdiagram.go
@@ -91,7 +91,7 @@ func generateMultipleAppIntegrationDiagramHelper(m *sysl.Module, appNames []stri
 }
 
 func printClassStatement(className string) string {
-	return fmt.Sprintf("    %s\n", className)
+	return fmt.Sprintf("    %s\n", cleanAppName(className))
 }
 
 //printIntegrationDiagramStatements is where the printing takes place

--- a/pkg/mermaid/integrationdiagram/integrationdiagram_test.go
+++ b/pkg/mermaid/integrationdiagram/integrationdiagram_test.go
@@ -134,3 +134,9 @@ func TestGenerateMermaidIntegrationDiagraMultipleAppsDependantAppsCallInConditio
 	assert.True(t, strings.Contains(r, "Visa"))
 	assert.True(t, strings.Contains(r, `PaymentServer["PaymentServer"] --> Visa["Visa"]`))
 }
+
+func TestPrintClassStatementWithSpaces(t *testing.T) {
+	r := printClassStatement("my application")
+	expected := "    my_application\n"
+	assert.Equal(t, expected, r)
+}


### PR DESCRIPTION
Fix a minor bug with application names not being escaped correctly

Checklist:
- [x] Added related tests
- [x] Made corresponding changes to the documentation
