### PR TITLE
Read blueprint from stdin in blueprint_make

### DIFF
--- a/pkg/arrai/blueprint_make.arrai
+++ b/pkg/arrai/blueprint_make.arrai
@@ -1,7 +1,6 @@
 # Generates a Makefile to execute the tests of downstream repos.
 
-# let blueprint = //eval.value(//os.stdin); 
-let blueprint = //{./blueprint.arrai};
+let blueprint = //eval.value(//os.stdin);
 
 # The local directory for blueprint operation.
 let blueprintDir = '.blueprint';


### PR DESCRIPTION
Relative imports don't work when running remotely.