### PR TITLE
More robust GOPATH use in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,8 @@
 
 include VersionReport.mk
 
-GOVERSION=$(shell go version | cut -d' ' -f3-4)
+GOPATH    = $(shell go env GOPATH)
+GOVERSION = $(shell go version | cut -d' ' -f3-4)
 BIN_DIR := $(GOPATH)/bin
 
 ifneq ("$(shell which gotestsum)", "")


### PR DESCRIPTION
* Please attach **WIP** tag when this PR is still work in progress.
* Please attach **breaking-change** tag if this PR potentially causes other components to fail or changes previous sysl executable's behaviour.

Changes proposed in this pull request:
- Auto-detect GOPATH in Makefile using `go env GOPATH`.
- 

Checklist:
- [ ] Added related tests
- [ ] Made corresponding changes to the documentation
