### PR TITLE
Fixes lint flagging existent endpoints as non-existent

### DIFF
--- a/pkg/parse/Parser_test.go
+++ b/pkg/parse/Parser_test.go
@@ -631,6 +631,11 @@ func TestDuplicateImportWarning(t *testing.T) {
 	}
 }
 
+func TestLintValid(t *testing.T) {
+	assertLintLogs(t,
+		"tests/lint_valid.sysl", "")
+}
+
 func TestCaseSensitiveRedefinition(t *testing.T) {
 	assertLintLogs(t,
 		"tests/case_sensitive_redefinition.sysl",
@@ -710,7 +715,11 @@ func assertLintLogs(t *testing.T, file, logMsg string) {
 	_, err := NewParser().Parse(file, syslutil.NewChrootFs(afero.NewOsFs(), ""))
 	require.NoError(t, err)
 	logrus.SetOutput(os.Stderr)
-	assert.Contains(t, buf.String(), fmt.Sprintf("level=warning msg=\"%s\"", logMsg))
+	if logMsg == "" {
+		assert.Equal(t, "", buf.String())
+	} else {
+		assert.Contains(t, buf.String(), fmt.Sprintf("level=warning msg=\"%s\"", logMsg))
+	}
 }
 
 func TestInferExprTypeNonTransform(t *testing.T) {

--- a/pkg/parse/linter.go
+++ b/pkg/parse/linter.go
@@ -185,13 +185,14 @@ func (s *TreeShapeListener) lintEndpoint() {
 			if app, exists := (*apps)[appName]; exists {
 				if endpoints, exists := (*app.rec)[endpoint]; exists {
 					// if method is empty string, it is linting simple endpoint, not REST endpoint
-					if method != "" {
-						if _, exists = (*endpoints.rec)[method]; exists {
-							continue
-						}
-						logrus.Warnf("lint %s: Method '%s' does not exist for call '%s'", location, method, call)
+					if method == "" {
 						continue
 					}
+					if _, exists = (*endpoints.rec)[method]; exists {
+						continue
+					}
+					logrus.Warnf("lint %s: Method '%s' does not exist for call '%s'", location, method, call)
+					continue
 				}
 				logrus.Warnf("lint %s: Endpoint '%s' does not exist for call '%s'", location, endpoint, call)
 				continue

--- a/pkg/parse/tests/lint_valid.sysl
+++ b/pkg/parse/tests/lint_valid.sysl
@@ -1,0 +1,25 @@
+AppOne:
+    EndpointOne:
+        AppOne <- EndpointOne
+        AppTwo <- EndpointTwo
+        RestAppOne <- GET /endpoint-one
+        RestAppTwo <- GET /endpoint-two
+        return ok <: string
+
+AppTwo:
+    EndpointTwo:
+        ...
+
+RestAppOne:
+    /endpoint-one:
+        GET:
+            AppOne <- EndpointOne
+            AppTwo <- EndpointTwo
+            RestAppOne <- GET /endpoint-one
+            RestAppTwo <- GET /endpoint-two
+            return ok <: string
+
+RestAppTwo:
+    /endpoint-two:
+        GET:
+            ...


### PR DESCRIPTION
Currently, applications that reference a simple, non-rest, endpoint
are flagged as being non-existent:

```
App:
  Endpoint:
    App <- Endpoint  # linted as non-existent
```

This change fixes the above to avoid incorrectly linting the endpoint
as non-existent.

Fixes #1019