### PR TITLE
Corrected sysl endpoint param type path 

### DIFF
--- a/pkg/parse/listener_impl.go
+++ b/pkg/parse/listener_impl.go
@@ -1373,24 +1373,13 @@ func (s *TreeShapeListener) ExitParams(*parser.ParamsContext) {
 		case *sysl.Type_Set:
 			t.Set.GetTypeRef().Context = nil
 			t.Set.SourceContext = nil
-			ref := t.Set.GetTypeRef().GetRef()
-			if ref.Appname == nil {
-				ref.Appname = &sysl.AppName{
-					Part: ref.Path,
-				}
-				ref.Path = nil
-			}
 		case *sysl.Type_TypeRef:
 			t.TypeRef.Context = nil
 			ref := t.TypeRef.GetRef()
-			if ref.Appname == nil {
-				ref.Appname = &sysl.AppName{
-					Part: ref.Path,
+			if ref.Appname != nil && ref.Appname.Part != nil {
+				for i := range ref.Appname.Part {
+					ref.Appname.Part[i] = strings.TrimSpace(ref.Appname.Part[i])
 				}
-				ref.Path = nil
-			}
-			for i := range ref.Appname.Part {
-				ref.Appname.Part[i] = strings.TrimSpace(ref.Appname.Part[i])
 			}
 		case nil:
 			type1.Type = &sysl.Type_NoType_{
@@ -1944,23 +1933,6 @@ func (s *TreeShapeListener) ExitSubscribe(ctx *parser.SubscribeContext) {
 		s.popScope()
 	}
 	s.endpointName = ""
-}
-
-// ExitView_type_spec is called when production view_type_spec is exited.
-func (s *TreeShapeListener) ExitView_type_spec(*parser.View_type_specContext) {
-	type1 := s.typemap[s.fieldname[len(s.fieldname)-1]]
-	if type1.GetSet() != nil {
-		type1 = type1.GetSet()
-	}
-	if type1.GetTypeRef() != nil {
-		tr := type1.GetTypeRef()
-		if tr.Ref.Appname == nil && len(tr.Ref.Path) == 1 {
-			tr.Ref.Appname = &sysl.AppName{
-				Part: tr.Ref.Path,
-			}
-			tr.Ref.Path = nil
-		}
-	}
 }
 
 // ExitLiteral is called when production literal is exited.

--- a/pkg/parse/tests/args.sysl.golden.textpb
+++ b/pkg/parse/tests/args.sysl.golden.textpb
@@ -13,9 +13,7 @@ apps: {
           type: {
             type_ref: {
               ref: {
-                appname: {
-                  part: "type1"
-                }
+                path: "type1"
               }
             }
           }
@@ -25,9 +23,7 @@ apps: {
           type: {
             type_ref: {
               ref: {
-                appname: {
-                  part: "type2"
-                }
+                path: "type2"
               }
             }
           }

--- a/pkg/parse/tests/ep_params.sysl.golden.textpb
+++ b/pkg/parse/tests/ep_params.sysl.golden.textpb
@@ -139,9 +139,7 @@ apps: {
           type: {
             type_ref: {
               ref: {
-                appname: {
-                  part: "id"
-                }
+                path: "id"
               }
             }
           }
@@ -169,9 +167,7 @@ apps: {
             set: {
               type_ref: {
                 ref: {
-                  appname: {
-                    part: "id"
-                  }
+                  path: "id"
                 }
               }
             }

--- a/pkg/parse/tests/petshop.sysl.golden.textpb
+++ b/pkg/parse/tests/petshop.sysl.golden.textpb
@@ -567,9 +567,7 @@ apps: {
               }
             }
             ref: {
-              appname: {
-                part: "PetShopModel"
-              }
+              path: "PetShopModel"
             }
           }
         }
@@ -2057,9 +2055,7 @@ apps: {
                 }
               }
               ref: {
-                appname: {
-                  part: "PetShopModel"
-                }
+                path: "PetShopModel"
               }
             }
           }
@@ -3410,9 +3406,7 @@ apps: {
           type: {
             type_ref: {
               ref: {
-                appname: {
-                  part: "PetShopModel"
-                }
+                path: "PetShopModel"
               }
             }
           }

--- a/pkg/parse/tests/test4.sysl.golden.textpb
+++ b/pkg/parse/tests/test4.sysl.golden.textpb
@@ -106,9 +106,7 @@ apps: {
           type: {
             type_ref: {
               ref: {
-                appname: {
-                  part: "id"
-                }
+                path: "id"
               }
             }
           }

--- a/pkg/parse/tests/transform.sysl.golden.textpb
+++ b/pkg/parse/tests/transform.sysl.golden.textpb
@@ -1369,9 +1369,7 @@ apps: {
           type: {
             type_ref: {
               ref: {
-                appname: {
-                  part: "Sometype"
-                }
+                path: "Sometype"
               }
             }
           }
@@ -1380,9 +1378,7 @@ apps: {
           set: {
             type_ref: {
               ref: {
-                appname: {
-                  part: "Sometype"
-                }
+                path: "Sometype"
               }
             }
           }
@@ -1471,9 +1467,7 @@ apps: {
                 }
               }
               ref: {
-                appname: {
-                  part: "Sometype"
-                }
+                path: "Sometype"
               }
             }
           }

--- a/pkg/printer/printer.go
+++ b/pkg/printer/printer.go
@@ -269,11 +269,13 @@ func Type(param *sysl.Param) string {
 	if param.Type == nil {
 		return ""
 	}
-	// Ref.Appname.Part is the type name if the type is in the same package and the application name of where it's at
-	// stored if its in another application and then Ref.Path is the type name
+	// The Appname field represents a reference to the app that contains the referenced type.
+	// The Path field represents the type itself.
 	if a := param.Type.GetTypeRef(); a != nil {
-		ans := append(a.Ref.Appname.Part, a.Ref.Path...)
-		return strings.Join(ans, ".")
+		if a.Ref.Appname != nil {
+			return strings.Join(append(a.Ref.Appname.Part, a.Ref.Path...), ".")
+		}
+		return strings.Join(a.Ref.Path, "")
 	}
 	return strings.Join(param.Type.GetTypeRef().Ref.Appname.Part, "")
 }

--- a/pkg/printer/printer.go
+++ b/pkg/printer/printer.go
@@ -275,7 +275,7 @@ func Type(param *sysl.Param) string {
 		if a.Ref.Appname != nil {
 			return strings.Join(append(a.Ref.Appname.Part, a.Ref.Path...), ".")
 		}
-		return strings.Join(a.Ref.Path, "")
+		return strings.Join(a.Ref.Path, ".")
 	}
 	return strings.Join(param.Type.GetTypeRef().Ref.Appname.Part, "")
 }

--- a/pkg/syslwrapper/app.go
+++ b/pkg/syslwrapper/app.go
@@ -399,7 +399,7 @@ func (am *AppMapper) GetRefDetails(t *sysl.Type) (appName string, typeName strin
 	} else {
 		if ref.GetAppname() != nil {
 			appName = strings.Join(ref.Appname.Part, "")
-		} else {
+		} else if t.GetTypeRef().GetContext() != nil {
 			appName = strings.Join(t.GetTypeRef().GetContext().Appname.Part, "")
 		}
 		typeName = strings.Join(ref.GetPath(), ".")


### PR DESCRIPTION
* Please attach **WIP** tag when this PR is still work in progress.
* Please attach **breaking-change** tag if this PR potentially causes other components to fail or changes previous sysl executable's behaviour.

Fixes #1040 

Changes proposed in this pull request:
```
"param": [
      {
       "name": "input",
       "type": {
        "typeRef": {
         "ref": {
          "appname": {
           "part": [
            "depserver"
           ]
          },
          "path": [
           "HelloRequest"
          ]
         }
        }
       }
      }
     ]
``` 
The appname field represents a reference to the app that contains the referenced type. The path field represents the type itself. This PR corrected code to follow this rule.  

Checklist:
- [x] Added related tests
- [x] Made corresponding changes to the documentation
