### PR TITLE
docs: fix openapi3 export format name

### DIFF
--- a/docs/docs/cmd/cmd-export.md
+++ b/docs/docs/cmd/cmd-export.md
@@ -19,7 +19,7 @@ sysl export [<flags>] <MODULE>
 Currently, the supported formats include:
 
 - OpenAPI 2.0 (fka Swagger): `swagger`
-- OpenAPI 3.0 `openapi`
+- OpenAPI 3.0 `openapi3`
 - Spanner `spanner`
 - Proto `proto`
 


### PR DESCRIPTION
## Summary
- fix the documented OpenAPI 3 export format name in `cmd-export`
- align the supported-format list with the actual `openapi3` flag used elsewhere in the docs and CLI

Closes #1097.
