### PR TITLE
docs: fix codegen tutorial path separators

### DIFF
--- a/docs/docs/tutorial-codegen.md
+++ b/docs/docs/tutorial-codegen.md
@@ -114,7 +114,7 @@ This can now be committed if you're using a version control system.
 
 Before you can successfully run your application, you need to add some handler functions for the endpoints you've defined in your specification.
 
-To do this, create the file in the path `internal\handlers\pet.go`
+To do this, create the file in the path `internal/handlers/pet.go`
 
 ```go
 package handlers


### PR DESCRIPTION
## Summary
- replace the Windows-style handler file path in the codegen tutorial with a forward-slash path
- keep the tutorial path style consistent with the surrounding commands and file references

## Why
Addresses #1079. The tutorial currently mixes `internal\handlers\pet.go` with slash-based paths like `cmd/Petdemo/main.go`, which is confusing in a cross-platform docs page.

## Testing
- not run (docs-only change)