### PR TITLE
docs: fix outdated output references

### DIFF
--- a/docs/docs/cmd/cmd.md
+++ b/docs/docs/cmd/cmd.md
@@ -58,7 +58,7 @@ Commands:
     initializes and writes a new go.mod to the current directory
 
   protobuf [<flags>] <MODULE>...
-    Generate textpb/json
+    Generate textpb/json/pb
 
   repl
     Enter a sysl REPL

--- a/docs/docs/lang-spec.md
+++ b/docs/docs/lang-spec.md
@@ -720,7 +720,7 @@ Client:
 
 Above code assumes, server and client files are in the same directory. If they are in different directories, you must have at least a common root directory and `import /path/from/root`.
 
-All sysl commands accept `--root` argument. Run `sysl -h` or `reljam -h` for more details.
+All sysl commands accept `--root` argument. Run `sysl -h` for more details.
 
 ### Internal relative file
 


### PR DESCRIPTION
## Summary
- update the top-level command docs to mention all protobuf output modes (`textpb`, `json`, and `pb`)
- remove the stale `reljam -h` reference from the language spec root-path guidance

## Why
Addresses #523 by removing outdated command/output references from the current docs.

## Testing
- not run (docs-only change)